### PR TITLE
feat/P0-03-route-scaffold

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Dashboard',
+}
+
+export default function DashboardPage() {
+  return (
+    <main className="px-4 py-22 font-body text-wood-800 sm:px-6 lg:px-8">
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">
+        Admin Group
+      </h1>
+      <p className="mt-4">Dashboard placeholder — (admin) route group.</p>
+    </main>
+  )
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function AdminIndexPage() {
+  redirect('/admin/dashboard')
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,12 @@
+export default function AdminLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <div className="flex min-h-screen">
+      {/* AdminSidebar will be added here */}
+      <div className="flex-1">{children}</div>
+    </div>
+  )
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,11 @@
+export default function AuthLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-cream-50">
+      {children}
+    </div>
+  )
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Login',
+}
+
+export default function LoginPage() {
+  return (
+    <main className="w-full max-w-md px-4 font-body text-wood-800">
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">
+        Auth Group
+      </h1>
+      <p className="mt-4">Login placeholder — (auth) route group.</p>
+    </main>
+  )
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,13 @@
+export default function PublicLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <>
+      {/* Navbar will be added here */}
+      {children}
+      {/* Footer will be added here */}
+    </>
+  )
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: "St. Basil's Syriac Orthodox Church",
+  description:
+    "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
+}
+
+export default function HomePage() {
+  return (
+    <main className="min-h-screen px-4 py-22 font-body text-wood-800">
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">
+        Public Group
+      </h1>
+      <p className="mt-4">Homepage placeholder — (public) route group.</p>
+    </main>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,0 @@
-import { cn } from '@/lib/utils'
-
-export default function Home() {
-  return (
-    <main className={cn('min-h-screen')}>
-      <h1>St. Basil&apos;s Syriac Orthodox Church</h1>
-    </main>
-  )
-}


### PR DESCRIPTION
## Summary
- Scaffolds `(public)`, `(auth)`, and `(admin)` route groups with placeholder layouts and pages
- Each placeholder page renders a heading identifying its group
- Routes accessible at `/`, `/login`, `/admin` (redirects to `/admin/dashboard`)
- Removes root `page.tsx` in favor of `(public)/page.tsx`

## Test plan
- [ ] `npm run build` compiles without errors
- [ ] `/` renders "Public Group" heading
- [ ] `/login` renders "Auth Group" heading with centered layout
- [ ] `/admin` redirects to `/admin/dashboard` which renders "Admin Group" heading

Implements georgenijo/St-Basils-Boston-Web#24