### PR TITLE
feat/P1-06-scroll-reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useReducedMotion, motion } from 'framer-motion'
+
+import type { ReactNode } from 'react'
+
+const directionOffsets = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+} as const
+
+type Direction = keyof typeof directionOffsets
+
+export interface ScrollRevealProps {
+  children: ReactNode
+  direction?: Direction
+  delay?: number
+  once?: boolean
+  className?: string
+}
+
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  once = true,
+  className,
+}: ScrollRevealProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = directionOffsets[direction]
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once }}
+      transition={{
+        type: 'spring',
+        stiffness: 200,
+        damping: 20,
+        delay,
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export interface ScrollRevealGroupProps {
+  children: ReactNode
+  direction?: Direction
+  stagger?: number
+  once?: boolean
+  className?: string
+}
+
+export function ScrollRevealGroup({
+  children,
+  direction = 'up',
+  stagger = 0.12,
+  once = true,
+  className,
+}: ScrollRevealGroupProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = directionOffsets[direction]
+
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once }}
+      variants={{
+        hidden: {},
+        visible: {
+          transition: {
+            staggerChildren: stagger,
+          },
+        },
+      }}
+      className={className}
+    >
+      {Array.isArray(children) ? (
+        children.map((child, i) => (
+          <motion.div
+            key={i}
+            variants={{
+              hidden: { opacity: 0, ...offset },
+              visible: {
+                opacity: 1,
+                x: 0,
+                y: 0,
+                transition: {
+                  type: 'spring',
+                  stiffness: 200,
+                  damping: 20,
+                },
+              },
+            }}
+          >
+            {child}
+          </motion.div>
+        ))
+      ) : (
+        <motion.div
+          variants={{
+            hidden: { opacity: 0, ...offset },
+            visible: {
+              opacity: 1,
+              x: 0,
+              y: 0,
+              transition: {
+                type: 'spring',
+                stiffness: 200,
+                damping: 20,
+              },
+            },
+          }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </motion.div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { ScrollReveal, ScrollRevealGroup } from './ScrollReveal'
+export type { ScrollRevealProps, ScrollRevealGroupProps } from './ScrollReveal'


### PR DESCRIPTION
## Summary
- Installs `framer-motion` as a dependency
- Adds `ScrollReveal` component — a `'use client'` wrapper using `whileInView` with spring physics (stiffness: 200, damping: 20)
- Adds `ScrollRevealGroup` component for staggered child animations (0.12s default stagger)
- Props: `direction` (up/down/left/right), `delay`, `once`, `className`
- Fully respects `prefers-reduced-motion` — renders children without animation when enabled
- Barrel-exported from `@/components/ui`

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify elements animate into view on scroll
- [ ] Verify each `direction` prop value produces correct animation origin
- [ ] Verify stagger works with `ScrollRevealGroup`
- [ ] Verify no animation with `prefers-reduced-motion: reduce`

Implements georgenijo/St-Basils-Boston-Web#37