### PR TITLE
feat/P1-02-button

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+  href?: string
+  children: React.ReactNode
+  className?: string
+}
+
+const variants = {
+  primary: 'bg-burgundy-700 text-cream-50 hover:bg-burgundy-800',
+  secondary:
+    'border border-burgundy-700 text-burgundy-700 hover:bg-burgundy-700 hover:text-cream-50',
+  ghost: 'text-burgundy-700 hover:bg-cream-100',
+}
+
+const sizes = {
+  sm: 'px-4 py-2 text-sm',
+  md: 'px-6 py-3 text-base',
+  lg: 'px-8 py-4 text-base',
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  href,
+  className,
+  children,
+  ...props
+}: ButtonProps) {
+  const classes = cn(
+    'inline-flex items-center justify-center rounded-lg font-medium transition-colors',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-burgundy-700 focus-visible:ring-offset-2',
+    'disabled:pointer-events-none disabled:opacity-50',
+    variants[variant],
+    sizes[size],
+    className,
+  )
+
+  if (href) {
+    return (
+      <Link href={href} className={classes}>
+        {children}
+      </Link>
+    )
+  }
+
+  return (
+    <button className={classes} {...props}>
+      {children}
+    </button>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
+export { Button } from './Button'
 export { GoldDivider } from './GoldDivider'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#33

## Summary
- Button component with `primary`, `secondary`, and `ghost` variants
- Three sizes: `sm`, `md`, `lg`
- Renders as `<Link>` when `href` prop is provided, `<button>` otherwise
- Focus-visible ring for keyboard navigation
- Disabled state with reduced opacity and no pointer events
- Uses `cn()` for class merging, exported from barrel `components/ui/index.ts`