### PR TITLE
feat/P1-15-json-ld

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,44 @@ import type { Metadata } from 'next'
 import { Cormorant_Garamond, DM_Sans } from 'next/font/google'
 
 import { cn } from '@/lib/utils'
+import { JsonLd } from '@/components/ui'
 
 import './globals.css'
+
+const churchJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Church',
+  name: "St. Basil's Syriac Orthodox Church",
+  description:
+    "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
+  url: 'https://stbasilsboston.org',
+  telephone: '+1-617-527-0527',
+  logo: 'https://stbasilsboston.org/images/logo.png',
+  image: 'https://stbasilsboston.org/images/logo.png',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: '73 Ellis Street',
+    addressLocality: 'Newton',
+    addressRegion: 'MA',
+    postalCode: '02464',
+    addressCountry: 'US',
+  },
+  geo: {
+    '@type': 'GeoCoordinates',
+    latitude: 42.3375,
+    longitude: -71.2093,
+  },
+  openingHoursSpecification: [
+    {
+      '@type': 'OpeningHoursSpecification',
+      dayOfWeek: 'Sunday',
+      opens: '08:30',
+      closes: '12:00',
+      description: 'Morning Prayer at 8:30 AM, Holy Qurbono at 9:15 AM',
+    },
+  ],
+  sameAs: ['https://www.facebook.com/stbasilsboston'],
+}
 
 const cormorantGaramond = Cormorant_Garamond({
   subsets: ['latin'],
@@ -35,7 +71,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={cn(cormorantGaramond.variable, dmSans.variable)}>
-      <body>{children}</body>
+      <body>
+        <JsonLd data={churchJsonLd} />
+        {children}
+      </body>
     </html>
   )
 }

--- a/src/components/ui/JsonLd.tsx
+++ b/src/components/ui/JsonLd.tsx
@@ -1,0 +1,12 @@
+interface JsonLdProps {
+  data: Record<string, unknown>
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  )
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 // Components
 export { Button } from './Button'
 export { GoldDivider } from './GoldDivider'
+export { JsonLd } from './JsonLd'
 export { PageHero } from './PageHero'
 export { SectionHeader } from './SectionHeader'
 


### PR DESCRIPTION
## Summary
- Add reusable `<JsonLd>` component that renders `<script type="application/ld+json">`
- Add Schema.org `Church` structured data to root layout with name, address, telephone, service hours, logo, geo coordinates, and Facebook sameAs link
- Renders on every page via root layout

## Test plan
- [ ] Run Google Rich Results Test against deployed page
- [ ] Verify JSON-LD `<script>` tag appears in page source
- [ ] Validate schema at https://validator.schema.org/

Implements georgenijo/St-Basils-Boston-Web#46