### PR TITLE
feat/P0-08-tooling

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -2,7 +2,7 @@ name: Deploy to Production
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
           local-dir: ./
           # Adjust server-dir to the actual folder for staging on GoDaddy
           server-dir: /preprod.stbasilsboston.org/
-          
+
           exclude: |
             **/.git*
             **/.git*/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Legacy static site
+*.html
+assets/
+documentation/
+forms/
+PSD/
+
+# Vendor / generated
+node_modules/
+.next/
+package-lock.json
+
+# Config managed elsewhere
+.ralph/
+.claude/
+CLAUDE.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "liveServer.settings.port": 5501
+  "liveServer.settings.port": 5501
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,13 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 })
 
-const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript')]
+const eslintConfig = [
+  ...compat.extends(
+    'next/core-web-vitals',
+    'next/typescript',
+    'plugin:jsx-a11y/recommended',
+    'prettier'
+  ),
+]
 
 export default eslintConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,9 @@
         "@types/react-dom": "^19.1.2",
         "eslint": "^9.25.0",
         "eslint-config-next": "^15.3.1",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "prettier": "^3.8.1",
         "tailwindcss": "^4.1.4",
         "typescript": "^5.8.3"
       }
@@ -10391,6 +10394,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "lint:fix": "next lint --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@sanity/image-url": "^2.0.3",
@@ -29,6 +32,9 @@
     "@types/react-dom": "^19.1.2",
     "eslint": "^9.25.0",
     "eslint-config-next": "^15.3.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "prettier": "^3.8.1",
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3"
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,16 +2,16 @@
 
 @theme {
   /* Colors — Primary palette */
-  --color-cream-50: #FFFDF8;
-  --color-cream-100: #FFF9EF;
-  --color-burgundy-100: #F5E6EB;
-  --color-burgundy-700: #9B1B3D;
-  --color-burgundy-800: #7A1530;
-  --color-gold-500: #D4A017;
-  --color-wood-800: #4A3729;
+  --color-cream-50: #fffdf8;
+  --color-cream-100: #fff9ef;
+  --color-burgundy-100: #f5e6eb;
+  --color-burgundy-700: #9b1b3d;
+  --color-burgundy-800: #7a1530;
+  --color-gold-500: #d4a017;
+  --color-wood-800: #4a3729;
   --color-wood-900: #352618;
   --color-charcoal: #253341;
-  --color-sand: #FAEDCD;
+  --color-sand: #faedcd;
 
   /* Font families */
   --font-heading: var(--font-cormorant-garamond), 'Georgia', serif;
@@ -34,7 +34,12 @@ body {
   color: var(--color-wood-800);
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: var(--font-heading);
   color: var(--color-wood-900);
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -15,9 +15,7 @@ export async function updateSession(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) =>
-            request.cookies.set(name, value)
-          )
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           supabaseResponse = NextResponse.next({
             request,
           })


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#29

## Summary
- Adds `eslint-plugin-jsx-a11y` (recommended ruleset) for accessibility linting
- Adds `eslint-config-prettier` to disable ESLint rules that conflict with Prettier
- Creates `.prettierrc` config (no semis, single quotes, 100 print width)
- Creates `.prettierignore` to skip legacy HTML, vendor assets, and docs
- Adds npm scripts: `lint:fix`, `format`, `format:check`
- Formats existing source files with Prettier for clean baseline
- `clsx`, `tailwind-merge`, and `cn()` utility already existed from prior tickets

## Test plan
- [x] `npm run lint` — passes with no warnings or errors
- [x] `npm run format:check` — all matched files pass
- [x] `npm run build` — compiles successfully