### PR TITLE
feat: responsive audit and accessibility polish pass

### DIFF
--- a/src/app/(public)/giving/page.tsx
+++ b/src/app/(public)/giving/page.tsx
@@ -92,7 +92,7 @@ const ministries = [
 
 export default function GivingPage() {
   return (
-    <main>
+    <>
       <PageHero title="Giving" backgroundImage="/images/giving/hero.png" />
 
       {/* Introduction */}
@@ -147,7 +147,7 @@ export default function GivingPage() {
           <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {ministries.map((ministry, i) => (
               <ScrollReveal key={ministry.title} delay={i * 0.12}>
-                <Card className="h-full transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
+                <Card className="h-full transition-shadow duration-300 hover:shadow-lg motion-safe:transition-all motion-safe:hover:-translate-y-1">
                   <Card.Body className="space-y-4">
                     <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-burgundy-700/10 text-burgundy-700">
                       {ministry.icon}
@@ -155,7 +155,7 @@ export default function GivingPage() {
                     <h3 className="font-heading text-xl font-semibold text-wood-900">
                       {ministry.title}
                     </h3>
-                    <p className="font-body text-sm leading-relaxed text-wood-800/80">
+                    <p className="font-body text-sm leading-relaxed text-wood-800/80 md:text-base">
                       {ministry.description}
                     </p>
                   </Card.Body>
@@ -174,6 +174,6 @@ export default function GivingPage() {
           </ScrollReveal>
         </div>
       </section>
-    </main>
+    </>
   )
 }

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -9,7 +9,7 @@ export default function PublicLayout({
   return (
     <div className="flex min-h-screen flex-col">
       <Navbar />
-      <main className="flex-1 pt-16">{children}</main>
+      <main id="main-content" className="flex-1 pt-16">{children}</main>
       <Footer />
     </div>
   )

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -15,9 +15,11 @@ export const metadata: Metadata = {
 
 export default function HomePage() {
   return (
-    <main className="min-h-screen px-4 py-22 font-body text-wood-800">
-      <h1 className="font-heading text-3xl font-semibold text-wood-900">Public Group</h1>
+    <div className="min-h-screen px-4 py-16 font-body text-wood-800 md:py-22">
+      <h1 className="font-heading text-[2rem] font-semibold text-wood-900 md:text-[3rem]">
+        Public Group
+      </h1>
       <p className="mt-4">Homepage placeholder — (public) route group.</p>
-    </main>
+    </div>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,10 @@
   }
 }
 
+html {
+  overflow-x: clip;
+}
+
 body {
   font-family: var(--font-body);
   background-color: var(--color-cream-50);

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -40,19 +40,19 @@ export function Footer() {
           <div>
             <h2 className="font-heading text-xl font-600 text-cream-50">Quick Links</h2>
             <nav aria-label="Footer navigation" className="mt-4">
-              <ul className="space-y-2 text-cream-50/80">
+              <ul className="-my-0.5 text-cream-50/80">
                 <li>
-                  <Link href="/contact" className="transition-colors hover:text-cream-50">
+                  <Link href="/contact" className="block py-2.5 transition-colors hover:text-cream-50">
                     Contact Us
                   </Link>
                 </li>
                 <li>
-                  <Link href="/privacy-policy" className="transition-colors hover:text-cream-50">
+                  <Link href="/privacy-policy" className="block py-2.5 transition-colors hover:text-cream-50">
                     Privacy Policy
                   </Link>
                 </li>
                 <li>
-                  <Link href="/terms-of-use" className="transition-colors hover:text-cream-50">
+                  <Link href="/terms-of-use" className="block py-2.5 transition-colors hover:text-cream-50">
                     Terms of Use
                   </Link>
                 </li>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -130,6 +130,14 @@ export function Navbar({ className }: NavbarProps) {
         className={cn('fixed inset-x-0 top-0 z-50 bg-cream-50 shadow-sm', className)}
         aria-label="Main navigation"
       >
+        {/* Skip link for keyboard/screen-reader users */}
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-2 focus:z-10 focus:rounded-lg focus:bg-burgundy-700 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-cream-50 focus:shadow-lg"
+        >
+          Skip to main content
+        </a>
+
         {/* ── Top bar ── */}
         <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
           <div className="flex h-16 items-center justify-between">
@@ -193,7 +201,7 @@ export function Navbar({ className }: NavbarProps) {
                           <Link
                             href={child.href}
                             className={cn(
-                              'block px-4 py-2.5 text-sm transition-colors',
+                              'block px-4 py-3 text-sm transition-colors',
                               isChildActive(child.href)
                                 ? 'bg-burgundy-100 text-burgundy-700'
                                 : 'text-wood-800 hover:bg-cream-100 hover:text-burgundy-700'
@@ -296,7 +304,7 @@ export function Navbar({ className }: NavbarProps) {
                         <Link
                           href={child.href}
                           className={cn(
-                            'block rounded-lg py-2.5 pl-8 pr-4 text-sm transition-colors',
+                            'block rounded-lg py-3 pl-8 pr-4 text-sm transition-colors',
                             isChildActive(child.href)
                               ? 'bg-burgundy-100 text-burgundy-700'
                               : 'text-wood-800 hover:text-burgundy-700'


### PR DESCRIPTION
## Summary

- Prevents horizontal overflow at all breakpoints via `overflow-x: clip` on `<html>`
- Adds skip-to-content link for keyboard and screen-reader accessibility
- Fixes touch targets to meet WCAG 44px minimum on mobile nav dropdown links and footer links
- Fixes invalid nested `<main>` elements on homepage and giving page
- Adds `motion-safe:` prefixes on giving page card hover transforms so animations respect `prefers-reduced-motion`
- Adds responsive font scaling to homepage placeholder and giving page card descriptions

Implements georgenijo/St-Basils-Boston-Web#48

## Test plan

- [ ] Verify no horizontal scrollbar at 375px, 768px, 1024px, 1280px, 1920px
- [ ] Tab through page and verify skip link appears and jumps to main content
- [ ] Verify all mobile nav/footer links have >= 44px touch targets (inspect element)
- [ ] Verify giving page card hover lift disabled with `prefers-reduced-motion: reduce`
- [ ] Run Lighthouse accessibility audit on all Phase 1 pages — expect >= 90
- [ ] Validate HTML (no nested `<main>` elements)