### PR TITLE
feat/P1-06-scroll-reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useReducedMotion, motion } from 'framer-motion'
+
+import { cn } from '@/lib/utils'
+
+type Direction = 'up' | 'down' | 'left' | 'right'
+
+interface ScrollRevealProps {
+  children: React.ReactNode
+  direction?: Direction
+  delay?: number
+  once?: boolean
+  stagger?: boolean
+  className?: string
+}
+
+const offsets: Record<Direction, { x?: number; y?: number }> = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+}
+
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  once = true,
+  stagger = false,
+  className,
+}: ScrollRevealProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = offsets[direction]
+
+  const containerVariants = {
+    hidden: { opacity: 0, ...offset },
+    visible: {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      transition: {
+        type: 'spring' as const,
+        stiffness: 200,
+        damping: 20,
+        delay,
+        ...(stagger && { staggerChildren: 0.12 }),
+      },
+    },
+  }
+
+  const childVariants = stagger
+    ? {
+        hidden: { opacity: 0, ...offset },
+        visible: {
+          opacity: 1,
+          x: 0,
+          y: 0,
+          transition: {
+            type: 'spring' as const,
+            stiffness: 200,
+            damping: 20,
+          },
+        },
+      }
+    : undefined
+
+  return (
+    <motion.div
+      className={cn(className)}
+      variants={containerVariants}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once }}
+    >
+      {stagger
+        ? (Array.isArray(children) ? children : [children]).map(
+            (child, index) => (
+              <motion.div key={index} variants={childVariants}>
+                {child}
+              </motion.div>
+            ),
+          )
+        : children}
+    </motion.div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,1 +1,2 @@
 export { GoldDivider } from './GoldDivider'
+export { ScrollReveal } from './ScrollReveal'


### PR DESCRIPTION
## Summary

Implements georgenijo/St-Basils-Boston-Web#37

- Installs `framer-motion` and creates a `<ScrollReveal>` client component
- Spring animation (stiffness: 200, damping: 20) with `whileInView` trigger
- `direction` prop (up/down/left/right) controls animation origin with 40px offset
- `stagger` prop enables sequential child animation at 0.12s intervals
- Fully respects `prefers-reduced-motion` — renders children without animation
- Exported from `@/components/ui` barrel

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] Elements animate into view on scroll in dev server
- [ ] Each `direction` value animates from the correct origin
- [ ] `stagger` prop staggers child elements sequentially
- [ ] `once={false}` re-triggers animation on re-entry
- [ ] Enabling `prefers-reduced-motion: reduce` in OS/browser disables all animation