### PR TITLE
feat: add public layout composing Navbar + Footer (#41)

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,13 +1,16 @@
+import { Navbar } from '@/components/layout/Navbar'
+import { Footer } from '@/components/layout/Footer'
+
 export default function PublicLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
   return (
-    <>
-      {/* Navbar will be added here */}
-      {children}
-      {/* Footer will be added here */}
-    </>
+    <div className="flex min-h-screen flex-col">
+      <Navbar />
+      <main className="flex-1 pt-16">{children}</main>
+      <Footer />
+    </div>
   )
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,12 @@
+export function Footer() {
+  return (
+    <footer className="bg-charcoal px-4 py-12 text-cream-50 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-[1200px]">
+        <p className="font-body text-sm text-cream-50/60">
+          &copy; {new Date().getFullYear()} St. Basil&apos;s Syriac Orthodox Church.
+          All rights reserved.
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,0 +1,11 @@
+export function Navbar() {
+  return (
+    <header className="fixed inset-x-0 top-0 z-50 h-16 border-b border-wood-800/10 bg-cream-50">
+      <nav className="mx-auto flex h-full max-w-[1200px] items-center px-4 sm:px-6 lg:px-8">
+        <span className="font-heading text-lg font-semibold text-wood-900">
+          St. Basil&apos;s
+        </span>
+      </nav>
+    </header>
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,22 +1,11 @@
 // Components
 export { Button } from './Button'
-export type { ButtonProps } from './Button'
 export { GoldDivider } from './GoldDivider'
 export { PageHero } from './PageHero'
-export type { PageHeroProps } from './PageHero'
 export { SectionHeader } from './SectionHeader'
-
-// TODO: Uncomment when components are merged
-// export { Card } from './Card'
-// export { PageHero } from './PageHero'
-// export { ScrollReveal } from './ScrollReveal'
 
 // Types
 export type { ButtonProps } from './Button'
 export type { GoldDividerProps } from './GoldDivider'
+export type { PageHeroProps } from './PageHero'
 export type { SectionHeaderProps } from './SectionHeader'
-
-// TODO: Uncomment when components are merged
-// export type { CardProps } from './Card'
-// export type { PageHeroProps } from './PageHero'
-// export type { ScrollRevealProps } from './ScrollReveal'


### PR DESCRIPTION
## Summary

- Composes `(public)/layout.tsx` with `<Navbar>` + `<main>` + `<Footer>`
- Sticky footer via `flex min-h-screen flex-col` + `flex-1` on main
- `pt-16` on main to clear the fixed navbar
- Adds placeholder `Navbar` and `Footer` layout components (to be replaced by P1-08 and P1-09)
- Fixes duplicate `ButtonProps`/`PageHeroProps` exports in `components/ui/index.ts`

Implements georgenijo/St-Basils-Boston-Web#41

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] Content does not hide behind fixed navbar
- [ ] Footer sticks to bottom on short pages
- [ ] All child pages inherit the public layout
- [ ] Responsive at 375px, 768px, 1024px, 1280px