### PR TITLE
feat/P1-03-card

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,40 @@
+import { cn } from '@/lib/utils'
+
+const variantStyles = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+} as const
+
+interface CardProps {
+  variant?: keyof typeof variantStyles
+  children: React.ReactNode
+  className?: string
+}
+
+function Card({ variant = 'default', children, className }: CardProps) {
+  return (
+    <div className={cn('rounded-2xl shadow-sm', variantStyles[variant], className)}>
+      {children}
+    </div>
+  )
+}
+
+function CardHeader({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6 pb-0', className)}>{children}</div>
+}
+
+function CardBody({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6', className)}>{children}</div>
+}
+
+function CardFooter({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('p-6 pt-0', className)}>{children}</div>
+}
+
+Card.Header = CardHeader
+Card.Body = CardBody
+Card.Footer = CardFooter
+
+export { Card }
+export type { CardProps }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,6 @@
 export { Button } from './Button'
+export { Card } from './Card'
+export type { CardProps } from './Card'
 export { GoldDivider } from './GoldDivider'
 export { SectionHeader } from './SectionHeader'
 export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#34

## Summary
- Add `Card` compound component with `Card.Header`, `Card.Body`, `Card.Footer` sub-components
- Three variants: `default` (sand bg), `dark` (charcoal bg, cream text), `outlined` (cream bg, subtle border)
- `rounded-2xl` corners, `shadow-sm`, `className` prop on all sub-components
- Exported from `components/ui/` barrel

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify all three variants render correct backgrounds and text colors
- [ ] Verify `className` prop merges correctly on Card and all sub-components
- [ ] Verify compound pattern works: `<Card><Card.Header>...</Card.Header></Card>`