### PR TITLE
feat/P2-08-acolytes-choir

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -7,6 +7,8 @@ import { schemaTypes } from '@/sanity/schemas'
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
 
+const singletonTypes = new Set(['acolytesChoirPage'])
+
 export default defineConfig({
   name: 'st-basils-boston',
   title: "St. Basil's Syriac Orthodox Church",
@@ -14,9 +16,32 @@ export default defineConfig({
   projectId,
   dataset,
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [
+    structureTool({
+      structure: (S) =>
+        S.list()
+          .title('Content')
+          .items([
+            S.listItem()
+              .title('Acolytes & Choir Page')
+              .id('acolytesChoirPage')
+              .child(
+                S.document()
+                  .schemaType('acolytesChoirPage')
+                  .documentId('acolytesChoirPage')
+              ),
+            S.divider(),
+            ...S.documentTypeListItems().filter(
+              (listItem) => !singletonTypes.has(listItem.getId() ?? '')
+            ),
+          ]),
+    }),
+    visionTool(),
+  ],
 
   schema: {
     types: schemaTypes,
+    templates: (templates) =>
+      templates.filter(({ schemaType }) => !singletonTypes.has(schemaType)),
   },
 })

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -8,3 +8,14 @@ export const pageContentQuery = groq`
     body
   }
 `
+
+export const acolytesChoirPageQuery = groq`
+  *[_type == "acolytesChoirPage"][0] {
+    _id,
+    pageTitle,
+    heroImage,
+    description,
+    groupPhoto,
+    metaDescription
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -9,3 +9,12 @@ export interface PageContent {
   slug: { current: string }
   body: PortableTextBlock[]
 }
+
+export interface AcolytesChoirPage {
+  _id: string
+  pageTitle: string
+  heroImage: SanityImageSource
+  description: PortableTextBlock[]
+  groupPhoto?: SanityImageSource
+  metaDescription?: string
+}

--- a/src/sanity/schemas/acolytesChoirPage.ts
+++ b/src/sanity/schemas/acolytesChoirPage.ts
@@ -1,0 +1,70 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'acolytesChoirPage',
+  title: 'Acolytes & Choir Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'pageTitle',
+      title: 'Page Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: 'Normal', value: 'normal' }],
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+            ],
+            annotations: [
+              {
+                name: 'burgundyHighlight',
+                title: 'Burgundy Highlight',
+                type: 'object',
+                fields: [
+                  defineField({
+                    name: 'dummy',
+                    title: ' ',
+                    type: 'string',
+                    hidden: true,
+                  }),
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'groupPhoto',
+      title: 'Group Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'metaDescription',
+      title: 'Meta Description',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.max(160),
+    }),
+  ],
+  preview: {
+    select: { title: 'pageTitle' },
+  },
+})

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import acolytesChoirPage from '@/sanity/schemas/acolytesChoirPage'
+
+export const schemaTypes: SchemaTypeDefinition[] = [acolytesChoirPage]


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#56

## Summary
- Add `acolytesChoirPage` singleton schema with pageTitle, heroImage, description (Portable Text with burgundy highlight annotation), groupPhoto, and metaDescription fields
- Register schema in index and configure Structure Builder singleton pattern (fixed document ID, hidden from "create new")
- Add GROQ query and TypeScript type for the page
- Filter singleton from document templates to prevent duplicate creation

## Test plan
- [ ] `npm run build` passes with no TypeScript errors
- [ ] Sanity Studio loads and shows "Acolytes & Choir Page" as a singleton in the sidebar
- [ ] All fields (pageTitle, heroImage, description with burgundy highlights, groupPhoto, metaDescription) are editable
- [ ] Cannot create duplicate acolytesChoirPage documents