### PR TITLE
feat/P1-16-metadata

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'About',
+  description:
+    "Learn about the history and mission of St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Rooted in the apostolic Syriac Orthodox tradition and serving the Jacobite Malayalee community in New England.",
+  openGraph: {
+    title: "About | St. Basil's Syriac Orthodox Church",
+    description:
+      "Learn about the history and mission of St. Basil's Syriac Orthodox Church in Boston, Massachusetts.",
+  },
+}
+
+export default function AboutPage() {
+  return (
+    <main className="min-h-screen px-4 py-22 font-body text-wood-800">
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">About</h1>
+      <p className="mt-4">About page placeholder.</p>
+    </main>
+  )
+}

--- a/src/app/(public)/first-time/page.tsx
+++ b/src/app/(public)/first-time/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'First Time Visiting?',
+  description:
+    "Planning your first visit to St. Basil's Syriac Orthodox Church in Boston? Find service times, directions, parking information, and what to expect on Sunday morning.",
+  openGraph: {
+    title: "First Time Visiting? | St. Basil's Syriac Orthodox Church",
+    description:
+      "Planning your first visit? Find service times, directions, and what to expect at St. Basil's in Boston.",
+  },
+}
+
+export default function FirstTimePage() {
+  return (
+    <main className="min-h-screen px-4 py-22 font-body text-wood-800">
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">First Time Visiting?</h1>
+      <p className="mt-4">First time visitor page placeholder.</p>
+    </main>
+  )
+}

--- a/src/app/(public)/giving/page.tsx
+++ b/src/app/(public)/giving/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Giving',
+  description:
+    "Support St. Basil's Syriac Orthodox Church in Boston through tithes, offerings, and donations. Your generosity sustains our ministries and community programs.",
+  openGraph: {
+    title: "Giving | St. Basil's Syriac Orthodox Church",
+    description:
+      "Support St. Basil's Syriac Orthodox Church through tithes, offerings, and donations.",
+  },
+}
+
+export default function GivingPage() {
+  return (
+    <main className="min-h-screen px-4 py-22 font-body text-wood-800">
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">Giving</h1>
+      <p className="mt-4">Giving page placeholder.</p>
+    </main>
+  )
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,9 +1,16 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: "St. Basil's Syriac Orthodox Church",
+  title: {
+    absolute: "St. Basil's Syriac Orthodox Church — Boston, MA",
+  },
   description:
-    "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
+    "Welcome to St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Join us for Sunday services, community events, and fellowship. Serving the Jacobite Malayalee community in New England.",
+  openGraph: {
+    title: "St. Basil's Syriac Orthodox Church — Boston, MA",
+    description:
+      "Welcome to St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Join us for Sunday services, community events, and fellowship.",
+  },
 }
 
 export default function HomePage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,12 +20,35 @@ const dmSans = DM_Sans({
 })
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://stbasilsboston.org'),
   title: {
     template: "%s | St. Basil's Syriac Orthodox Church",
     default: "St. Basil's Syriac Orthodox Church",
   },
   description:
     "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
+  openGraph: {
+    title: "St. Basil's Syriac Orthodox Church",
+    description:
+      "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
+    url: 'https://stbasilsboston.org',
+    siteName: "St. Basil's Syriac Orthodox Church",
+    locale: 'en_US',
+    type: 'website',
+    images: [
+      {
+        url: '/logo.png',
+        alt: "St. Basil's Syriac Orthodox Church logo",
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary',
+    title: "St. Basil's Syriac Orthodox Church",
+    description:
+      "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
+    images: ['/logo.png'],
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#47

## Summary
- Configured `metadataBase` to production URL in root layout
- Added default Open Graph image, description, site name, and locale
- Added Twitter card configuration (`summary` card type)
- Homepage uses `title.absolute` to avoid template duplication
- Created about, first-time, and giving pages with per-page `metadata` exports
- All subpage titles follow the template: `"Page | St. Basil's Syriac Orthodox Church"`

## Acceptance Criteria
- [x] Root layout has `metadata` export with title template
- [x] `metadataBase` configured
- [x] Default OG image and description set
- [x] Twitter card meta tags present
- [x] Each Phase 1 page has custom `metadata` export
- [x] Titles follow the template pattern