### PR TITLE
feat/P1-03-card

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/lib/utils'
+
+type CardVariant = 'default' | 'dark' | 'outlined'
+
+interface CardProps {
+  variant?: CardVariant
+  children: React.ReactNode
+  className?: string
+}
+
+interface CardSubProps {
+  children: React.ReactNode
+  className?: string
+}
+
+const variantStyles: Record<CardVariant, string> = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+}
+
+function Card({ variant = 'default', children, className }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-2xl shadow-sm',
+        variantStyles[variant],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}
+
+Card.Header = function CardHeader({ children, className }: CardSubProps) {
+  return <div className={cn('p-6 pb-0', className)}>{children}</div>
+}
+
+Card.Body = function CardBody({ children, className }: CardSubProps) {
+  return <div className={cn('p-6', className)}>{children}</div>
+}
+
+Card.Footer = function CardFooter({ children, className }: CardSubProps) {
+  return (
+    <div className={cn('border-t border-current/10 p-6 pt-4', className)}>
+      {children}
+    </div>
+  )
+}
+
+export { Card }
+export type { CardProps, CardVariant }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
+export { Card } from './Card'
 export { GoldDivider } from './GoldDivider'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#34

## Summary
- Add `Card` compound component (`Card`, `Card.Header`, `Card.Body`, `Card.Footer`)
- Three variants: `default` (sand bg), `dark` (charcoal bg, cream text), `outlined` (cream-50 bg, border)
- `rounded-2xl` corners with subtle `shadow-sm`
- All sub-components accept `className` for customization
- Exported from `components/ui/` barrel

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify all three variants render correct colors
- [ ] Verify `className` overrides work on all sub-components
- [ ] Verify compound pattern (`Card.Header`, etc.) works in consuming components