### PR TITLE
feat/P1-07-barrel-exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/app/(public)/dev/showcase/page.tsx
+++ b/src/app/(public)/dev/showcase/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from 'next'
+
+import {
+  Button,
+  Card,
+  GoldDivider,
+  PageHero,
+  ScrollReveal,
+  SectionHeader,
+} from '@/components/ui'
+
+export const metadata: Metadata = {
+  title: 'Component Showcase',
+  description: 'Dev-only showcase of all UI component variants.',
+  robots: { index: false, follow: false },
+}
+
+export default function ShowcasePage() {
+  return (
+    <main>
+      {/* PageHero */}
+      <PageHero
+        title="Component Showcase"
+        imageSrc="/placeholder-hero.jpg"
+        imageAlt="Showcase hero"
+      />
+
+      {/* Button Variants */}
+      <section className="py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="Button"
+            subtitle="Three variants (primary, secondary, ghost) across three sizes (sm, md, lg)."
+          />
+          <div className="space-y-8">
+            {(['primary', 'secondary', 'ghost'] as const).map((variant) => (
+              <div key={variant} className="space-y-3">
+                <h3 className="font-heading text-xl font-semibold capitalize text-wood-900">
+                  {variant}
+                </h3>
+                <div className="flex flex-wrap items-center gap-4">
+                  <Button variant={variant} size="sm">Small</Button>
+                  <Button variant={variant} size="md">Medium</Button>
+                  <Button variant={variant} size="lg">Large</Button>
+                  <Button variant={variant} disabled>Disabled</Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* GoldDivider */}
+      <section className="bg-sand py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader title="GoldDivider" subtitle="A decorative gradient separator." />
+          <div className="space-y-8">
+            <GoldDivider />
+            <GoldDivider className="max-w-[400px]" />
+            <GoldDivider className="mx-0 max-w-[100px]" />
+          </div>
+        </div>
+      </section>
+
+      {/* Card Variants */}
+      <section className="py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="Card"
+            subtitle="Three variants (default, dark, outlined) with compound sub-components."
+          />
+          <div className="grid gap-8 md:grid-cols-3">
+            {(['default', 'dark', 'outlined'] as const).map((variant) => (
+              <Card key={variant} variant={variant}>
+                <Card.Header>
+                  <h3 className="font-heading text-xl font-semibold capitalize">
+                    {variant}
+                  </h3>
+                </Card.Header>
+                <Card.Body>
+                  <p className="text-sm leading-relaxed opacity-80">
+                    This is a {variant} card with Header, Body, and Footer sub-components.
+                  </p>
+                </Card.Body>
+                <Card.Footer>
+                  <p className="text-xs opacity-60">Card footer content</p>
+                </Card.Footer>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* SectionHeader */}
+      <section className="bg-sand py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="SectionHeader"
+            subtitle="Center-aligned (default) with GoldDivider between title and subtitle."
+          />
+          <div className="mt-16">
+            <SectionHeader
+              title="Left-Aligned Variant"
+              subtitle="Pass align='left' for left-aligned headers."
+              align="left"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* ScrollReveal */}
+      <section className="py-22">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <SectionHeader
+            title="ScrollReveal"
+            subtitle="Scroll-triggered spring animations from four directions. Respects prefers-reduced-motion."
+          />
+          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+            {(['up', 'down', 'left', 'right'] as const).map(
+              (direction, i) => (
+                <ScrollReveal
+                  key={direction}
+                  direction={direction}
+                  delay={i * 0.12}
+                >
+                  <Card variant="outlined">
+                    <Card.Body>
+                      <p className="text-center font-medium capitalize">
+                        {direction}
+                      </p>
+                    </Card.Body>
+                  </Card>
+                </ScrollReveal>
+              ),
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+interface ButtonProps {
+  variant?: 'primary' | 'secondary' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+  href?: string
+  children: React.ReactNode
+  className?: string
+  disabled?: boolean
+  type?: 'button' | 'submit' | 'reset'
+  onClick?: () => void
+}
+
+const variantStyles = {
+  primary:
+    'bg-burgundy-700 text-cream-50 hover:bg-burgundy-800 focus-visible:ring-burgundy-700',
+  secondary:
+    'border border-burgundy-700 text-burgundy-700 hover:bg-burgundy-700 hover:text-cream-50 focus-visible:ring-burgundy-700',
+  ghost:
+    'text-burgundy-700 hover:bg-cream-100 focus-visible:ring-burgundy-700',
+}
+
+const sizeStyles = {
+  sm: 'px-4 py-2 text-sm',
+  md: 'px-6 py-3 text-base',
+  lg: 'px-8 py-4 text-lg',
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  href,
+  children,
+  className,
+  disabled,
+  type = 'button',
+  onClick,
+}: ButtonProps) {
+  const classes = cn(
+    'inline-flex items-center justify-center rounded-lg font-body font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+    'min-h-11 min-w-11',
+    variantStyles[variant],
+    sizeStyles[size],
+    className,
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className={classes}>
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <button
+      type={type}
+      className={classes}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,65 @@
+import { cn } from '@/lib/utils'
+
+type CardVariant = 'default' | 'dark' | 'outlined'
+
+interface CardProps {
+  variant?: CardVariant
+  children: React.ReactNode
+  className?: string
+}
+
+const variantStyles: Record<CardVariant, string> = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+}
+
+function Card({ variant = 'default', children, className }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl shadow transition-all duration-200 hover:-translate-y-1 hover:shadow-lg',
+        variantStyles[variant],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+Card.Header = function CardHeader({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return <div className={cn('p-6 pb-0', className)}>{children}</div>
+}
+
+Card.Body = function CardBody({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return <div className={cn('p-6', className)}>{children}</div>
+}
+
+Card.Footer = function CardFooter({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div className={cn('border-t border-current/10 p-6 pt-4', className)}>
+      {children}
+    </div>
+  )
+}
+
+export { Card }

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -1,0 +1,33 @@
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
+interface PageHeroProps {
+  title: string
+  imageSrc: string
+  imageAlt: string
+  className?: string
+}
+
+export function PageHero({ title, imageSrc, imageAlt, className }: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        'relative flex h-[40vh] items-center justify-center md:h-[60vh]',
+        className,
+      )}
+    >
+      <Image
+        src={imageSrc}
+        alt={imageAlt}
+        fill
+        className="object-cover"
+        priority
+      />
+      <div className="absolute inset-0 bg-black/50" />
+      <h1 className="relative z-10 px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+        {title}
+      </h1>
+    </section>
+  )
+}

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+
+import { cn } from '@/lib/utils'
+
+type Direction = 'up' | 'down' | 'left' | 'right'
+
+interface ScrollRevealProps {
+  children: React.ReactNode
+  direction?: Direction
+  delay?: number
+  className?: string
+  as?: keyof typeof motion
+}
+
+const offsets: Record<Direction, { x?: number; y?: number }> = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+}
+
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  className,
+  as = 'div',
+}: ScrollRevealProps) {
+  const prefersReducedMotion = useReducedMotion()
+  const Component = motion[as] as typeof motion.div
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = offsets[direction]
+
+  return (
+    <Component
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once: true, margin: '-100px' }}
+      transition={{
+        type: 'spring',
+        stiffness: 200,
+        damping: 20,
+        delay,
+      }}
+      className={cn(className)}
+    >
+      {children}
+    </Component>
+  )
+}

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils'
+
+import { GoldDivider } from './GoldDivider'
+
+interface SectionHeaderProps {
+  title: string
+  subtitle?: string
+  align?: 'left' | 'center'
+  className?: string
+}
+
+export function SectionHeader({
+  title,
+  subtitle,
+  align = 'center',
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div
+      className={cn(
+        'mb-12',
+        align === 'center' && 'text-center',
+        className,
+      )}
+    >
+      <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900 md:text-[2.25rem] leading-[1.3]">
+        {title}
+      </h2>
+      <GoldDivider className={cn('my-4', align === 'left' && 'mx-0')} />
+      {subtitle && (
+        <p className="max-w-2xl text-wood-800/60 mx-auto text-base leading-relaxed">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,6 @@
+export { Button } from './Button'
+export { Card } from './Card'
 export { GoldDivider } from './GoldDivider'
+export { PageHero } from './PageHero'
+export { ScrollReveal } from './ScrollReveal'
+export { SectionHeader } from './SectionHeader'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#38

## Summary

- Created 5 missing UI components: **Button**, **Card**, **SectionHeader**, **PageHero**, **ScrollReveal**
- Updated `components/ui/index.ts` barrel file to export all 6 UI primitives
- Added dev-only showcase page at `/dev/showcase` displaying all component variants
- Installed `framer-motion` for ScrollReveal spring animations

## Components

| Component | Variants | Notes |
|-----------|----------|-------|
| Button | primary, secondary, ghost × sm, md, lg | Renders as `<Link>` when `href` provided; 44px min touch target |
| Card | default, dark, outlined | Compound: Card.Header, Card.Body, Card.Footer |
| SectionHeader | center (default), left | Includes GoldDivider between title and subtitle |
| PageHero | — | 40vh mobile / 60vh desktop, image + overlay |
| ScrollReveal | up, down, left, right | Spring animation, respects `prefers-reduced-motion` |
| GoldDivider | — | Already existed (P1-06) |

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify `/dev/showcase` renders all component variants
- [ ] Verify barrel imports work: `import { Button, Card } from '@/components/ui'`
- [ ] Verify `cn()` class merging works on all components
- [ ] Check reduced motion behavior for ScrollReveal