### PR TITLE
feat/P1-01-gold-divider

### DIFF
--- a/src/components/ui/GoldDivider.tsx
+++ b/src/components/ui/GoldDivider.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+interface GoldDividerProps {
+  className?: string
+}
+
+export function GoldDivider({ className }: GoldDividerProps) {
+  return (
+    <div
+      role="separator"
+      className={cn(
+        'mx-auto h-[2px] max-w-[200px] bg-linear-to-r from-transparent via-gold-500 to-transparent',
+        className,
+      )}
+    />
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,1 @@
+export { GoldDivider } from './GoldDivider'


### PR DESCRIPTION
## Summary
- Adds `<GoldDivider>` component — a centered 2px gradient line (transparent → gold-500 → transparent) with 200px max-width
- Accepts `className` prop for customization via `cn()` merge
- Barrel-exported from `components/ui/index.ts`

Implements georgenijo/St-Basils-Boston-Web#32

## Test plan
- [ ] Renders a horizontal gold gradient line
- [ ] Gradient: transparent → #D4A017 → transparent
- [ ] Max-width 200px, centered, 2px height
- [ ] `className` prop merges correctly
- [ ] `npm run build` passes with no errors