### PR TITLE
feat/P1-10-public-layout

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,4 +1,5 @@
 import { Navbar } from '@/components/layout/Navbar'
+import { Footer } from '@/components/layout/Footer'
 
 export default function PublicLayout({
   children,
@@ -6,10 +7,10 @@ export default function PublicLayout({
   children: React.ReactNode
 }>) {
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Navbar />
-      <main className="pt-16">{children}</main>
-      {/* Footer will be added here */}
-    </>
+      <main className="flex-1 pt-16">{children}</main>
+      <Footer />
+    </div>
   )
 }


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#41

## Summary
- Import `<Footer>` alongside existing `<Navbar>` in `(public)/layout.tsx`
- Add `flex min-h-screen flex-col` wrapper for sticky footer on short pages
- Add `flex-1` to `<main>` so content area expands to fill available space
- `pt-16` on `<main>` offsets the fixed navbar height

## Test plan
- [ ] All child pages under `(public)/` render Navbar + content + Footer
- [ ] Footer sticks to bottom on pages with little content
- [ ] Content is not hidden behind the fixed navbar
- [ ] `npm run build` passes with no errors