### PR TITLE
feat/P0-08-tooling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ const compat = new FlatCompat({
 })
 
 const eslintConfig = [
+  {
+    ignores: ['assets/**', 'forms/**', 'documentation/**', 'PSD/**', '.next/**', 'next-env.d.ts'],
+  },
   ...compat.extends(
     'next/core-web-vitals',
     'next/typescript',

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -7,9 +7,7 @@ export const metadata: Metadata = {
 export default function DashboardPage() {
   return (
     <main className="px-4 py-22 font-body text-wood-800 sm:px-6 lg:px-8">
-      <h1 className="font-heading text-3xl font-semibold text-wood-900">
-        Admin Group
-      </h1>
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">Admin Group</h1>
       <p className="mt-4">Dashboard placeholder — (admin) route group.</p>
     </main>
   )

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -3,9 +3,5 @@ export default function AuthLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-cream-50">
-      {children}
-    </div>
-  )
+  return <div className="flex min-h-screen items-center justify-center bg-cream-50">{children}</div>
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -7,9 +7,7 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <main className="w-full max-w-md px-4 font-body text-wood-800">
-      <h1 className="font-heading text-3xl font-semibold text-wood-900">
-        Auth Group
-      </h1>
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">Auth Group</h1>
       <p className="mt-4">Login placeholder — (auth) route group.</p>
     </main>
   )

--- a/src/app/(dev)/showcase/page.tsx
+++ b/src/app/(dev)/showcase/page.tsx
@@ -1,10 +1,6 @@
 import { Metadata } from 'next'
 
-import {
-  Button,
-  GoldDivider,
-  SectionHeader,
-} from '@/components/ui'
+import { Button, GoldDivider, SectionHeader } from '@/components/ui'
 
 export const metadata: Metadata = {
   title: 'Component Showcase',
@@ -21,16 +17,12 @@ export default function ShowcasePage() {
           <h1 className="font-heading text-[2rem] font-semibold text-wood-900 md:text-[3rem]">
             Component Showcase
           </h1>
-          <p className="mt-2 font-body text-wood-800/60">
-            All UI component variants — dev only
-          </p>
+          <p className="mt-2 font-body text-wood-800/60">All UI component variants — dev only</p>
         </div>
 
         {/* GoldDivider */}
         <section className="space-y-6">
-          <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900">
-            GoldDivider
-          </h2>
+          <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900">GoldDivider</h2>
           <div className="space-y-8 rounded-2xl bg-sand p-8">
             <div>
               <p className="mb-3 font-body text-sm text-wood-800/60">Default</p>
@@ -43,9 +35,7 @@ export default function ShowcasePage() {
               <GoldDivider className="max-w-[100px]" />
             </div>
             <div>
-              <p className="mb-3 font-body text-sm text-wood-800/60">
-                Left-aligned (mx-0)
-              </p>
+              <p className="mb-3 font-body text-sm text-wood-800/60">Left-aligned (mx-0)</p>
               <GoldDivider className="mx-0" />
             </div>
           </div>
@@ -53,9 +43,7 @@ export default function ShowcasePage() {
 
         {/* Button */}
         <section className="space-y-6">
-          <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900">
-            Button
-          </h2>
+          <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900">Button</h2>
 
           {/* Variants */}
           <div className="space-y-4 rounded-2xl bg-sand p-8">
@@ -90,15 +78,11 @@ export default function ShowcasePage() {
 
         {/* SectionHeader */}
         <section className="space-y-6">
-          <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900">
-            SectionHeader
-          </h2>
+          <h2 className="font-heading text-[1.75rem] font-semibold text-wood-900">SectionHeader</h2>
 
           <div className="space-y-12 rounded-2xl bg-sand p-8">
             <div>
-              <p className="mb-4 font-body text-sm text-wood-800/60">
-                Centered (default) — h2
-              </p>
+              <p className="mb-4 font-body text-sm text-wood-800/60">Centered (default) — h2</p>
               <SectionHeader
                 title="Our History"
                 subtitle="Learn about the rich heritage of St. Basil's"
@@ -106,9 +90,7 @@ export default function ShowcasePage() {
             </div>
 
             <div>
-              <p className="mb-4 font-body text-sm text-wood-800/60">
-                Left-aligned — h2
-              </p>
+              <p className="mb-4 font-body text-sm text-wood-800/60">Left-aligned — h2</p>
               <SectionHeader
                 title="Upcoming Events"
                 subtitle="Join us for worship and community gatherings"
@@ -117,9 +99,7 @@ export default function ShowcasePage() {
             </div>
 
             <div>
-              <p className="mb-4 font-body text-sm text-wood-800/60">
-                As h1
-              </p>
+              <p className="mb-4 font-body text-sm text-wood-800/60">As h1</p>
               <SectionHeader
                 as="h1"
                 title="Welcome to St. Basil's"
@@ -128,9 +108,7 @@ export default function ShowcasePage() {
             </div>
 
             <div>
-              <p className="mb-4 font-body text-sm text-wood-800/60">
-                As h3, no subtitle
-              </p>
+              <p className="mb-4 font-body text-sm text-wood-800/60">As h3, no subtitle</p>
               <SectionHeader as="h3" title="Quick Links" />
             </div>
           </div>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -9,9 +9,7 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <main className="min-h-screen px-4 py-22 font-body text-wood-800">
-      <h1 className="font-heading text-3xl font-semibold text-wood-900">
-        Public Group
-      </h1>
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">Public Group</h1>
       <p className="mt-4">Homepage placeholder — (public) route group.</p>
     </main>
   )

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -23,9 +23,7 @@ export function Footer() {
 
           {/* Service Times */}
           <div>
-            <h2 className="font-heading text-xl font-600 text-cream-50">
-              Sunday Services
-            </h2>
+            <h2 className="font-heading text-xl font-600 text-cream-50">Sunday Services</h2>
             <dl className="mt-4 space-y-2 text-cream-50/80">
               <div>
                 <dt className="font-medium text-cream-50">Morning Prayer</dt>
@@ -40,32 +38,21 @@ export function Footer() {
 
           {/* Links & Social */}
           <div>
-            <h2 className="font-heading text-xl font-600 text-cream-50">
-              Quick Links
-            </h2>
+            <h2 className="font-heading text-xl font-600 text-cream-50">Quick Links</h2>
             <nav aria-label="Footer navigation" className="mt-4">
               <ul className="space-y-2 text-cream-50/80">
                 <li>
-                  <Link
-                    href="/contact"
-                    className="transition-colors hover:text-cream-50"
-                  >
+                  <Link href="/contact" className="transition-colors hover:text-cream-50">
                     Contact Us
                   </Link>
                 </li>
                 <li>
-                  <Link
-                    href="/privacy-policy"
-                    className="transition-colors hover:text-cream-50"
-                  >
+                  <Link href="/privacy-policy" className="transition-colors hover:text-cream-50">
                     Privacy Policy
                   </Link>
                 </li>
                 <li>
-                  <Link
-                    href="/terms-of-use"
-                    className="transition-colors hover:text-cream-50"
-                  >
+                  <Link href="/terms-of-use" className="transition-colors hover:text-cream-50">
                     Terms of Use
                   </Link>
                 </li>
@@ -97,8 +84,7 @@ export function Footer() {
         <GoldDivider className="my-10" />
 
         <p className="text-center text-sm text-cream-50/60">
-          &copy; {currentYear} St. Basil&#39;s Syriac Orthodox Church. All
-          rights reserved.
+          &copy; {currentYear} St. Basil&#39;s Syriac Orthodox Church. All rights reserved.
         </p>
       </div>
     </footer>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -108,13 +108,10 @@ export function Navbar({ className }: NavbarProps) {
       if (item.href) return pathname === item.href
       return item.children?.some((child) => pathname === child.href) ?? false
     },
-    [pathname],
+    [pathname]
   )
 
-  const isChildActive = useCallback(
-    (href: string) => pathname === href,
-    [pathname],
-  )
+  const isChildActive = useCallback((href: string) => pathname === href, [pathname])
 
   return (
     <>
@@ -122,7 +119,7 @@ export function Navbar({ className }: NavbarProps) {
       <div
         className={cn(
           'fixed inset-0 z-40 bg-black/20 transition-opacity duration-300 xl:hidden',
-          mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+          mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
         )}
         aria-hidden="true"
         onClick={() => setMobileOpen(false)}
@@ -137,11 +134,7 @@ export function Navbar({ className }: NavbarProps) {
         <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">
             {/* Logo */}
-            <Link
-              href="/"
-              className="flex-shrink-0"
-              aria-label="St. Basil's — Home"
-            >
+            <Link href="/" className="flex-shrink-0" aria-label="St. Basil's — Home">
               <Image
                 src="/logo.png"
                 alt="St. Basil's Syriac Orthodox Church"
@@ -168,21 +161,19 @@ export function Navbar({ className }: NavbarProps) {
                         'flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                         isActive(item)
                           ? 'text-burgundy-700'
-                          : 'text-wood-800 hover:text-burgundy-700',
+                          : 'text-wood-800 hover:text-burgundy-700'
                       )}
                       aria-expanded={activeDropdown === item.label}
                       aria-controls={`dropdown-${item.label}`}
                       onClick={() =>
-                        setActiveDropdown(
-                          activeDropdown === item.label ? null : item.label,
-                        )
+                        setActiveDropdown(activeDropdown === item.label ? null : item.label)
                       }
                     >
                       {item.label}
                       <ChevronDown
                         className={cn(
                           'transition-transform duration-200',
-                          activeDropdown === item.label && 'rotate-180',
+                          activeDropdown === item.label && 'rotate-180'
                         )}
                       />
                     </button>
@@ -194,7 +185,7 @@ export function Navbar({ className }: NavbarProps) {
                         'absolute left-0 top-full mt-1 w-56 origin-top rounded-xl bg-cream-50 py-2 shadow-md transition-all duration-200',
                         activeDropdown === item.label
                           ? 'translate-y-0 scale-100 opacity-100'
-                          : 'pointer-events-none -translate-y-2 scale-95 opacity-0',
+                          : 'pointer-events-none -translate-y-2 scale-95 opacity-0'
                       )}
                     >
                       {item.children.map((child) => (
@@ -205,7 +196,7 @@ export function Navbar({ className }: NavbarProps) {
                               'block px-4 py-2.5 text-sm transition-colors',
                               isChildActive(child.href)
                                 ? 'bg-burgundy-100 text-burgundy-700'
-                                : 'text-wood-800 hover:bg-cream-100 hover:text-burgundy-700',
+                                : 'text-wood-800 hover:bg-cream-100 hover:text-burgundy-700'
                             )}
                             {...(isChildActive(child.href) && {
                               'aria-current': 'page' as const,
@@ -225,7 +216,7 @@ export function Navbar({ className }: NavbarProps) {
                         'rounded-lg px-4 py-2 text-sm font-medium transition-colors',
                         isActive(item)
                           ? 'text-burgundy-700'
-                          : 'text-wood-800 hover:text-burgundy-700',
+                          : 'text-wood-800 hover:text-burgundy-700'
                       )}
                       {...(isActive(item) && {
                         'aria-current': 'page' as const,
@@ -234,7 +225,7 @@ export function Navbar({ className }: NavbarProps) {
                       {item.label}
                     </Link>
                   </li>
-                ),
+                )
               )}
             </ul>
 
@@ -264,7 +255,7 @@ export function Navbar({ className }: NavbarProps) {
           id="mobile-menu"
           className={cn(
             'overflow-hidden bg-cream-50 transition-all duration-300 ease-in-out xl:hidden',
-            mobileOpen ? 'max-h-[calc(100vh-4.25rem)]' : 'max-h-0',
+            mobileOpen ? 'max-h-[calc(100vh-4.25rem)]' : 'max-h-0'
           )}
         >
           <ul className="max-h-[calc(100vh-5rem)] space-y-1 overflow-y-auto px-4 py-4">
@@ -275,21 +266,19 @@ export function Navbar({ className }: NavbarProps) {
                     type="button"
                     className={cn(
                       'flex w-full items-center justify-between rounded-lg px-4 py-3 text-base font-medium transition-colors',
-                      isActive(item) ? 'text-burgundy-700' : 'text-wood-800',
+                      isActive(item) ? 'text-burgundy-700' : 'text-wood-800'
                     )}
                     aria-expanded={activeAccordion === item.label}
                     aria-controls={`accordion-${item.label}`}
                     onClick={() =>
-                      setActiveAccordion(
-                        activeAccordion === item.label ? null : item.label,
-                      )
+                      setActiveAccordion(activeAccordion === item.label ? null : item.label)
                     }
                   >
                     {item.label}
                     <ChevronDown
                       className={cn(
                         'transition-transform duration-200',
-                        activeAccordion === item.label && 'rotate-180',
+                        activeAccordion === item.label && 'rotate-180'
                       )}
                     />
                   </button>
@@ -299,9 +288,7 @@ export function Navbar({ className }: NavbarProps) {
                     id={`accordion-${item.label}`}
                     className={cn(
                       'overflow-hidden transition-all duration-200',
-                      activeAccordion === item.label
-                        ? 'max-h-96 opacity-100'
-                        : 'max-h-0 opacity-0',
+                      activeAccordion === item.label ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
                     )}
                   >
                     {item.children.map((child) => (
@@ -312,7 +299,7 @@ export function Navbar({ className }: NavbarProps) {
                             'block rounded-lg py-2.5 pl-8 pr-4 text-sm transition-colors',
                             isChildActive(child.href)
                               ? 'bg-burgundy-100 text-burgundy-700'
-                              : 'text-wood-800 hover:text-burgundy-700',
+                              : 'text-wood-800 hover:text-burgundy-700'
                           )}
                           {...(isChildActive(child.href) && {
                             'aria-current': 'page' as const,
@@ -332,7 +319,7 @@ export function Navbar({ className }: NavbarProps) {
                       'block rounded-lg px-4 py-3 text-base font-medium transition-colors',
                       isActive(item)
                         ? 'bg-burgundy-100 text-burgundy-700'
-                        : 'text-wood-800 hover:text-burgundy-700',
+                        : 'text-wood-800 hover:text-burgundy-700'
                     )}
                     {...(isActive(item) && {
                       'aria-current': 'page' as const,
@@ -341,7 +328,7 @@ export function Navbar({ className }: NavbarProps) {
                     {item.label}
                   </Link>
                 </li>
-              ),
+              )
             )}
           </ul>
         </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -3,12 +3,10 @@ import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
 const variants = {
-  primary:
-    'bg-burgundy-700 text-cream-50 hover:bg-burgundy-800',
+  primary: 'bg-burgundy-700 text-cream-50 hover:bg-burgundy-800',
   secondary:
     'border border-burgundy-700 text-burgundy-700 hover:bg-burgundy-700 hover:text-cream-50',
-  ghost:
-    'text-burgundy-700 hover:bg-cream-100',
+  ghost: 'text-burgundy-700 hover:bg-cream-100',
 } as const
 
 const sizes = {

--- a/src/components/ui/GoldDivider.tsx
+++ b/src/components/ui/GoldDivider.tsx
@@ -10,7 +10,7 @@ export function GoldDivider({ className }: GoldDividerProps) {
       role="separator"
       className={cn(
         'mx-auto h-[2px] max-w-[200px] bg-linear-to-r from-transparent via-gold-500 to-transparent',
-        className,
+        className
       )}
     />
   )

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -13,17 +13,10 @@ export function PageHero({ title, backgroundImage, className }: PageHeroProps) {
     <section
       className={cn(
         'relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]',
-        className,
+        className
       )}
     >
-      <Image
-        src={backgroundImage}
-        alt=""
-        fill
-        priority
-        className="object-cover"
-        sizes="100vw"
-      />
+      <Image src={backgroundImage} alt="" fill priority className="object-cover" sizes="100vw" />
 
       <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
 

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -30,16 +30,12 @@ export function SectionHeader({
 
   return (
     <div className={cn(isCenter ? 'text-center' : 'text-left', className)}>
-      <Tag className={cn(headingSizes[Tag], 'text-wood-900')}>
-        {title}
-      </Tag>
+      <Tag className={cn(headingSizes[Tag], 'text-wood-900')}>{title}</Tag>
 
       <GoldDivider className={cn('my-4', !isCenter && 'mx-0')} />
 
       {subtitle && (
-        <p className="font-body text-base leading-relaxed text-wood-800/60">
-          {subtitle}
-        </p>
+        <p className="font-body text-base leading-relaxed text-wood-800/60">{subtitle}</p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Migrated lint scripts from deprecated `next lint` to ESLint CLI (`eslint .`)
- Added ESLint ignores for legacy `assets/`, `forms/`, `documentation/`, `PSD/`, and auto-generated files
- Applied Prettier formatting to all 11 source files with style issues
- Verified: `eslint-plugin-jsx-a11y` configured, `eslint-config-prettier` integrated, `cn()` utility at `lib/utils.ts` with `clsx` + `tailwind-merge`

Implements georgenijo/St-Basils-Boston-Web#29

## Test plan
- [x] `npm run lint` — passes clean (0 errors, 0 warnings)
- [x] `npm run lint:fix` — works
- [x] `npm run format:check` — all files pass
- [x] `npm run format` — works
- [x] `npm run build` — compiles successfully