### PR TITLE
feat/P0-06-groq-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "st-basils-boston-web",
       "version": "0.1.0",
       "dependencies": {
+        "@sanity/image-url": "^2.0.3",
         "@sanity/vision": "^4.22.0",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@sanity/image-url": "^2.0.3",
     "@sanity/vision": "^4.22.0",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -1,0 +1,11 @@
+import { createClient } from 'next-sanity'
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
+
+export const client = createClient({
+  projectId,
+  dataset,
+  apiVersion: '2024-01-01',
+  useCdn: true,
+})

--- a/src/lib/sanity/image.ts
+++ b/src/lib/sanity/image.ts
@@ -1,0 +1,11 @@
+import imageUrlBuilder from '@sanity/image-url'
+
+import { client } from '@/lib/sanity/client'
+
+import type { SanityImageSource } from '@/lib/sanity/types'
+
+const builder = imageUrlBuilder(client)
+
+export function urlFor(source: SanityImageSource) {
+  return builder.image(source)
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -1,0 +1,10 @@
+import { groq } from 'next-sanity'
+
+export const pageContentQuery = groq`
+  *[_type == "pageContent" && slug.current == $slug][0] {
+    _id,
+    title,
+    slug,
+    body
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -1,0 +1,11 @@
+import type { PortableTextBlock } from 'next-sanity'
+import type { SanityImageSource } from '@sanity/image-url'
+
+export type { SanityImageSource }
+
+export interface PageContent {
+  _id: string
+  title: string
+  slug: { current: string }
+  body: PortableTextBlock[]
+}


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#27

## Summary
- Installed `@sanity/image-url` for image URL generation
- Created `src/lib/sanity/client.ts` — configured Sanity client via `next-sanity`
- Created `src/lib/sanity/queries.ts` — placeholder GROQ query for page content
- Created `src/lib/sanity/types.ts` — placeholder TypeScript types (`PageContent`, re-exported `SanityImageSource`)
- Created `src/lib/sanity/image.ts` — `urlFor()` helper using `@sanity/image-url`

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify `urlFor()` generates correct URLs when connected to a Sanity project