### PR TITLE
feat: add usefulLink and usefulLinksPage Sanity schemas (#55)

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,11 +1,32 @@
 import { defineConfig } from 'sanity'
 import { structureTool } from 'sanity/structure'
 import { visionTool } from '@sanity/vision'
+import type { StructureBuilder } from 'sanity/structure'
 
 import { schemaTypes } from '@/sanity/schemas'
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
+
+const singletonTypes = new Set(['usefulLinksPage'])
+
+const structure = (S: StructureBuilder) =>
+  S.list()
+    .title('Content')
+    .items([
+      S.listItem()
+        .title('Useful Links Page')
+        .id('usefulLinksPage')
+        .child(
+          S.document()
+            .schemaType('usefulLinksPage')
+            .documentId('usefulLinksPage')
+        ),
+      S.divider(),
+      ...S.documentTypeListItems().filter(
+        (item) => !singletonTypes.has(item.getId()!)
+      ),
+    ])
 
 export default defineConfig({
   name: 'st-basils-boston',
@@ -14,9 +35,14 @@ export default defineConfig({
   projectId,
   dataset,
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [
+    structureTool({ structure }),
+    visionTool(),
+  ],
 
   schema: {
     types: schemaTypes,
+    templates: (templates) =>
+      templates.filter(({ schemaType }) => !singletonTypes.has(schemaType)),
   },
 })

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -8,3 +8,23 @@ export const pageContentQuery = groq`
     body
   }
 `
+
+export const usefulLinksQuery = groq`
+  *[_type == "usefulLink" && isActive == true] | order(order asc) {
+    _id,
+    title,
+    file,
+    category,
+    order
+  }
+`
+
+export const usefulLinksPageQuery = groq`
+  *[_type == "usefulLinksPage"][0] {
+    _id,
+    pageTitle,
+    heroImage,
+    introText,
+    sectionTitle
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -9,3 +9,27 @@ export interface PageContent {
   slug: { current: string }
   body: PortableTextBlock[]
 }
+
+export interface SanityFileAsset {
+  _type: 'file'
+  asset: {
+    _ref: string
+    _type: 'reference'
+  }
+}
+
+export interface UsefulLink {
+  _id: string
+  title: string
+  file?: SanityFileAsset
+  category?: string
+  order: number
+}
+
+export interface UsefulLinksPage {
+  _id: string
+  pageTitle: string
+  heroImage?: SanityImageSource
+  introText?: string
+  sectionTitle?: string
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,6 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import usefulLink from '@/sanity/schemas/usefulLink'
+import usefulLinksPage from '@/sanity/schemas/usefulLinksPage'
+
+export const schemaTypes: SchemaTypeDefinition[] = [usefulLink, usefulLinksPage]

--- a/src/sanity/schemas/usefulLink.ts
+++ b/src/sanity/schemas/usefulLink.ts
@@ -1,0 +1,45 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'usefulLink',
+  title: 'Useful Link',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'file',
+      title: 'File (PDF)',
+      type: 'file',
+      options: {
+        accept: '.pdf',
+      },
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'category',
+    },
+  },
+})

--- a/src/sanity/schemas/usefulLinksPage.ts
+++ b/src/sanity/schemas/usefulLinksPage.ts
@@ -1,0 +1,36 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'usefulLinksPage',
+  title: 'Useful Links Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'pageTitle',
+      title: 'Page Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'introText',
+      title: 'Intro Text',
+      type: 'text',
+    }),
+    defineField({
+      name: 'sectionTitle',
+      title: 'Section Title',
+      type: 'string',
+    }),
+  ],
+  preview: {
+    select: {
+      title: 'pageTitle',
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `usefulLink` document schema with title, file (PDF), category, order, and isActive fields
- Adds `usefulLinksPage` singleton schema with pageTitle, heroImage, introText, and sectionTitle
- Configures Structure Builder to enforce singleton pattern (prevents duplicate page creation)
- Adds GROQ queries and TypeScript types for both document types

Implements georgenijo/St-Basils-Boston-Web#55