### PR TITLE
feat/P1-05-page-hero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import Image from 'next/image'
+import { motion, useReducedMotion } from 'framer-motion'
+
+import { cn } from '@/lib/utils'
+
+export interface PageHeroProps {
+  title: string
+  backgroundImage: string
+  className?: string
+}
+
+export function PageHero({ title, backgroundImage, className }: PageHeroProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  return (
+    <section
+      className={cn('relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]', className)}
+    >
+      <Image
+        src={backgroundImage}
+        alt=""
+        fill
+        priority
+        className="object-cover"
+        sizes="100vw"
+      />
+      <div className="absolute inset-0 bg-black/50" />
+      <motion.h1
+        className="relative z-10 px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]"
+        initial={prefersReducedMotion ? false : { opacity: 0, y: -40 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ type: 'spring', stiffness: 200, damping: 20 }}
+      >
+        {title}
+      </motion.h1>
+    </section>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,3 @@
 export { GoldDivider } from './GoldDivider'
+export { PageHero } from './PageHero'
+export type { PageHeroProps } from './PageHero'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#36

## Summary
- Add `PageHero` component (`src/components/ui/PageHero.tsx`)
- Full-width section with responsive height (40vh mobile, 60vh desktop)
- Background image via `next/image` with `object-cover` and dark overlay (`bg-black/50`)
- Centered title using Cormorant Garamond 300 in cream-50
- Drop-in entrance animation (spring: stiffness 200, damping 20) with `prefers-reduced-motion` support
- Props: `title`, `backgroundImage`, `className`
- Exported from `components/ui` barrel file

## Test plan
- [ ] Verify responsive height at 375px (40vh) and 1280px (60vh)
- [ ] Confirm background image fills and covers the section
- [ ] Verify title animation plays on load
- [ ] Test with `prefers-reduced-motion: reduce` — animation should be skipped
- [ ] `npm run build` passes with no TypeScript errors