### PR TITLE
feat/P1-06-scroll-reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+
+type Direction = 'up' | 'down' | 'left' | 'right'
+
+export interface ScrollRevealProps {
+  children: React.ReactNode
+  direction?: Direction
+  delay?: number
+  once?: boolean
+  stagger?: number
+  className?: string
+}
+
+const offsets: Record<Direction, { x?: number; y?: number }> = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+}
+
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  once = true,
+  stagger = 0.12,
+  className,
+}: ScrollRevealProps) {
+  const prefersReducedMotion = useReducedMotion()
+
+  if (prefersReducedMotion) {
+    return <div className={className}>{children}</div>
+  }
+
+  const offset = offsets[direction]
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, ...offset }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+      viewport={{ once }}
+      transition={{
+        type: 'spring',
+        stiffness: 200,
+        damping: 20,
+        delay,
+        staggerChildren: stagger,
+      }}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,6 @@
 export { Button } from './Button'
 export { GoldDivider } from './GoldDivider'
+export { ScrollReveal } from './ScrollReveal'
+export type { ScrollRevealProps } from './ScrollReveal'
 export { SectionHeader } from './SectionHeader'
 export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
## Summary
- Installs `framer-motion` dependency
- Adds `ScrollReveal` client component with `whileInView` spring animation (stiffness: 200, damping: 20)
- Supports `direction` (up/down/left/right), `delay`, `once`, and `stagger` props
- Respects `prefers-reduced-motion` — renders children without animation when enabled

Implements georgenijo/St-Basils-Boston-Web#37

## Test plan
- [ ] Wrap content in `<ScrollReveal>` and verify elements animate into view on scroll
- [ ] Test each `direction` prop value (up, down, left, right)
- [ ] Test `delay` and `stagger` props
- [ ] Enable `prefers-reduced-motion` in OS settings and confirm no animation occurs
- [ ] Verify `npm run build` passes with no TypeScript errors