### PR TITLE
feat/P1-03-card

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,62 @@
+import { cn } from '@/lib/utils'
+
+const variants = {
+  default: 'bg-sand text-wood-800',
+  dark: 'bg-charcoal text-cream-50',
+  outlined: 'bg-cream-50 text-wood-800 border border-wood-800/10',
+} as const
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: keyof typeof variants
+  children: React.ReactNode
+  className?: string
+}
+
+export interface CardSectionProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode
+  className?: string
+}
+
+type CardComponent = React.FC<CardProps> & {
+  Header: React.FC<CardSectionProps>
+  Body: React.FC<CardSectionProps>
+  Footer: React.FC<CardSectionProps>
+}
+
+const Card: CardComponent = Object.assign(
+  function Card({ variant = 'default', className, children, ...props }: CardProps) {
+    return (
+      <div
+        className={cn('rounded-2xl shadow-sm', variants[variant], className)}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  },
+  {
+    Header: function CardHeader({ className, children, ...props }: CardSectionProps) {
+      return (
+        <div className={cn('p-6 pb-0', className)} {...props}>
+          {children}
+        </div>
+      )
+    },
+    Body: function CardBody({ className, children, ...props }: CardSectionProps) {
+      return (
+        <div className={cn('p-6', className)} {...props}>
+          {children}
+        </div>
+      )
+    },
+    Footer: function CardFooter({ className, children, ...props }: CardSectionProps) {
+      return (
+        <div className={cn('p-6 pt-0', className)} {...props}>
+          {children}
+        </div>
+      )
+    },
+  }
+)
+
+export { Card }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,11 +1,13 @@
 // Components
 export { Button } from './Button'
+export { Card } from './Card'
 export { GoldDivider } from './GoldDivider'
 export { PageHero } from './PageHero'
 export { SectionHeader } from './SectionHeader'
 
 // Types
 export type { ButtonProps } from './Button'
+export type { CardProps, CardSectionProps } from './Card'
 export type { GoldDividerProps } from './GoldDivider'
 export type { PageHeroProps } from './PageHero'
 export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#34

## Summary
- Add `Card` compound component (`Card`, `Card.Header`, `Card.Body`, `Card.Footer`)
- Three variants: `default` (sand bg), `dark` (charcoal bg, cream text), `outlined` (cream-50 bg with border)
- `rounded-2xl` corners and `shadow-sm` elevation
- All sub-components accept `className` for customization
- Exported from `components/ui/index.ts` barrel

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify all three variants render correct backgrounds/text colors
- [ ] Confirm `className` overrides work on Card and all sub-components
- [ ] Check compound pattern usage: `<Card><Card.Header>...</Card.Header></Card>`