### PR TITLE
feat/P0-05-sanity-init

### DIFF
--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,22 +1,11 @@
 // Components
 export { Button } from './Button'
-export type { ButtonProps } from './Button'
 export { GoldDivider } from './GoldDivider'
 export { PageHero } from './PageHero'
-export type { PageHeroProps } from './PageHero'
 export { SectionHeader } from './SectionHeader'
-
-// TODO: Uncomment when components are merged
-// export { Card } from './Card'
-// export { PageHero } from './PageHero'
-// export { ScrollReveal } from './ScrollReveal'
 
 // Types
 export type { ButtonProps } from './Button'
 export type { GoldDividerProps } from './GoldDivider'
+export type { PageHeroProps } from './PageHero'
 export type { SectionHeaderProps } from './SectionHeader'
-
-// TODO: Uncomment when components are merged
-// export type { CardProps } from './Card'
-// export type { PageHeroProps } from './PageHero'
-// export type { ScrollRevealProps } from './ScrollReveal'

--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -6,6 +6,6 @@ const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
 export const client = createClient({
   projectId,
   dataset,
-  apiVersion: '2024-01-01',
+  apiVersion: '2025-03-01',
   useCdn: true,
 })


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#26

## Summary
- Sanity project fully initialized with embedded Studio at `/studio`
- `sanity.config.ts` and `sanity.cli.ts` configured with env-based project ID/dataset
- Empty schema registry scaffolded at `src/sanity/schemas/index.ts`
- Sanity client, image helper (`urlFor`), GROQ queries, and types in `src/lib/sanity/`
- `.env.local.example` updated with `NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET`
- Fixed duplicate `ButtonProps` export in UI barrel file that broke the build
- Updated Sanity API version from `2024-01-01` to `2025-03-01`

## Test plan
- [x] `npm run build` passes
- [ ] `/studio` route loads Sanity Studio in browser
- [ ] Schema registry accepts new schemas when added