### PR TITLE
feat/P1-05-page-hero

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,9 @@
   /* Custom border radius */
   --radius-arch: 50% 50% 0 0;
 
+  /* Animations */
+  --animate-drop-in: drop-in 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+
   /* Extended spacing (22–30 in steps of 2) */
   --spacing-22: 5.5rem;
   --spacing-24: 6rem;
@@ -42,4 +45,15 @@ h5,
 h6 {
   font-family: var(--font-heading);
   color: var(--color-wood-900);
+}
+
+@keyframes drop-in {
+  from {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -1,0 +1,32 @@
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
+export interface PageHeroProps {
+  title: string
+  backgroundImage: string
+  className?: string
+}
+
+export function PageHero({ title, backgroundImage, className }: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        'relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]',
+        className,
+      )}
+    >
+      <Image
+        src={backgroundImage}
+        alt=""
+        fill
+        priority
+        className="object-cover"
+      />
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+      <h1 className="relative z-10 max-w-4xl px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 opacity-0 animate-drop-in motion-reduce:opacity-100 motion-reduce:animate-none md:text-[4rem]">
+        {title}
+      </h1>
+    </section>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
 export { GoldDivider } from './GoldDivider'
+export { PageHero } from './PageHero'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#36

## Summary
- Full-width `PageHero` component with responsive height (40vh mobile → 60vh desktop)
- Background image via `next/image` with `fill` + `object-cover` and dark overlay
- Centered title using Cormorant Garamond 300, cream-50
- CSS drop-in entrance animation with `prefers-reduced-motion` support
- Exported from `@/components/ui` barrel

## Test plan
- [ ] Verify responsive height at 375px (40vh) and 1280px (60vh)
- [ ] Confirm background image covers full section without distortion
- [ ] Check dark overlay provides readable text contrast
- [ ] Verify title drop-in animation plays on page load
- [ ] Enable `prefers-reduced-motion` and confirm animation is disabled
- [ ] No horizontal overflow at any breakpoint
- [ ] `npm run build` passes with no TypeScript errors