### PR TITLE
feat: add spiritualLeader Sanity schema (#51)

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -8,3 +8,15 @@ export const pageContentQuery = groq`
     body
   }
 `
+
+export const spiritualLeadersQuery = groq`
+  *[_type == "spiritualLeader" && isActive == true] | order(order asc) {
+    _id,
+    name,
+    title,
+    photo,
+    photoPosition,
+    biography,
+    order
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -9,3 +9,13 @@ export interface PageContent {
   slug: { current: string }
   body: PortableTextBlock[]
 }
+
+export interface SpiritualLeader {
+  _id: string
+  name: string
+  title: string
+  photo: SanityImageSource
+  photoPosition?: string
+  biography: PortableTextBlock[]
+  order: number
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import spiritualLeader from '@/sanity/schemas/spiritualLeader'
+
+export const schemaTypes: SchemaTypeDefinition[] = [spiritualLeader]

--- a/src/sanity/schemas/spiritualLeader.ts
+++ b/src/sanity/schemas/spiritualLeader.ts
@@ -1,0 +1,62 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'spiritualLeader',
+  title: 'Spiritual Leader',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      title: 'Ecclesiastical Title',
+      type: 'string',
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'photoPosition',
+      title: 'Photo Position',
+      type: 'string',
+      description: 'CSS object-position override (e.g. "center top", "50% 30%")',
+    }),
+    defineField({
+      name: 'biography',
+      title: 'Biography',
+      type: 'array',
+      of: [
+        { type: 'block' },
+        { type: 'image', options: { hotspot: true } },
+      ],
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: { title: 'name', subtitle: 'title' },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `spiritualLeader` Sanity document schema with all required fields (name, title, photo with hotspot, photoPosition, biography as Portable Text, order, isActive)
- Registers schema in `src/sanity/schemas/index.ts`
- Adds `spiritualLeadersQuery` GROQ query to `src/lib/sanity/queries.ts`
- Adds `SpiritualLeader` TypeScript interface to `src/lib/sanity/types.ts`

Implements georgenijo/St-Basils-Boston-Web#51

## Test plan
- [x] `npm run build` passes with no TypeScript errors
- [ ] Verify schema appears in Sanity Studio
- [ ] Create a test spiritual leader document and confirm preview shows name + title
- [ ] Confirm photo hotspot/crop works in the studio