### PR TITLE
feat/P2-20-office-bearers

### DIFF
--- a/src/app/(public)/office-bearers/page.tsx
+++ b/src/app/(public)/office-bearers/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { officeBearersQuery } from '@/lib/sanity/queries'
+import { SectionHeader, ScrollReveal } from '@/components/ui'
+import { OfficeBearerCard } from '@/components/features/OfficeBearerCard'
+
+import type { OfficeBearer } from '@/lib/sanity/types'
+
+export const metadata: Metadata = {
+  title: 'Office Bearers',
+  description:
+    "Meet the office bearers of St. Basil's Syriac Orthodox Church in Boston. Our executive committee and board members serve the parish with dedication and faith.",
+  openGraph: {
+    title: "Office Bearers | St. Basil's Syriac Orthodox Church",
+    description:
+      "Meet the office bearers of St. Basil's Syriac Orthodox Church in Boston.",
+  },
+}
+
+export const revalidate = 60
+
+export default async function OfficeBearersPage() {
+  const bearers = await sanityFetch<OfficeBearer[]>({
+    query: officeBearersQuery,
+    tags: ['officeBearer'],
+  })
+
+  const currentYear = new Date().getFullYear()
+  const executive = bearers.filter((b) => b.category === 'executive')
+  const board = bearers.filter((b) => b.category === 'board')
+
+  return (
+    <main>
+      {/* Hero — maroon banner with dynamic year */}
+      <section className="flex h-[40vh] items-center justify-center bg-burgundy-700 md:h-[60vh]">
+        <div className="px-4 text-center">
+          <h1 className="animate-drop-in font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            Our Office Bearers
+          </h1>
+          <p className="mt-4 animate-drop-in font-body text-lg text-cream-50/80 [animation-delay:0.15s]">
+            {currentYear}
+          </p>
+        </div>
+      </section>
+
+      {/* Executive Committee */}
+      {executive.length > 0 && (
+        <section className="py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+            <ScrollReveal>
+              <SectionHeader
+                title="Executive Committee"
+                subtitle="The executive committee guides the parish's administrative affairs and spiritual mission."
+              />
+            </ScrollReveal>
+
+            <div className="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+              {executive.map((bearer, i) => (
+                <ScrollReveal key={bearer._id} delay={i * 0.12}>
+                  <OfficeBearerCard
+                    name={bearer.name}
+                    role={bearer.role}
+                    photoUrl={bearer.photo ? urlFor(bearer.photo).width(400).height(480).auto('format').url() : undefined}
+                    variant="executive"
+                  />
+                </ScrollReveal>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Board Members */}
+      {board.length > 0 && (
+        <section className="bg-sand py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+            <ScrollReveal>
+              <SectionHeader
+                title="Board Members"
+                subtitle="Our board members dedicate their time and talents to serving the parish community."
+              />
+            </ScrollReveal>
+
+            <div className="mt-12 grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+              {board.map((bearer, i) => (
+                <ScrollReveal key={bearer._id} delay={i * 0.08}>
+                  <OfficeBearerCard
+                    name={bearer.name}
+                    role={bearer.role}
+                    photoUrl={bearer.photo ? urlFor(bearer.photo).width(300).height(360).auto('format').url() : undefined}
+                    variant="board"
+                  />
+                </ScrollReveal>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Empty state */}
+      {bearers.length === 0 && (
+        <section className="py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
+            <p className="font-body text-base text-wood-800/60">
+              Office bearer information will be available soon.
+            </p>
+          </div>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,8 @@
 @import 'tailwindcss';
 
+/* Hover effects only on devices with pointer hover (not touch) */
+@custom-variant can-hover (@media (hover: hover));
+
 @theme {
   /* Colors — Primary palette */
   --color-cream-50: #fffdf8;

--- a/src/components/features/OfficeBearerCard.tsx
+++ b/src/components/features/OfficeBearerCard.tsx
@@ -1,0 +1,82 @@
+import Image from 'next/image'
+
+import { cn } from '@/lib/utils'
+
+export interface OfficeBearerCardProps {
+  name: string
+  role: string
+  photoUrl?: string
+  variant: 'executive' | 'board'
+}
+
+export function OfficeBearerCard({ name, role, photoUrl, variant }: OfficeBearerCardProps) {
+  const isExecutive = variant === 'executive'
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-2xl bg-cream-50 shadow-sm',
+        'transition-[transform,box-shadow] duration-300',
+        'can-hover:hover:-translate-y-1 can-hover:hover:shadow-lg',
+      )}
+    >
+      {/* Photo */}
+      <div
+        className={cn(
+          'relative w-full overflow-hidden bg-sand',
+          isExecutive ? 'aspect-[5/6]' : 'aspect-square',
+        )}
+      >
+        {photoUrl ? (
+          <Image
+            src={photoUrl}
+            alt={`${name}, ${role}`}
+            fill
+            className="object-cover"
+            sizes={
+              isExecutive
+                ? '(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw'
+                : '(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw'
+            }
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className={cn('text-wood-800/20', isExecutive ? 'h-16 w-16' : 'h-12 w-12')}
+              aria-hidden="true"
+            >
+              <path
+                fillRule="evenodd"
+                d="M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className={cn('p-5 text-center', isExecutive && 'p-6')}>
+        <h3
+          className={cn(
+            'font-heading font-semibold text-wood-900',
+            isExecutive ? 'text-xl' : 'text-lg',
+          )}
+        >
+          {name}
+        </h3>
+        <p
+          className={cn(
+            'mt-1 font-body text-wood-800/60',
+            isExecutive ? 'text-base' : 'text-sm',
+          )}
+        >
+          {role}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -13,3 +13,14 @@ export const pageContentBySlugQuery = groq`
     lastUpdated
   }
 `
+
+export const officeBearersQuery = groq`
+  *[_type == "officeBearer"] | order(order asc) {
+    _id,
+    name,
+    role,
+    category,
+    photo,
+    order
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -14,3 +14,12 @@ export interface PageContent {
   effectiveDate?: string
   lastUpdated?: string
 }
+
+export interface OfficeBearer {
+  _id: string
+  name: string
+  role: string
+  category: 'executive' | 'board'
+  photo?: SanityImageSource
+  order: number
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import { SchemaTypeDefinition } from 'sanity'
 
+import officeBearer from './officeBearer'
 import pageContent from './pageContent'
 
-export const schemaTypes: SchemaTypeDefinition[] = [pageContent]
+export const schemaTypes: SchemaTypeDefinition[] = [officeBearer, pageContent]

--- a/src/sanity/schemas/officeBearer.ts
+++ b/src/sanity/schemas/officeBearer.ts
@@ -1,0 +1,60 @@
+import { defineField, defineType } from 'sanity'
+
+export default defineType({
+  name: 'officeBearer',
+  title: 'Office Bearer',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'role',
+      title: 'Role / Position',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Executive Committee', value: 'executive' },
+          { title: 'Board Member', value: 'board' },
+        ],
+        layout: 'radio',
+      },
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+      validation: (rule) => rule.required().min(0),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'role',
+      media: 'photo',
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Adds `/office-bearers` page with maroon hero banner displaying the current year dynamically
- Creates `officeBearer` Sanity schema (P2-05 dependency was missing, included here)
- Executive Committee section with larger portrait cards (5:6 aspect) in a 3-column grid
- Board Members section with compact square cards in a 4-column grid
- Hover lift effect gated behind `@media (hover: hover)` via custom `can-hover` Tailwind variant — no hover effects on touch devices
- Graceful empty state when no bearers are in Sanity yet
- `OfficeBearerCard` component with placeholder avatar fallback for missing photos

Implements georgenijo/St-Basils-Boston-Web#68

## Test plan
- [ ] Seed office bearers in Sanity Studio (P2-12) and verify cards render with photos
- [ ] Verify hero displays current year
- [ ] Verify executive cards are larger than board cards
- [ ] Test hover lift on desktop (mouse) — cards should lift with shadow
- [ ] Test on touch device (iOS/Android) — no hover lift on tap
- [ ] Responsive: 375px (1 col), 768px (2-3 col), 1280px (3-4 col)
- [ ] Empty state renders when no bearers exist