### PR TITLE
feat: add PageHero component (#36)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,6 +26,20 @@
   --spacing-26: 6.5rem;
   --spacing-28: 7rem;
   --spacing-30: 7.5rem;
+
+  /* Animations */
+  --animate-drop-in: drop-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+
+  @keyframes drop-in {
+    from {
+      opacity: 0;
+      transform: translateY(-30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 body {
@@ -42,4 +56,10 @@ h5,
 h6 {
   font-family: var(--font-heading);
   color: var(--color-wood-900);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-drop-in {
+    animation: none;
+  }
 }

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
+export interface PageHeroProps {
+  title: string
+  backgroundImage: string
+  className?: string
+}
+
+export function PageHero({ title, backgroundImage, className }: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        'relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]',
+        className,
+      )}
+    >
+      <Image
+        src={backgroundImage}
+        alt=""
+        fill
+        priority
+        className="object-cover"
+        sizes="100vw"
+      />
+
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+
+      <h1 className="relative z-10 animate-drop-in px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+        {title}
+      </h1>
+    </section>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,6 @@
 export { Button } from './Button'
 export { GoldDivider } from './GoldDivider'
+export { PageHero } from './PageHero'
+export type { PageHeroProps } from './PageHero'
 export { SectionHeader } from './SectionHeader'
 export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
## Summary

- Adds `PageHero` component with full-width responsive height (40vh mobile / 60vh desktop)
- Background image via `next/image` with `object-cover` and black/50 overlay for readability
- Centered title with Cormorant Garamond 300, cream-50, and CSS drop-in animation
- Respects `prefers-reduced-motion` by disabling animation
- Exports `PageHero` and `PageHeroProps` from barrel index

Implements georgenijo/St-Basils-Boston-Web#36