### PR TITLE
feat/P2-16-privacy-policy

### DIFF
--- a/src/app/(public)/privacy-policy/page.tsx
+++ b/src/app/(public)/privacy-policy/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { LegalPageLayout } from '@/components/features/LegalPageLayout'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+export const revalidate = 60
+
+async function getPage() {
+  return sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: 'privacy-policy' },
+    tags: ['pageContent'],
+  })
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const page = await getPage()
+
+  return {
+    title: page?.title ?? 'Privacy Policy',
+    description:
+      page?.metaDescription ??
+      "Privacy Policy for St. Basil's Syriac Orthodox Church website.",
+  }
+}
+
+export default async function PrivacyPolicyPage() {
+  const page = await getPage()
+
+  if (!page) {
+    notFound()
+  }
+
+  return <LegalPageLayout page={page} />
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,7 @@
   /* Font families */
   --font-heading: var(--font-cormorant-garamond), 'Georgia', serif;
   --font-body: var(--font-dm-sans), 'Helvetica Neue', sans-serif;
+  --font-legal: var(--font-poppins), 'Helvetica Neue', sans-serif;
 
   /* Custom border radius */
   --radius-arch: 50% 50% 0 0;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Cormorant_Garamond, DM_Sans } from 'next/font/google'
+import { Cormorant_Garamond, DM_Sans, Poppins } from 'next/font/google'
 
 import { cn } from '@/lib/utils'
 import { JsonLd } from '@/components/ui'
@@ -55,6 +55,13 @@ const dmSans = DM_Sans({
   display: 'swap',
 })
 
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['400', '500', '600'],
+  variable: '--font-poppins',
+  display: 'swap',
+})
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://stbasilsboston.org'),
   title: {
@@ -93,7 +100,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className={cn(cormorantGaramond.variable, dmSans.variable)}>
+    <html lang="en" className={cn(cormorantGaramond.variable, dmSans.variable, poppins.variable)}>
       <body>
         <JsonLd data={churchJsonLd} />
         {children}

--- a/src/components/features/LegalPageLayout.tsx
+++ b/src/components/features/LegalPageLayout.tsx
@@ -1,0 +1,105 @@
+import { PortableText } from 'next-sanity'
+import type { PortableTextReactComponents } from '@portabletext/react'
+
+import { urlFor } from '@/lib/sanity/image'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const legalComponents: Partial<PortableTextReactComponents> = {
+  block: {
+    normal: ({ children }) => (
+      <p className="mb-6 text-[17px] leading-[1.8]">{children}</p>
+    ),
+    h2: ({ children }) => (
+      <h2 className="mb-4 mt-10 font-heading text-[1.75rem] font-semibold leading-[1.3] text-wood-900 md:text-[2.25rem]">
+        {children}
+      </h2>
+    ),
+    h3: ({ children }) => (
+      <h3 className="mb-3 mt-8 font-heading text-[1.25rem] font-semibold leading-[1.4] text-wood-900 md:text-[1.5rem]">
+        {children}
+      </h3>
+    ),
+    h4: ({ children }) => (
+      <h4 className="mb-2 mt-6 font-heading text-lg font-semibold leading-[1.4] text-wood-900">
+        {children}
+      </h4>
+    ),
+  },
+  list: {
+    bullet: ({ children }) => (
+      <ul className="mb-6 list-disc space-y-2 pl-6 text-[17px] leading-[1.8]">
+        {children}
+      </ul>
+    ),
+    number: ({ children }) => (
+      <ol className="mb-6 list-decimal space-y-2 pl-6 text-[17px] leading-[1.8]">
+        {children}
+      </ol>
+    ),
+  },
+  listItem: {
+    bullet: ({ children }) => <li>{children}</li>,
+    number: ({ children }) => <li>{children}</li>,
+  },
+  marks: {
+    strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+    em: ({ children }) => <em>{children}</em>,
+    link: ({ value, children }) => {
+      const href = value?.href || ''
+      const isExternal = href.startsWith('http')
+      return (
+        <a
+          href={href}
+          className="font-medium text-burgundy-700 underline underline-offset-4 hover:text-burgundy-800"
+          {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+        >
+          {children}
+        </a>
+      )
+    },
+  },
+}
+
+export interface LegalPageLayoutProps {
+  page: PageContent
+}
+
+export function LegalPageLayout({ page }: LegalPageLayoutProps) {
+  const formattedDate = page.effectiveDate
+    ? new Date(page.effectiveDate + 'T00:00:00').toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero title={page.title} backgroundImage={urlFor(page.heroImage).url()} />
+      ) : (
+        <section className="flex items-center justify-center bg-burgundy-700 py-16 md:py-22">
+          <h1 className="animate-drop-in px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+
+      <section className="py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          {formattedDate && (
+            <p className="mb-8 text-sm text-wood-800/60">
+              Effective Date: {formattedDate}
+            </p>
+          )}
+
+          <div className="font-legal text-justify text-wood-800">
+            <PortableText value={page.body} components={legalComponents} />
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds `/privacy-policy` page that fetches `pageContent` from Sanity by slug
- Creates reusable `LegalPageLayout` component with maroon hero banner and styled Portable Text serializers (headings, lists, links, bold, italic)
- Adds Poppins font for legal page body text (justified, 17px, 1.8 line-height)
- ISR with 60-second revalidation

Implements georgenijo/St-Basils-Boston-Web#64

## Test plan
- [ ] Seed privacy-policy content in Sanity (depends on P2-09)
- [ ] Verify maroon hero banner renders with page title and drop-in animation
- [ ] Verify Portable Text renders all block types: h2, h3, h4, paragraphs, bullet/numbered lists, links, bold, italic
- [ ] Verify Poppins font, justified text alignment, and correct line-height
- [ ] Verify effective date displays when set in Sanity
- [ ] Verify responsive layout at 375px, 768px, 1024px, 1280px
- [ ] Verify `notFound()` renders when slug has no matching content
- [ ] Verify LegalPageLayout works with parallax-image heroStyle (for future pages)