### PR TITLE
feat/P1-06-scroll-reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import { useReducedMotion } from 'framer-motion'
+import { motion } from 'framer-motion'
+
+import { cn } from '@/lib/utils'
+
+type Direction = 'up' | 'down' | 'left' | 'right'
+
+export interface ScrollRevealProps {
+  children: React.ReactNode
+  direction?: Direction
+  delay?: number
+  once?: boolean
+  stagger?: number
+  className?: string
+}
+
+const offsets: Record<Direction, { x?: number; y?: number }> = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+}
+
+/**
+ * Scroll-triggered reveal animation wrapper.
+ *
+ * Use standalone for single-element reveals, or wrap `ScrollRevealItem`
+ * children to stagger them into view.
+ */
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  once = true,
+  stagger = 0.12,
+  className,
+}: ScrollRevealProps) {
+  const prefersReducedMotion = useReducedMotion()
+  const offset = offsets[direction]
+
+  if (prefersReducedMotion) {
+    return <div className={cn(className)}>{children}</div>
+  }
+
+  return (
+    <motion.div
+      className={cn(className)}
+      variants={{
+        hidden: { opacity: 0, ...offset },
+        visible: {
+          opacity: 1,
+          x: 0,
+          y: 0,
+          transition: {
+            type: 'spring',
+            stiffness: 200,
+            damping: 20,
+            delay,
+            staggerChildren: stagger,
+          },
+        },
+      }}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once }}
+    >
+      {children}
+    </motion.div>
+  )
+}
+
+export interface ScrollRevealItemProps {
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * Child item that inherits stagger timing from a parent `ScrollReveal`.
+ * Does not set its own `initial`/`whileInView` — the parent orchestrates.
+ */
+export function ScrollRevealItem({ children, className }: ScrollRevealItemProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={cn(className)}>{children}</div>
+  }
+
+  return (
+    <motion.div
+      className={cn(className)}
+      variants={{
+        hidden: { opacity: 0, y: 40 },
+        visible: {
+          opacity: 1,
+          y: 0,
+          transition: {
+            type: 'spring',
+            stiffness: 200,
+            damping: 20,
+          },
+        },
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
 export { GoldDivider } from './GoldDivider'
+export { ScrollReveal, ScrollRevealItem } from './ScrollReveal'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#37

## Summary
- Installs `framer-motion`
- Adds `ScrollReveal` component — scroll-triggered reveal with spring physics (stiffness: 200, damping: 20)
- Supports `direction` (up/down/left/right), `delay`, `once` props
- Adds `ScrollRevealItem` for staggered child animations (0.12s default)
- Respects `prefers-reduced-motion` — renders without animation when enabled
- Barrel-exported from `@/components/ui`

## Test plan
- [ ] Wrap content in `<ScrollReveal>` — elements animate in on scroll
- [ ] Test all four directions: up, down, left, right
- [ ] Wrap multiple `<ScrollRevealItem>` inside `<ScrollReveal>` — children stagger in
- [ ] Enable `prefers-reduced-motion` in OS settings — no animations fire
- [ ] `npm run build` passes with no errors