### PR TITLE
feat: add pageContent Sanity schema (#50)

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -1,10 +1,15 @@
 import { groq } from 'next-sanity'
 
-export const pageContentQuery = groq`
+export const pageContentBySlugQuery = groq`
   *[_type == "pageContent" && slug.current == $slug][0] {
     _id,
     title,
     slug,
-    body
+    heroStyle,
+    heroImage,
+    body,
+    metaDescription,
+    effectiveDate,
+    lastUpdated
   }
 `

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -7,5 +7,10 @@ export interface PageContent {
   _id: string
   title: string
   slug: { current: string }
+  heroStyle: 'maroon-banner' | 'parallax-image'
+  heroImage?: SanityImageSource
   body: PortableTextBlock[]
+  metaDescription?: string
+  effectiveDate?: string
+  lastUpdated?: string
 }

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import pageContent from './pageContent'
+
+export const schemaTypes: SchemaTypeDefinition[] = [pageContent]

--- a/src/sanity/schemas/pageContent.ts
+++ b/src/sanity/schemas/pageContent.ts
@@ -1,0 +1,108 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'pageContent',
+  title: 'Page Content',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      type: 'slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'heroStyle',
+      title: 'Hero Style',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Maroon Banner', value: 'maroon-banner' },
+          { title: 'Parallax Image', value: 'parallax-image' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'maroon-banner',
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+      hidden: ({ document }) => document?.heroStyle !== 'parallax-image',
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [
+            { title: 'Normal', value: 'normal' },
+            { title: 'H2', value: 'h2' },
+            { title: 'H3', value: 'h3' },
+            { title: 'H4', value: 'h4' },
+          ],
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+            ],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'Link',
+                fields: [
+                  {
+                    name: 'href',
+                    type: 'url',
+                    title: 'URL',
+                    validation: (Rule) =>
+                      Rule.uri({ allowRelative: true, scheme: ['http', 'https', 'mailto', 'tel'] }),
+                  },
+                ],
+              },
+            ],
+          },
+          lists: [
+            { title: 'Bullet', value: 'bullet' },
+            { title: 'Numbered', value: 'number' },
+          ],
+        },
+        {
+          type: 'image',
+          options: { hotspot: true },
+        },
+      ],
+    }),
+    defineField({
+      name: 'metaDescription',
+      title: 'Meta Description',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.max(160),
+    }),
+    defineField({
+      name: 'effectiveDate',
+      title: 'Effective Date',
+      type: 'date',
+    }),
+    defineField({
+      name: 'lastUpdated',
+      title: 'Last Updated',
+      type: 'datetime',
+    }),
+  ],
+  preview: {
+    select: { title: 'title', subtitle: 'slug.current' },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `pageContent` Sanity document schema with all fields: title, slug, heroStyle (maroon-banner / parallax-image), heroImage with hotspot, Portable Text body (headings, lists, links, bold, italic, inline images), metaDescription, effectiveDate, lastUpdated
- Registers schema in `src/sanity/schemas/index.ts`
- Updates GROQ query (`pageContentBySlugQuery`) to project all fields
- Updates `PageContent` TypeScript interface to match full schema

Implements georgenijo/St-Basils-Boston-Web#50

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Schema visible in Sanity Studio at `/studio`
- [ ] Can create a pageContent document with all fields
- [ ] Slug auto-generates from title
- [ ] heroImage field hides when heroStyle is maroon-banner