### PR TITLE
feat/P0-10-sitemap-robots

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/studio', '/admin'],
+    },
+    sitemap: 'https://stbasilsboston.org/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = 'https://stbasilsboston.org'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Phase 1 static pages
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1.0,
+    },
+    {
+      url: `${BASE_URL}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/first-time`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/giving`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+  ]
+
+  // TODO: Add dynamic routes for events pages
+  // TODO: Add dynamic routes for announcements pages
+
+  return staticPages
+}


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#31

## Summary
- Add `src/app/sitemap.ts` with hardcoded Phase 1 page URLs (home, about, first-time, giving)
- Add `src/app/robots.ts` disallowing `/studio` and `/admin`
- TODO comments for future dynamic routes (events, announcements)

## Test plan
- [ ] `npm run build` passes — `/sitemap.xml` and `/robots.txt` render as static routes
- [ ] Visit `/sitemap.xml` — returns valid XML with 4 page URLs
- [ ] Visit `/robots.txt` — disallows `/studio` and `/admin`, includes sitemap reference