### PR TITLE
feat/P1-03-card

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,73 @@
+import { cn } from '@/lib/utils'
+
+/* ------------------------------------------------------------------ */
+/*  Variant maps                                                       */
+/* ------------------------------------------------------------------ */
+
+const cardVariants = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+} as const
+
+type CardVariant = keyof typeof cardVariants
+
+/* ------------------------------------------------------------------ */
+/*  Props                                                              */
+/* ------------------------------------------------------------------ */
+
+interface CardProps {
+  variant?: CardVariant
+  children: React.ReactNode
+  className?: string
+}
+
+interface CardSectionProps {
+  children: React.ReactNode
+  className?: string
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function CardHeader({ children, className }: CardSectionProps) {
+  return <div className={cn('p-6 pb-0', className)}>{children}</div>
+}
+
+function CardBody({ children, className }: CardSectionProps) {
+  return <div className={cn('p-6', className)}>{children}</div>
+}
+
+function CardFooter({ children, className }: CardSectionProps) {
+  return <div className={cn('p-6 pt-0', className)}>{children}</div>
+}
+
+/* ------------------------------------------------------------------ */
+/*  Card (root) + compound assignment                                  */
+/* ------------------------------------------------------------------ */
+
+function Card({ variant = 'default', children, className }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl shadow-sm',
+        cardVariants[variant],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+Card.Header = CardHeader
+Card.Body = CardBody
+Card.Footer = CardFooter
+
+/* ------------------------------------------------------------------ */
+/*  Export                                                             */
+/* ------------------------------------------------------------------ */
+
+export { Card }
+export type { CardProps, CardSectionProps, CardVariant }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,3 @@
+export { Card } from './Card'
+export type { CardProps, CardSectionProps, CardVariant } from './Card'
 export { GoldDivider } from './GoldDivider'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#34

## Summary
- Adds `Card` compound component (`Card`, `Card.Header`, `Card.Body`, `Card.Footer`)
- Three variants: `default` (sand bg), `dark` (charcoal bg, cream text), `outlined` (cream bg, subtle border)
- `rounded-2xl` corners with `shadow-sm`
- All sub-components accept `className` for customization
- Exported from `components/ui/` barrel

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify all three variants render correct backgrounds/text colors
- [ ] Verify `className` override works on root and all sub-components
- [ ] Check `rounded-2xl` corners and shadow are visible