### PR TITLE
feat/P1-06-scroll-reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.0",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.38.0",
         "next": "^15.3.1",
         "next-sanity": "^11.6.12",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.0",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.38.0",
     "next": "^15.3.1",
     "next-sanity": "^11.6.12",
     "react": "^19.1.0",

--- a/src/components/ui/ScrollReveal.tsx
+++ b/src/components/ui/ScrollReveal.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { createContext, useContext } from 'react'
+import { useReducedMotion, motion } from 'framer-motion'
+import type { Variant } from 'framer-motion'
+
+import { cn } from '@/lib/utils'
+
+type Direction = 'up' | 'down' | 'left' | 'right'
+
+export interface ScrollRevealProps {
+  children: React.ReactNode
+  direction?: Direction
+  delay?: number
+  once?: boolean
+  stagger?: number
+  className?: string
+  as?: keyof typeof motion
+}
+
+export interface ScrollRevealItemProps {
+  children: React.ReactNode
+  className?: string
+}
+
+const offsets: Record<Direction, { x?: number; y?: number }> = {
+  up: { y: 40 },
+  down: { y: -40 },
+  left: { x: 40 },
+  right: { x: -40 },
+}
+
+const ScrollRevealContext = createContext<{
+  direction: Direction
+  reducedMotion: boolean
+}>({ direction: 'up', reducedMotion: false })
+
+function getVariants(
+  direction: Direction,
+  reducedMotion: boolean,
+): { hidden: Variant; visible: Variant } {
+  if (reducedMotion) {
+    return {
+      hidden: { opacity: 0 },
+      visible: { opacity: 1, transition: { duration: 0.2 } },
+    }
+  }
+
+  const offset = offsets[direction]
+
+  return {
+    hidden: { opacity: 0, ...offset },
+    visible: {
+      opacity: 1,
+      x: 0,
+      y: 0,
+      transition: {
+        type: 'spring',
+        stiffness: 200,
+        damping: 20,
+      },
+    },
+  }
+}
+
+export function ScrollReveal({
+  children,
+  direction = 'up',
+  delay = 0,
+  once = true,
+  stagger = 0.12,
+  className,
+  as = 'div',
+}: ScrollRevealProps) {
+  const reducedMotion = useReducedMotion() ?? false
+  const variants = getVariants(direction, reducedMotion)
+
+  const MotionComponent = motion[as] as typeof motion.div
+
+  return (
+    <ScrollRevealContext.Provider value={{ direction, reducedMotion }}>
+      <MotionComponent
+        initial="hidden"
+        whileInView="visible"
+        viewport={{ once, margin: '-50px' }}
+        variants={variants}
+        transition={{
+          delay,
+          staggerChildren: stagger,
+        }}
+        className={cn(className)}
+      >
+        {children}
+      </MotionComponent>
+    </ScrollRevealContext.Provider>
+  )
+}
+
+function ScrollRevealItem({ children, className }: ScrollRevealItemProps) {
+  const { direction, reducedMotion } = useContext(ScrollRevealContext)
+  const variants = getVariants(direction, reducedMotion)
+
+  return (
+    <motion.div variants={variants} className={cn(className)}>
+      {children}
+    </motion.div>
+  )
+}
+
+ScrollReveal.Item = ScrollRevealItem

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -2,10 +2,12 @@
 export { Button } from './Button'
 export { GoldDivider } from './GoldDivider'
 export { PageHero } from './PageHero'
+export { ScrollReveal } from './ScrollReveal'
 export { SectionHeader } from './SectionHeader'
 
 // Types
 export type { ButtonProps } from './Button'
 export type { GoldDividerProps } from './GoldDivider'
 export type { PageHeroProps } from './PageHero'
+export type { ScrollRevealProps, ScrollRevealItemProps } from './ScrollReveal'
 export type { SectionHeaderProps } from './SectionHeader'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#37

## Summary
- Installs `framer-motion` dependency
- Adds `ScrollReveal` client component with `whileInView` scroll-triggered animation
- Spring physics: stiffness 200, damping 20
- `direction` prop (up/down/left/right) controls animation origin
- `ScrollReveal.Item` compound component for staggered children (0.12s default)
- Respects `prefers-reduced-motion` — falls back to opacity-only with short duration
- Exports `ScrollReveal`, `ScrollRevealProps`, and `ScrollRevealItemProps` from barrel

## Test plan
- [ ] `npm run build` passes
- [ ] Wrap content in `<ScrollReveal>` — animates on scroll
- [ ] Test each direction: up, down, left, right
- [ ] Use `<ScrollReveal.Item>` children — stagger works
- [ ] Enable `prefers-reduced-motion: reduce` in OS settings — no transform animations
- [ ] Verify `once` prop: element only animates the first time it enters viewport