### PR TITLE
feat/P1-04-section-header

### DIFF
--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils'
+
+import { GoldDivider } from '@/components/ui/GoldDivider'
+
+type HeadingLevel = 'h1' | 'h2' | 'h3'
+type Alignment = 'left' | 'center'
+
+export interface SectionHeaderProps {
+  title: string
+  subtitle?: string
+  align?: Alignment
+  as?: HeadingLevel
+  className?: string
+}
+
+const headingSizes: Record<HeadingLevel, string> = {
+  h1: 'text-[2rem] md:text-[3rem] leading-[1.2] font-semibold',
+  h2: 'text-[1.75rem] md:text-[2.25rem] leading-[1.3] font-semibold',
+  h3: 'text-[1.25rem] md:text-[1.5rem] leading-[1.4] font-semibold',
+}
+
+export function SectionHeader({
+  title,
+  subtitle,
+  align = 'center',
+  as: Tag = 'h2',
+  className,
+}: SectionHeaderProps) {
+  const isCenter = align === 'center'
+
+  return (
+    <div className={cn(isCenter ? 'text-center' : 'text-left', className)}>
+      <Tag className={cn(headingSizes[Tag], 'text-wood-900')}>
+        {title}
+      </Tag>
+
+      <GoldDivider className={cn('my-4', !isCenter && 'mx-0')} />
+
+      {subtitle && (
+        <p className="font-body text-base leading-relaxed text-wood-800/60">
+          {subtitle}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,3 @@
 export { GoldDivider } from './GoldDivider'
+export { SectionHeader } from './SectionHeader'
+export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
## Summary
- Adds `SectionHeader` component with `title`, `subtitle`, `align` (left/center), and `as` (h1-h3) props
- Title renders in Cormorant Garamond, subtitle in DM Sans
- `GoldDivider` rendered between title and subtitle
- Exported from barrel `components/ui/index.ts`

Implements georgenijo/St-Basils-Boston-Web#35

## Test plan
- [ ] Verify title renders in Cormorant Garamond font
- [ ] Verify subtitle renders in DM Sans font
- [ ] Verify GoldDivider appears between title and subtitle
- [ ] Test `align="left"` and `align="center"`
- [ ] Test `as="h1"`, `as="h2"`, `as="h3"` render correct heading elements
- [ ] Verify responsive sizing at 375px, 768px, 1280px
- [ ] Confirm `npm run build` passes with no errors