### PR TITLE
feat: add officeBearer Sanity schema (#53)

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -8,3 +8,16 @@ export const pageContentQuery = groq`
     body
   }
 `
+
+export const officeBearersQuery = groq`
+  *[_type == "officeBearer" && isActive == true] | order(order asc) {
+    _id,
+    name,
+    role,
+    photo,
+    photoPosition,
+    category,
+    year,
+    order
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -9,3 +9,14 @@ export interface PageContent {
   slug: { current: string }
   body: PortableTextBlock[]
 }
+
+export interface OfficeBearer {
+  _id: string
+  name: string
+  role?: string
+  photo?: SanityImageSource
+  photoPosition?: string
+  category: 'executive' | 'board'
+  year?: string
+  order: number
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import officeBearer from './officeBearer'
+
+export const schemaTypes: SchemaTypeDefinition[] = [officeBearer]

--- a/src/sanity/schemas/officeBearer.ts
+++ b/src/sanity/schemas/officeBearer.ts
@@ -1,0 +1,77 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'officeBearer',
+  title: 'Office Bearer',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'role',
+      title: 'Role',
+      type: 'string',
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'photoPosition',
+      title: 'Photo Position',
+      type: 'string',
+      description: 'CSS object-position value (e.g., "center top")',
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Executive', value: 'executive' },
+          { title: 'Board', value: 'board' },
+        ],
+        layout: 'radio',
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'year',
+      title: 'Year',
+      type: 'string',
+      description: 'Term year (e.g., "2025")',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'role',
+      year: 'year',
+      media: 'photo',
+    },
+    prepare({ title, subtitle, year, media }) {
+      return {
+        title,
+        subtitle: [subtitle, year].filter(Boolean).join(' · '),
+        media,
+      }
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `officeBearer` Sanity document schema with name, role, photo (hotspot), photoPosition, category (executive/board), year, order, and isActive fields
- Registers schema in `src/sanity/schemas/index.ts`
- Adds `officeBearersQuery` GROQ query in `src/lib/sanity/queries.ts`
- Adds `OfficeBearer` TypeScript interface in `src/lib/sanity/types.ts`

Implements georgenijo/St-Basils-Boston-Web#53

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify schema appears in Sanity Studio
- [ ] Create test office bearer document with all fields
- [ ] Confirm preview shows name · role · year