### PR TITLE
feat/P1-04-section-header

### DIFF
--- a/src/components/ui/GoldDivider.tsx
+++ b/src/components/ui/GoldDivider.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+interface GoldDividerProps {
+  className?: string
+}
+
+export function GoldDivider({ className }: GoldDividerProps) {
+  return (
+    <div
+      role="separator"
+      className={cn(
+        'mx-auto h-0.5 max-w-[200px] bg-linear-to-r from-transparent via-gold-500 to-transparent',
+        className,
+      )}
+    />
+  )
+}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils'
+
+import { GoldDivider } from '@/components/ui/GoldDivider'
+
+interface SectionHeaderProps {
+  title: string
+  subtitle?: string
+  align?: 'left' | 'center'
+  as?: 'h1' | 'h2' | 'h3'
+  className?: string
+}
+
+const headingStyles = {
+  h1: 'text-[2rem] md:text-[3rem] font-semibold leading-[1.2]',
+  h2: 'text-[1.75rem] md:text-[2.25rem] font-semibold leading-[1.3]',
+  h3: 'text-[1.25rem] md:text-[1.5rem] font-semibold leading-[1.4]',
+} as const
+
+export function SectionHeader({
+  title,
+  subtitle,
+  align = 'center',
+  as: Tag = 'h2',
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'mb-12',
+        align === 'center' && 'text-center',
+        align === 'left' && 'text-left',
+        className,
+      )}
+    >
+      <Tag className={cn('font-heading text-wood-900', headingStyles[Tag])}>
+        {title}
+      </Tag>
+      <GoldDivider className={cn('my-4', align === 'left' && 'mx-0')} />
+      {subtitle && (
+        <p className="font-body text-base leading-relaxed text-wood-800/60">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+export { GoldDivider } from '@/components/ui/GoldDivider'
+export { SectionHeader } from '@/components/ui/SectionHeader'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#35

## Summary
- Adds `SectionHeader` component with `title`, `subtitle`, `align` (left/center), and `as` (h1-h3) props
- Adds `GoldDivider` component (dependency P1-01) — 2px gradient separator using gold-500
- Adds barrel export file at `components/ui/index.ts`

## Details
- Title renders in Cormorant Garamond (font-heading) with responsive sizes per heading level
- Subtitle renders in DM Sans (font-body) with muted wood-800/60 color
- GoldDivider renders between title and subtitle with transparent→gold→transparent gradient
- Left-aligned variant shifts divider to left edge

## Test plan
- [x] `npm run build` compiles with no TypeScript errors
- [ ] Verify responsive typography at 375px, 768px, 1280px
- [ ] Verify left and center alignment variants render correctly
- [ ] Verify h1/h2/h3 heading levels produce correct HTML elements