### PR TITLE
feat/P1-03-card

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils'
+
+type CardVariant = 'default' | 'dark' | 'outlined'
+
+interface CardProps {
+  variant?: CardVariant
+  children: React.ReactNode
+  className?: string
+}
+
+const variantStyles: Record<CardVariant, string> = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+}
+
+function Card({ variant = 'default', children, className }: CardProps) {
+  return (
+    <div className={cn('rounded-2xl shadow-sm', variantStyles[variant], className)}>
+      {children}
+    </div>
+  )
+}
+
+function CardHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6 pb-0', className)}>{children}</div>
+}
+
+function CardBody({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6', className)}>{children}</div>
+}
+
+function CardFooter({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6 pt-0', className)}>{children}</div>
+}
+
+Card.Header = CardHeader
+Card.Body = CardBody
+Card.Footer = CardFooter
+
+export { Card }
+export type { CardProps, CardVariant }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { Card } from './Card'
+export type { CardProps, CardVariant } from './Card'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#34

## Summary
- Add `Card` compound component with `Card.Header`, `Card.Body`, and `Card.Footer` sub-components
- Three variants: `default` (sand bg), `dark` (charcoal bg, cream text), `outlined` (cream bg, subtle border)
- Rounded-2xl corners with subtle shadow
- All sub-components accept `className` for extensibility
- Barrel export from `components/ui/index.ts`

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify all three variants render correct backgrounds and text colors
- [ ] Confirm `className` prop merges correctly on all sub-components
- [ ] Check rounded corners and shadow appear as expected