### PR TITLE
feat/P1-04-section-header

### DIFF
--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils'
+
+import { GoldDivider } from '@/components/ui/GoldDivider'
+
+interface SectionHeaderProps {
+  title: string
+  subtitle?: string
+  align?: 'left' | 'center'
+  as?: 'h1' | 'h2' | 'h3'
+  className?: string
+}
+
+const headingStyles = {
+  h1: 'text-[2rem] md:text-[3rem] font-semibold leading-[1.2]',
+  h2: 'text-[1.75rem] md:text-[2.25rem] font-semibold leading-[1.3]',
+  h3: 'text-[1.25rem] md:text-[1.5rem] font-semibold leading-[1.4]',
+} as const
+
+export function SectionHeader({
+  title,
+  subtitle,
+  align = 'center',
+  as: Tag = 'h2',
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'mb-12',
+        align === 'center' && 'text-center',
+        align === 'left' && 'text-left',
+        className,
+      )}
+    >
+      <Tag className={headingStyles[Tag]}>{title}</Tag>
+      <GoldDivider className={cn('mt-4 mb-4', align === 'left' && 'mx-0')} />
+      {subtitle && (
+        <p className={cn('max-w-2xl font-body text-base text-wood-800/60', align === 'center' && 'mx-auto')}>
+          {subtitle}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
 export { GoldDivider } from './GoldDivider'
+export { SectionHeader } from './SectionHeader'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#35

## Summary
- Adds `SectionHeader` component with `title`, `subtitle`, `align` (left/center), and `as` (h1/h2/h3) props
- Title renders in Cormorant Garamond with responsive sizing per heading level
- Subtitle renders in DM Sans with muted color
- GoldDivider rendered between title and subtitle
- Exported from `components/ui` barrel

## Test plan
- [ ] Verify title renders in Cormorant Garamond at correct sizes for h1/h2/h3
- [ ] Verify subtitle renders in DM Sans with muted wood-800/60 color
- [ ] Verify GoldDivider appears between title and subtitle
- [ ] Verify `align="center"` centers all content and `align="left"` left-aligns
- [ ] Verify responsive sizing at 375px, 768px, 1024px, 1280px
- [ ] `npm run build` passes with no TypeScript errors