### PR TITLE
feat: add organization Sanity schema (#54)

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -8,3 +8,18 @@ export const pageContentQuery = groq`
     body
   }
 `
+
+export const organizationsQuery = groq`
+  *[_type == "organization" && isActive == true] | order(order asc) {
+    _id,
+    name,
+    slug,
+    photo,
+    description,
+    missionStatement,
+    scriptureQuote,
+    externalLink,
+    order,
+    backgroundColor
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -9,3 +9,19 @@ export interface PageContent {
   slug: { current: string }
   body: PortableTextBlock[]
 }
+
+export interface Organization {
+  _id: string
+  name: string
+  slug: { current: string }
+  photo?: SanityImageSource
+  description?: PortableTextBlock[]
+  missionStatement?: string
+  scriptureQuote?: {
+    text: string
+    reference: string
+  }
+  externalLink?: string
+  order: number
+  backgroundColor?: string
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import organization from './organization'
+
+export const schemaTypes: SchemaTypeDefinition[] = [organization]

--- a/src/sanity/schemas/organization.ts
+++ b/src/sanity/schemas/organization.ts
@@ -1,0 +1,83 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'organization',
+  title: 'Organization',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'name', maxLength: 96 },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'array',
+      of: [
+        { type: 'block' },
+        { type: 'image', options: { hotspot: true } },
+      ],
+    }),
+    defineField({
+      name: 'missionStatement',
+      title: 'Mission Statement',
+      type: 'text',
+    }),
+    defineField({
+      name: 'scriptureQuote',
+      title: 'Scripture Quote',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'text',
+          title: 'Text',
+          type: 'text',
+        }),
+        defineField({
+          name: 'reference',
+          title: 'Reference',
+          type: 'string',
+        }),
+      ],
+    }),
+    defineField({
+      name: 'externalLink',
+      title: 'External Link',
+      type: 'url',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+    defineField({
+      name: 'backgroundColor',
+      title: 'Background Color',
+      type: 'string',
+    }),
+  ],
+  preview: {
+    select: { title: 'name' },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `organization` document schema with all fields from P2-06: name, slug, photo, description (Portable Text), mission statement, scripture quote (structured object with text + reference), external link, order, isActive, backgroundColor
- Registers schema in `schemas/index.ts`
- Adds `organizationsQuery` GROQ query with `isActive` filter and `order` sorting
- Adds `Organization` TypeScript interface in `types.ts`

Implements georgenijo/St-Basils-Boston-Web#54

## Test plan
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Schema appears in Sanity Studio
- [ ] Can create organization documents with all fields
- [ ] Scripture quote renders as structured object (text + reference)
- [ ] Slug auto-generates from name
- [ ] Preview shows organization name in studio