### PR TITLE
feat/P0-02-tailwind-config

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,40 @@
 @import 'tailwindcss';
+
+@theme {
+  /* Colors — Primary palette */
+  --color-cream-50: #FFFDF8;
+  --color-cream-100: #FFF9EF;
+  --color-burgundy-100: #F5E6EB;
+  --color-burgundy-700: #9B1B3D;
+  --color-burgundy-800: #7A1530;
+  --color-gold-500: #D4A017;
+  --color-wood-800: #4A3729;
+  --color-wood-900: #352618;
+  --color-charcoal: #253341;
+  --color-sand: #FAEDCD;
+
+  /* Font families */
+  --font-heading: var(--font-cormorant-garamond), 'Georgia', serif;
+  --font-body: var(--font-dm-sans), 'Helvetica Neue', sans-serif;
+
+  /* Custom border radius */
+  --radius-arch: 50% 50% 0 0;
+
+  /* Extended spacing (22–30 in steps of 2) */
+  --spacing-22: 5.5rem;
+  --spacing-24: 6rem;
+  --spacing-26: 6.5rem;
+  --spacing-28: 7rem;
+  --spacing-30: 7.5rem;
+}
+
+body {
+  font-family: var(--font-body);
+  background-color: var(--color-cream-50);
+  color: var(--color-wood-800);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
+  color: var(--color-wood-900);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,23 @@
 import type { Metadata } from 'next'
+import { Cormorant_Garamond, DM_Sans } from 'next/font/google'
+
+import { cn } from '@/lib/utils'
+
 import './globals.css'
+
+const cormorantGaramond = Cormorant_Garamond({
+  subsets: ['latin'],
+  weight: ['300', '400', '600', '700'],
+  variable: '--font-cormorant-garamond',
+  display: 'swap',
+})
+
+const dmSans = DM_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-dm-sans',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   title: {
@@ -16,7 +34,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={cn(cormorantGaramond.variable, dmSans.variable)}>
       <body>{children}</body>
     </html>
   )


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#23

## Summary
- Configure all Tailwind design tokens in `globals.css` via `@theme` (Tailwind v4)
- Load Cormorant Garamond (headings) + DM Sans (body) via `next/font/google` as CSS variables
- Add color tokens: cream, burgundy, gold, wood, charcoal, sand (with extended palette)
- Add custom `arch` border-radius (`50% 50% 0 0`) and extended spacing (`py-22` through `py-30`)
- Set default body background to cream `#FFFDF8` with wood-800 text color
- Apply heading font family and wood-900 color to all heading elements

## Test plan
- [x] `npm run build` compiles with no TypeScript errors
- [x] All color tokens generate correct Tailwind utility classes
- [x] Custom spacing values (`py-22`, `py-26`, `py-30`) generate correct CSS
- [x] `rounded-arch` generates dome-shaped border radius
- [x] `font-heading` and `font-body` utilities resolve to the correct font stacks