### PR TITLE
feat/P2-18-spiritual-leaders

### DIFF
--- a/src/app/(public)/spiritual-leaders/page.tsx
+++ b/src/app/(public)/spiritual-leaders/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next'
+import { PortableText } from 'next-sanity'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { SanityImage } from '@/lib/sanity/image'
+import { allSpiritualLeadersQuery } from '@/lib/sanity/queries'
+import { cn } from '@/lib/utils'
+import { GoldDivider, ScrollReveal } from '@/components/ui'
+
+import type { SpiritualLeader } from '@/lib/sanity/types'
+
+export const metadata: Metadata = {
+  title: 'Our Spiritual Fathers',
+  description:
+    "Meet the spiritual fathers who guide St. Basil's Syriac Orthodox Church in Boston, Massachusetts.",
+  openGraph: {
+    title: "Our Spiritual Fathers | St. Basil's Syriac Orthodox Church",
+    description:
+      "Meet the spiritual fathers who guide St. Basil's Syriac Orthodox Church in Boston, Massachusetts.",
+  },
+}
+
+export const revalidate = 60
+
+export default async function SpiritualLeadersPage() {
+  const leaders = await sanityFetch<SpiritualLeader[]>({
+    query: allSpiritualLeadersQuery,
+    tags: ['spiritualLeader'],
+  })
+
+  return (
+    <>
+      {/* Maroon Hero Banner */}
+      <section className="flex h-[40vh] items-center justify-center bg-burgundy-700 md:h-[60vh]">
+        <h1 className="animate-drop-in px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+          Our Spiritual Fathers
+        </h1>
+      </section>
+
+      {/* Leaders */}
+      {leaders.length > 0 ? (
+        <section className="py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+            <div className="space-y-20 md:space-y-28">
+              {leaders.map((leader, index) => {
+                const imageFirst = index % 2 === 0
+
+                return (
+                  <ScrollReveal key={leader._id} direction="up">
+                    <article
+                      className={cn(
+                        'flex flex-col gap-8 md:flex-row md:items-center md:gap-12 lg:gap-16',
+                        !imageFirst && 'md:flex-row-reverse'
+                      )}
+                    >
+                      {/* Photo */}
+                      <div className="w-full md:w-5/12">
+                        <div className="relative aspect-[3/4] overflow-hidden rounded-2xl shadow-md">
+                          <SanityImage
+                            image={leader.photo}
+                            alt={`Portrait of ${leader.name}`}
+                            fill
+                            sizes="(max-width: 768px) 100vw, 40vw"
+                            lqip={leader.photoLqip}
+                          />
+                        </div>
+                      </div>
+
+                      {/* Text */}
+                      <div className="w-full md:w-7/12">
+                        <h2 className="font-heading text-[1.75rem] font-semibold leading-[1.3] text-wood-900 md:text-[2.25rem]">
+                          {leader.name}
+                        </h2>
+
+                        <p className="mt-2 text-sm font-medium tracking-wide text-burgundy-700 uppercase">
+                          {leader.title}
+                        </p>
+
+                        <GoldDivider className="my-5 mx-0" />
+
+                        {leader.biography && (
+                          <div className="space-y-4 text-base leading-relaxed text-wood-800">
+                            <PortableText value={leader.biography} />
+                          </div>
+                        )}
+                      </div>
+                    </article>
+                  </ScrollReveal>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+      ) : (
+        <section className="py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 text-center sm:px-6 lg:px-8">
+            <p className="text-lg text-wood-800/60">
+              Spiritual leader information is being updated. Please check back soon.
+            </p>
+          </div>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -13,3 +13,15 @@ export const pageContentBySlugQuery = groq`
     lastUpdated
   }
 `
+
+export const allSpiritualLeadersQuery = groq`
+  *[_type == "spiritualLeader"] | order(order asc) {
+    _id,
+    name,
+    title,
+    photo,
+    "photoLqip": photo.asset->metadata.lqip,
+    biography,
+    order
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -14,3 +14,13 @@ export interface PageContent {
   effectiveDate?: string
   lastUpdated?: string
 }
+
+export interface SpiritualLeader {
+  _id: string
+  name: string
+  title: string
+  photo: SanityImageSource
+  photoLqip?: string
+  biography: PortableTextBlock[]
+  order: number
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import { SchemaTypeDefinition } from 'sanity'
 
 import pageContent from './pageContent'
+import spiritualLeader from './spiritualLeader'
 
-export const schemaTypes: SchemaTypeDefinition[] = [pageContent]
+export const schemaTypes: SchemaTypeDefinition[] = [pageContent, spiritualLeader]

--- a/src/sanity/schemas/spiritualLeader.ts
+++ b/src/sanity/schemas/spiritualLeader.ts
@@ -1,0 +1,79 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'spiritualLeader',
+  title: 'Spiritual Leader',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'title',
+      title: 'Title / Role',
+      type: 'string',
+      description: 'Ecclesiastical title (e.g., "Patriarch of Antioch and All the East")',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'biography',
+      title: 'Biography',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: 'Normal', value: 'normal' }],
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+            ],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'Link',
+                fields: [
+                  {
+                    name: 'href',
+                    type: 'url',
+                    title: 'URL',
+                    validation: (Rule) =>
+                      Rule.uri({ allowRelative: true, scheme: ['http', 'https', 'mailto', 'tel'] }),
+                  },
+                ],
+              },
+            ],
+          },
+          lists: [],
+        },
+      ],
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: { title: 'name', subtitle: 'title', media: 'photo' },
+  },
+})


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#66

## Summary
- Add `spiritualLeader` Sanity schema with name, title, photo, biography, and display order fields
- Add GROQ query and `SpiritualLeader` TypeScript type
- Build `/spiritual-leaders` page with maroon hero banner, alternating image-left/image-right layout, fade-up scroll animations, responsive images, and graceful empty state

## Test plan
- [ ] Verify TypeScript compiles with `npm run build`
- [ ] Seed spiritual leaders in Sanity Studio and confirm they render in order
- [ ] Check alternating layout (image left, right, left) at desktop widths
- [ ] Verify responsive behavior at 375px, 768px, 1024px, 1280px
- [ ] Confirm scroll animations fire and `prefers-reduced-motion` is respected
- [ ] Test empty state when no leaders exist in Sanity