### PR TITLE
feat/P1-07-barrel-exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/app/(public)/style-guide/StyleGuideAnimations.tsx
+++ b/src/app/(public)/style-guide/StyleGuideAnimations.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { Card, ScrollReveal, ScrollRevealGroup } from '@/components/ui'
+
+export function StyleGuideAnimations() {
+  return (
+    <div className="mt-12 space-y-12">
+      <div>
+        <p className="mb-4 text-sm text-wood-800/60">Individual — up, down, left, right</p>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <ScrollReveal direction="up">
+            <Card variant="outlined">
+              <Card.Body><p className="text-center">Up</p></Card.Body>
+            </Card>
+          </ScrollReveal>
+          <ScrollReveal direction="down">
+            <Card variant="outlined">
+              <Card.Body><p className="text-center">Down</p></Card.Body>
+            </Card>
+          </ScrollReveal>
+          <ScrollReveal direction="left">
+            <Card variant="outlined">
+              <Card.Body><p className="text-center">Left</p></Card.Body>
+            </Card>
+          </ScrollReveal>
+          <ScrollReveal direction="right">
+            <Card variant="outlined">
+              <Card.Body><p className="text-center">Right</p></Card.Body>
+            </Card>
+          </ScrollReveal>
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-4 text-sm text-wood-800/60">Staggered group</p>
+        <ScrollRevealGroup direction="up" stagger={0.12} className="grid gap-6 sm:grid-cols-3">
+          <Card>
+            <Card.Body><p className="text-center">First</p></Card.Body>
+          </Card>
+          <Card>
+            <Card.Body><p className="text-center">Second</p></Card.Body>
+          </Card>
+          <Card>
+            <Card.Body><p className="text-center">Third</p></Card.Body>
+          </Card>
+        </ScrollRevealGroup>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/style-guide/page.tsx
+++ b/src/app/(public)/style-guide/page.tsx
@@ -1,0 +1,177 @@
+import { Metadata } from 'next'
+
+import {
+  Button,
+  Card,
+  GoldDivider,
+  PageHero,
+  SectionHeader,
+} from '@/components/ui'
+
+import { StyleGuideAnimations } from './StyleGuideAnimations'
+
+export const metadata: Metadata = {
+  title: 'Style Guide',
+  description: 'Component showcase and design system reference.',
+  robots: { index: false, follow: false },
+}
+
+export default function StyleGuidePage() {
+  return (
+    <main>
+      <PageHero
+        title="Style Guide"
+        backgroundImage="/images/placeholder-hero.jpg"
+      />
+
+      {/* GoldDivider */}
+      <section className="py-16 md:py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="GoldDivider"
+            subtitle="A decorative horizontal rule with a gold gradient."
+          />
+          <div className="mt-12 space-y-8">
+            <div className="space-y-2">
+              <p className="text-sm text-wood-800/60">Default</p>
+              <GoldDivider />
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm text-wood-800/60">Left-aligned, wider</p>
+              <GoldDivider className="mx-0 max-w-sm" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Button */}
+      <section className="bg-sand py-16 md:py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="Button"
+            subtitle="Three variants (primary, secondary, ghost) in three sizes (sm, md, lg)."
+          />
+          <div className="mt-12 space-y-8">
+            <div>
+              <p className="mb-4 text-sm font-medium text-wood-800/60">Primary</p>
+              <div className="flex flex-wrap items-center gap-4">
+                <Button size="sm">Small</Button>
+                <Button size="md">Medium</Button>
+                <Button size="lg">Large</Button>
+                <Button disabled>Disabled</Button>
+              </div>
+            </div>
+            <div>
+              <p className="mb-4 text-sm font-medium text-wood-800/60">Secondary</p>
+              <div className="flex flex-wrap items-center gap-4">
+                <Button variant="secondary" size="sm">Small</Button>
+                <Button variant="secondary" size="md">Medium</Button>
+                <Button variant="secondary" size="lg">Large</Button>
+                <Button variant="secondary" disabled>Disabled</Button>
+              </div>
+            </div>
+            <div>
+              <p className="mb-4 text-sm font-medium text-wood-800/60">Ghost</p>
+              <div className="flex flex-wrap items-center gap-4">
+                <Button variant="ghost" size="sm">Small</Button>
+                <Button variant="ghost" size="md">Medium</Button>
+                <Button variant="ghost" size="lg">Large</Button>
+                <Button variant="ghost" disabled>Disabled</Button>
+              </div>
+            </div>
+            <div>
+              <p className="mb-4 text-sm font-medium text-wood-800/60">As Link</p>
+              <Button href="/style-guide">Link Button</Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Card */}
+      <section className="py-16 md:py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="Card"
+            subtitle="Compound component with Header, Body, and Footer. Three variants."
+          />
+          <div className="mt-12 grid gap-8 md:grid-cols-3">
+            <Card>
+              <Card.Header>
+                <h3 className="font-heading text-xl font-semibold">Default</h3>
+              </Card.Header>
+              <Card.Body>
+                <p>Sand background with wood text. Used for general content cards.</p>
+              </Card.Body>
+              <Card.Footer>
+                <Button size="sm">Action</Button>
+              </Card.Footer>
+            </Card>
+
+            <Card variant="dark">
+              <Card.Header>
+                <h3 className="font-heading text-xl font-semibold">Dark</h3>
+              </Card.Header>
+              <Card.Body>
+                <p>Charcoal background with cream text. Used for featured content.</p>
+              </Card.Body>
+              <Card.Footer>
+                <Button size="sm" variant="secondary" className="border-cream-50 text-cream-50 hover:bg-cream-50 hover:text-charcoal">Action</Button>
+              </Card.Footer>
+            </Card>
+
+            <Card variant="outlined">
+              <Card.Header>
+                <h3 className="font-heading text-xl font-semibold">Outlined</h3>
+              </Card.Header>
+              <Card.Body>
+                <p>Cream background with subtle border. Used for clean, minimal layouts.</p>
+              </Card.Body>
+              <Card.Footer>
+                <Button size="sm" variant="ghost">Action</Button>
+              </Card.Footer>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      {/* SectionHeader */}
+      <section className="bg-sand py-16 md:py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="SectionHeader"
+            subtitle="Title, gold divider, and optional subtitle. Supports h2/h3 and left/center alignment."
+          />
+          <div className="mt-12 space-y-12">
+            <div className="rounded-2xl bg-cream-50 p-8">
+              <p className="mb-4 text-sm text-wood-800/60">Centered h2 (default)</p>
+              <SectionHeader
+                title="Our History"
+                subtitle="A community of faith since 1993."
+              />
+            </div>
+            <div className="rounded-2xl bg-cream-50 p-8">
+              <p className="mb-4 text-sm text-wood-800/60">Left-aligned h3</p>
+              <SectionHeader
+                as="h3"
+                align="left"
+                title="Sunday School"
+                subtitle="Nurturing the next generation in faith."
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ScrollReveal */}
+      <section className="py-16 md:py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="ScrollReveal"
+            subtitle="Spring-based scroll animations. Respects prefers-reduced-motion."
+          />
+          <StyleGuideAnimations />
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,20 @@
   --spacing-26: 6.5rem;
   --spacing-28: 7rem;
   --spacing-30: 7.5rem;
+
+  /* Animations */
+  --animate-drop-in: drop-in 0.6s ease-out both;
+
+  @keyframes drop-in {
+    from {
+      opacity: 0;
+      transform: translateY(-20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 body {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+const variantStyles = {
+  primary:
+    'bg-burgundy-700 text-cream-50 hover:bg-burgundy-800',
+  secondary:
+    'border border-burgundy-700 text-burgundy-700 hover:bg-burgundy-700 hover:text-cream-50',
+  ghost:
+    'text-burgundy-700 hover:bg-cream-100',
+} as const
+
+const sizeStyles = {
+  sm: 'px-4 py-2 text-sm',
+  md: 'px-6 py-3 text-base',
+  lg: 'px-8 py-4 text-lg',
+} as const
+
+interface ButtonProps {
+  variant?: keyof typeof variantStyles
+  size?: keyof typeof sizeStyles
+  href?: string
+  disabled?: boolean
+  children: React.ReactNode
+  className?: string
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  href,
+  disabled = false,
+  children,
+  className,
+  ...rest
+}: ButtonProps & (
+  | (Omit<React.ComponentPropsWithoutRef<'button'>, keyof ButtonProps>)
+  | (Omit<React.ComponentPropsWithoutRef<typeof Link>, keyof ButtonProps>)
+)) {
+  const classes = cn(
+    'inline-flex items-center justify-center rounded-lg font-body font-medium transition-colors',
+    'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-burgundy-700',
+    variantStyles[variant],
+    sizeStyles[size],
+    disabled && 'pointer-events-none opacity-50',
+    className,
+  )
+
+  if (href && !disabled) {
+    return (
+      <Link href={href} className={classes} {...(rest as Omit<React.ComponentPropsWithoutRef<typeof Link>, keyof ButtonProps>)}>
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <button type="button" className={classes} disabled={disabled} {...(rest as Omit<React.ComponentPropsWithoutRef<'button'>, keyof ButtonProps>)}>
+      {children}
+    </button>
+  )
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils'
+
+type CardVariant = 'default' | 'dark' | 'outlined'
+
+interface CardProps {
+  variant?: CardVariant
+  children: React.ReactNode
+  className?: string
+}
+
+const variantStyles: Record<CardVariant, string> = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+}
+
+function Card({ variant = 'default', children, className }: CardProps) {
+  return (
+    <div className={cn('rounded-2xl shadow-sm', variantStyles[variant], className)}>
+      {children}
+    </div>
+  )
+}
+
+function CardHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6 pb-0', className)}>{children}</div>
+}
+
+function CardBody({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6', className)}>{children}</div>
+}
+
+function CardFooter({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6 pt-0', className)}>{children}</div>
+}
+
+Card.Header = CardHeader
+Card.Body = CardBody
+Card.Footer = CardFooter
+
+export { Card }
+export type { CardProps, CardVariant }

--- a/src/components/ui/GoldDivider.tsx
+++ b/src/components/ui/GoldDivider.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+interface GoldDividerProps {
+  className?: string
+}
+
+export function GoldDivider({ className }: GoldDividerProps) {
+  return (
+    <div
+      role="separator"
+      className={cn(
+        'mx-auto h-[2px] max-w-[200px] bg-linear-to-r from-transparent via-gold-500 to-transparent',
+        className,
+      )}
+    />
+  )
+}

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
+interface PageHeroProps {
+  title: string
+  backgroundImage: string
+  className?: string
+}
+
+export function PageHero({ title, backgroundImage, className }: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        'relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]',
+        className
+      )}
+    >
+      <Image
+        src={backgroundImage}
+        alt=""
+        fill
+        priority
+        className="object-cover"
+        sizes="100vw"
+      />
+
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+      <h1 className="relative z-10 mx-auto max-w-[1200px] px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 motion-safe:animate-drop-in sm:px-6 md:text-[4rem] lg:px-8">
+        {title}
+      </h1>
+    </section>
+  )
+}

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useReducedMotion, motion } from 'framer-motion'
+
+import type { ReactNode } from 'react'
+
+const directionOffsets = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+} as const
+
+type Direction = keyof typeof directionOffsets
+
+export interface ScrollRevealProps {
+  children: ReactNode
+  direction?: Direction
+  delay?: number
+  once?: boolean
+  className?: string
+}
+
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  once = true,
+  className,
+}: ScrollRevealProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = directionOffsets[direction]
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once }}
+      transition={{
+        type: 'spring',
+        stiffness: 200,
+        damping: 20,
+        delay,
+      }}
+      className={className}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export interface ScrollRevealGroupProps {
+  children: ReactNode
+  direction?: Direction
+  stagger?: number
+  once?: boolean
+  className?: string
+}
+
+export function ScrollRevealGroup({
+  children,
+  direction = 'up',
+  stagger = 0.12,
+  once = true,
+  className,
+}: ScrollRevealGroupProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = directionOffsets[direction]
+
+  return (
+    <motion.div
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once }}
+      variants={{
+        hidden: {},
+        visible: {
+          transition: {
+            staggerChildren: stagger,
+          },
+        },
+      }}
+      className={className}
+    >
+      {Array.isArray(children) ? (
+        children.map((child, i) => (
+          <motion.div
+            key={i}
+            variants={{
+              hidden: { opacity: 0, ...offset },
+              visible: {
+                opacity: 1,
+                x: 0,
+                y: 0,
+                transition: {
+                  type: 'spring',
+                  stiffness: 200,
+                  damping: 20,
+                },
+              },
+            }}
+          >
+            {child}
+          </motion.div>
+        ))
+      ) : (
+        <motion.div
+          variants={{
+            hidden: { opacity: 0, ...offset },
+            visible: {
+              opacity: 1,
+              x: 0,
+              y: 0,
+              transition: {
+                type: 'spring',
+                stiffness: 200,
+                damping: 20,
+              },
+            },
+          }}
+        >
+          {children}
+        </motion.div>
+      )}
+    </motion.div>
+  )
+}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@/lib/utils'
+
+import { GoldDivider } from './GoldDivider'
+
+type HeadingLevel = 'h2' | 'h3'
+
+interface SectionHeaderProps {
+  title: string
+  subtitle?: string
+  as?: HeadingLevel
+  align?: 'left' | 'center'
+  className?: string
+}
+
+export function SectionHeader({
+  title,
+  subtitle,
+  as: Tag = 'h2',
+  align = 'center',
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div className={cn('space-y-4', align === 'center' && 'text-center', className)}>
+      <Tag
+        className={cn(
+          'font-heading font-semibold text-wood-900',
+          Tag === 'h2' && 'text-[1.75rem] leading-[1.3] md:text-[2.25rem]',
+          Tag === 'h3' && 'text-[1.25rem] leading-[1.4] md:text-[1.5rem]',
+        )}
+      >
+        {title}
+      </Tag>
+
+      <GoldDivider className={align === 'left' ? 'mx-0' : undefined} />
+
+      {subtitle && (
+        <p className="mx-auto max-w-2xl text-wood-800/60">{subtitle}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,8 @@
+export { GoldDivider } from './GoldDivider'
+export { Button } from './Button'
+export { Card } from './Card'
+export type { CardProps, CardVariant } from './Card'
+export { SectionHeader } from './SectionHeader'
+export { PageHero } from './PageHero'
+export { ScrollReveal, ScrollRevealGroup } from './ScrollReveal'
+export type { ScrollRevealProps, ScrollRevealGroupProps } from './ScrollReveal'


### PR DESCRIPTION
## Summary

- Add barrel `components/ui/index.ts` exporting all 6 UI components (GoldDivider, Button, Card, SectionHeader, PageHero, ScrollReveal/ScrollRevealGroup)
- Create all UI component files from P1-01 through P1-06, including SectionHeader (P1-04 which was not yet implemented)
- Add `/style-guide` showcase page demonstrating all component variants and interactions
- Install framer-motion for ScrollReveal animations
- Add `animate-drop-in` keyframe for PageHero entry animation

Implements georgenijo/St-Basils-Boston-Web#38

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [ ] Visit `/style-guide` to verify all component variants render
- [ ] Verify barrel imports work: `import { Button, Card } from '@/components/ui'`
- [ ] Check `prefers-reduced-motion` disables ScrollReveal animations
- [ ] Verify responsive layout at 375px, 768px, 1280px