### PR TITLE
feat: Button component props export (#33)

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -20,7 +20,7 @@ const sizes = {
 const base =
   'inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-burgundy-700 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: keyof typeof variants
   size?: keyof typeof sizes
   href?: string

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,5 @@
 export { Button } from './Button'
+export type { ButtonProps } from './Button'
 export { GoldDivider } from './GoldDivider'
 export { SectionHeader } from './SectionHeader'
 export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
## Summary
- Exports `ButtonProps` interface from `Button.tsx` to follow project convention of exporting props interfaces alongside components
- Adds `ButtonProps` type re-export to `components/ui/index.ts` barrel file

Implements georgenijo/St-Basils-Boston-Web#33

## Verification
- `npm run build` passes with no TypeScript errors
- All acceptance criteria from #33 met (variants, sizes, Link rendering, focus ring, disabled state, `cn()` usage)