### PR TITLE
feat/P1-09-footer

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link'
+
+import { GoldDivider } from '@/components/ui'
+
+export function Footer() {
+  const currentYear = new Date().getFullYear()
+
+  return (
+    <footer className="bg-charcoal text-cream-50">
+      <div className="mx-auto max-w-[1200px] px-4 py-16 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-3">
+          {/* Church Info */}
+          <div>
+            <h2 className="font-heading text-xl font-600 text-cream-50">
+              St. Basil&#39;s Syriac Orthodox Church
+            </h2>
+            <address className="mt-4 not-italic leading-relaxed text-cream-50/80">
+              73 Ellis Street
+              <br />
+              Newton, MA 02464
+            </address>
+          </div>
+
+          {/* Service Times */}
+          <div>
+            <h2 className="font-heading text-xl font-600 text-cream-50">
+              Sunday Services
+            </h2>
+            <dl className="mt-4 space-y-2 text-cream-50/80">
+              <div>
+                <dt className="font-medium text-cream-50">Morning Prayer</dt>
+                <dd>8:30 AM EST</dd>
+              </div>
+              <div>
+                <dt className="font-medium text-cream-50">Holy Qurbono</dt>
+                <dd>9:15 AM EST</dd>
+              </div>
+            </dl>
+          </div>
+
+          {/* Links & Social */}
+          <div>
+            <h2 className="font-heading text-xl font-600 text-cream-50">
+              Quick Links
+            </h2>
+            <nav aria-label="Footer navigation" className="mt-4">
+              <ul className="space-y-2 text-cream-50/80">
+                <li>
+                  <Link
+                    href="/contact"
+                    className="transition-colors hover:text-cream-50"
+                  >
+                    Contact Us
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/privacy-policy"
+                    className="transition-colors hover:text-cream-50"
+                  >
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/terms-of-use"
+                    className="transition-colors hover:text-cream-50"
+                  >
+                    Terms of Use
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+            <div className="mt-6">
+              <a
+                href="https://www.facebook.com/stbasilsboston"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="St. Basil's on Facebook"
+                className="inline-flex h-11 w-11 items-center justify-center rounded-full border border-cream-50/20 text-cream-50/80 transition-colors hover:border-cream-50/40 hover:text-cream-50"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path d="M9.101 23.691v-7.98H6.627v-3.667h2.474v-1.58c0-4.085 1.848-5.978 5.858-5.978.401 0 1.09.044 1.613.115V7.93h-1.143c-1.628 0-2.131.891-2.131 2.228v1.49h3.165l-.567 3.667h-2.598v8.376C18.788 23.022 24 18.091 24 12c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.635 3.887 10.36 9.101 11.691Z" />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+
+        <GoldDivider className="my-10" />
+
+        <p className="text-center text-sm text-cream-50/60">
+          &copy; {currentYear} St. Basil&#39;s Syriac Orthodox Church. All
+          rights reserved.
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,22 +1,11 @@
 // Components
 export { Button } from './Button'
-export type { ButtonProps } from './Button'
 export { GoldDivider } from './GoldDivider'
 export { PageHero } from './PageHero'
-export type { PageHeroProps } from './PageHero'
 export { SectionHeader } from './SectionHeader'
-
-// TODO: Uncomment when components are merged
-// export { Card } from './Card'
-// export { PageHero } from './PageHero'
-// export { ScrollReveal } from './ScrollReveal'
 
 // Types
 export type { ButtonProps } from './Button'
 export type { GoldDividerProps } from './GoldDivider'
+export type { PageHeroProps } from './PageHero'
 export type { SectionHeaderProps } from './SectionHeader'
-
-// TODO: Uncomment when components are merged
-// export type { CardProps } from './Card'
-// export type { PageHeroProps } from './PageHero'
-// export type { ScrollRevealProps } from './ScrollReveal'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#40

## Summary
- Adds `Footer` layout component with charcoal background and cream text
- Displays church address (73 Ellis St, Newton MA) and Sunday service times
- Dynamic copyright year, legal links (Privacy Policy, Terms of Use, Contact), and Facebook social link
- Responsive grid: 3 columns on desktop, stacked on mobile
- Gold divider separating content from copyright
- Fixes duplicate `ButtonProps` export in `components/ui/index.ts`

## Test plan
- [ ] `npm run build` passes with no TypeScript errors
- [ ] Footer renders charcoal bg with cream text
- [ ] Address and service times display correctly
- [ ] Copyright year is current year
- [ ] Legal links route to `/privacy-policy`, `/terms-of-use`, `/contact`
- [ ] Facebook icon opens in new tab
- [ ] Layout stacks to single column on mobile (< 768px)
- [ ] 44x44px touch target on Facebook icon
- [ ] Keyboard navigable (tab through links)