### PR TITLE
feat/P0-06-groq-client

### DIFF
--- a/src/lib/sanity/client.ts
+++ b/src/lib/sanity/client.ts
@@ -2,10 +2,27 @@ import { createClient } from 'next-sanity'
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
+const apiVersion = '2025-03-01'
 
 export const client = createClient({
   projectId,
   dataset,
-  apiVersion: '2025-03-01',
+  apiVersion,
   useCdn: true,
 })
+
+export async function sanityFetch<T>({
+  query,
+  params = {},
+  tags = [],
+  revalidate = 60,
+}: {
+  query: string
+  params?: Record<string, unknown>
+  tags?: string[]
+  revalidate?: number | false
+}): Promise<T> {
+  return client.fetch<T>(query, params, {
+    next: { tags, revalidate },
+  })
+}

--- a/src/lib/sanity/image.ts
+++ b/src/lib/sanity/image.ts
@@ -1,10 +1,10 @@
-import imageUrlBuilder from '@sanity/image-url'
+import { createImageUrlBuilder } from '@sanity/image-url'
 
 import { client } from '@/lib/sanity/client'
 
 import type { SanityImageSource } from '@/lib/sanity/types'
 
-const builder = imageUrlBuilder(client)
+const builder = createImageUrlBuilder(client)
 
 export function urlFor(source: SanityImageSource) {
   return builder.image(source)


### PR DESCRIPTION
## Summary
- Add `sanityFetch<T>()` helper in `src/lib/sanity/client.ts` with Next.js cache tag and revalidation support
- Replace deprecated `imageUrlBuilder` default import with `createImageUrlBuilder` named import in `src/lib/sanity/image.ts`
- Placeholder GROQ queries and TypeScript types already in place from P0-05

Implements georgenijo/St-Basils-Boston-Web#27

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [x] `sanityFetch` properly typed with generics
- [x] `urlFor()` uses non-deprecated `createImageUrlBuilder`