### PR TITLE
feat/P2-23-acolytes-choir

### DIFF
--- a/src/app/(public)/acolytes-choir/page.tsx
+++ b/src/app/(public)/acolytes-choir/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from 'next'
+import { PortableText } from 'next-sanity'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor, SanityImage } from '@/lib/sanity/image'
+import { acolytesChoirPageQuery } from '@/lib/sanity/queries'
+import { PageHero, ScrollReveal } from '@/components/ui'
+
+import type { AcolytesChoirPage } from '@/lib/sanity/types'
+import type { PortableTextComponents } from 'next-sanity'
+
+export const revalidate = 60
+
+const portableTextComponents: PortableTextComponents = {
+  marks: {
+    strong: ({ children }) => (
+      <strong className="font-semibold text-burgundy-700">{children}</strong>
+    ),
+    em: ({ children }) => <em>{children}</em>,
+    link: ({ value, children }) => (
+      <a
+        href={value?.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-burgundy-700 underline underline-offset-4 hover:text-burgundy-800"
+      >
+        {children}
+      </a>
+    ),
+  },
+  block: {
+    normal: ({ children }) => (
+      <p className="text-base leading-relaxed text-wood-800">{children}</p>
+    ),
+  },
+}
+
+async function getData() {
+  return sanityFetch<AcolytesChoirPage | null>({
+    query: acolytesChoirPageQuery,
+    tags: ['acolytesChoirPage'],
+  })
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const data = await getData()
+
+  return {
+    title: 'Our Acolytes & Choir',
+    description:
+      data?.metaDescription ??
+      "Meet the acolytes and choir of St. Basil's Syriac Orthodox Church in Boston.",
+    openGraph: {
+      title: "Our Acolytes & Choir | St. Basil's Syriac Orthodox Church",
+      description:
+        data?.metaDescription ??
+        "Meet the acolytes and choir of St. Basil's Syriac Orthodox Church in Boston.",
+      ...(data?.heroImage && {
+        images: [urlFor(data.heroImage).width(1200).height(630).url()],
+      }),
+    },
+  }
+}
+
+export default async function AcolytesChoirPage() {
+  const data = await getData()
+
+  const heroImageUrl = data?.heroImage
+    ? urlFor(data.heroImage).width(1920).quality(80).url()
+    : '/images/about/church-exterior.jpg'
+
+  return (
+    <>
+      {/* Parallax Hero */}
+      <PageHero title="Our Acolytes & Choir" backgroundImage={heroImageUrl} />
+
+      {/* Description */}
+      {data?.body && (
+        <section className="py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+            <ScrollReveal>
+              <div className="mx-auto max-w-3xl space-y-6">
+                <PortableText value={data.body} components={portableTextComponents} />
+              </div>
+            </ScrollReveal>
+          </div>
+        </section>
+      )}
+
+      {/* Group Photo */}
+      {data?.groupPhoto && (
+        <section className="pb-16 md:pb-22 lg:pb-28">
+          <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+            <ScrollReveal>
+              <div className="mx-auto max-w-3xl">
+                <div className="relative aspect-[3/2] overflow-hidden rounded-2xl shadow-lg">
+                  <SanityImage
+                    image={data.groupPhoto}
+                    alt={data.groupPhotoAlt ?? 'Acolytes and choir group photo'}
+                    fill
+                    sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 768px"
+                  />
+                </div>
+              </div>
+            </ScrollReveal>
+          </div>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -13,3 +13,14 @@ export const pageContentBySlugQuery = groq`
     lastUpdated
   }
 `
+
+export const acolytesChoirPageQuery = groq`
+  *[_type == "acolytesChoirPage"][0] {
+    _id,
+    heroImage,
+    body,
+    groupPhoto,
+    groupPhotoAlt,
+    metaDescription
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -14,3 +14,12 @@ export interface PageContent {
   effectiveDate?: string
   lastUpdated?: string
 }
+
+export interface AcolytesChoirPage {
+  _id: string
+  heroImage: SanityImageSource
+  body: PortableTextBlock[]
+  groupPhoto?: SanityImageSource
+  groupPhotoAlt?: string
+  metaDescription?: string
+}

--- a/src/sanity/schemas/acolytesChoirPage.ts
+++ b/src/sanity/schemas/acolytesChoirPage.ts
@@ -1,0 +1,73 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'acolytesChoirPage',
+  title: 'Acolytes & Choir Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'body',
+      title: 'Description',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: 'Normal', value: 'normal' }],
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+            ],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'Link',
+                fields: [
+                  {
+                    name: 'href',
+                    type: 'url',
+                    title: 'URL',
+                    validation: (Rule) =>
+                      Rule.uri({ allowRelative: true, scheme: ['http', 'https', 'mailto', 'tel'] }),
+                  },
+                ],
+              },
+            ],
+          },
+          lists: [],
+        },
+      ],
+    }),
+    defineField({
+      name: 'groupPhoto',
+      title: 'Group Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'groupPhotoAlt',
+      title: 'Group Photo Alt Text',
+      type: 'string',
+    }),
+    defineField({
+      name: 'metaDescription',
+      title: 'Meta Description',
+      type: 'text',
+      rows: 3,
+      validation: (Rule) => Rule.max(160),
+    }),
+  ],
+  preview: {
+    prepare() {
+      return { title: 'Acolytes & Choir Page' }
+    },
+  },
+})

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import { SchemaTypeDefinition } from 'sanity'
 
+import acolytesChoirPage from './acolytesChoirPage'
 import pageContent from './pageContent'
 
-export const schemaTypes: SchemaTypeDefinition[] = [pageContent]
+export const schemaTypes: SchemaTypeDefinition[] = [acolytesChoirPage, pageContent]


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#71

## Summary
- Add `acolytesChoirPage` Sanity singleton schema with hero image, PortableText body, group photo, and meta description fields
- Add GROQ query and TypeScript interface for the new schema
- Build `/acolytes-choir` page that fetches content from Sanity, renders a parallax hero, description with inline burgundy bold marks via PortableText, and a centered group photo with shadow
- Register schema in Sanity schema index

## Test plan
- [ ] Seed acolytes/choir content in Sanity Studio (P2-15)
- [ ] Verify parallax hero renders with Sanity image
- [ ] Verify PortableText bold marks render in burgundy
- [ ] Verify group photo centered with rounded corners and shadow
- [ ] Check responsive layout at 375px, 768px, 1024px, 1280px
- [ ] Verify ISR revalidation (60s)