### PR TITLE
feat/P2-04-clergy

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -8,3 +8,17 @@ export const pageContentQuery = groq`
     body
   }
 `
+
+export const clergyQuery = groq`
+  *[_type == "clergy" && isActive == true] | order(category asc, order asc) {
+    _id,
+    name,
+    role,
+    photo,
+    photoPosition,
+    yearsOfService,
+    biography,
+    category,
+    order
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -9,3 +9,15 @@ export interface PageContent {
   slug: { current: string }
   body: PortableTextBlock[]
 }
+
+export interface Clergy {
+  _id: string
+  name: string
+  role?: string
+  photo?: SanityImageSource
+  photoPosition?: string
+  yearsOfService?: string
+  biography?: PortableTextBlock[]
+  category: 'current' | 'previous' | 'memoriam'
+  order?: number
+}

--- a/src/sanity/schemas/clergy.ts
+++ b/src/sanity/schemas/clergy.ts
@@ -1,0 +1,105 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'clergy',
+  title: 'Clergy',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'role',
+      title: 'Role',
+      type: 'string',
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'photoPosition',
+      title: 'Photo Position',
+      type: 'string',
+      description: 'CSS object-position override (e.g. "center top")',
+    }),
+    defineField({
+      name: 'yearsOfService',
+      title: 'Years of Service',
+      type: 'string',
+    }),
+    defineField({
+      name: 'biography',
+      title: 'Biography',
+      type: 'array',
+      of: [
+        { type: 'block' },
+        { type: 'image', options: { hotspot: true } },
+      ],
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Current', value: 'current' },
+          { title: 'Previous', value: 'previous' },
+          { title: 'In Memoriam', value: 'memoriam' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'current',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'order',
+      title: 'Order',
+      type: 'number',
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Category, then Order',
+      name: 'categoryOrder',
+      by: [
+        { field: 'category', direction: 'asc' },
+        { field: 'order', direction: 'asc' },
+      ],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'role',
+      category: 'category',
+      media: 'photo',
+    },
+    prepare({ title, subtitle, category, media }) {
+      const categoryLabel =
+        category === 'current'
+          ? 'Current'
+          : category === 'previous'
+            ? 'Previous'
+            : category === 'memoriam'
+              ? 'In Memoriam'
+              : ''
+      return {
+        title,
+        subtitle: [subtitle, categoryLabel].filter(Boolean).join(' — '),
+        media,
+      }
+    },
+  },
+})

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,3 +1,5 @@
 import { SchemaTypeDefinition } from 'sanity'
 
-export const schemaTypes: SchemaTypeDefinition[] = []
+import clergy from './clergy'
+
+export const schemaTypes: SchemaTypeDefinition[] = [clergy]


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#52

## Summary
- Add `clergy` Sanity document schema with name, role, photo (hotspot), photoPosition, yearsOfService, biography (Portable Text), category (current/previous/memoriam), order, and isActive fields
- Register schema in `src/sanity/schemas/index.ts`
- Add `clergyQuery` GROQ query ordered by category then order, filtered by isActive
- Add `Clergy` TypeScript interface in `src/lib/sanity/types.ts`
- Studio preview shows name, role, and category label

## Test plan
- [ ] Verify schema appears in Sanity Studio
- [ ] Create clergy documents in each category and confirm ordering
- [ ] Verify preview displays name — role — category
- [ ] Confirm hotspot cropping works on photo field
- [ ] Run `npm run build` — passes cleanly