### PR TITLE
feat/P2-25-og-tags

### DIFF
--- a/src/app/(public)/acolytes-choir/page.tsx
+++ b/src/app/(public)/acolytes-choir/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'acolytes-choir'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Our Acolytes & Choir',
+    fallbackDescription:
+      "Meet the acolytes and choir of St. Basil's Syriac Orthodox Church in Boston.",
+  })
+}
+
+export default async function AcolytesChoirPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/office-bearers/page.tsx
+++ b/src/app/(public)/office-bearers/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'office-bearers'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Our Office Bearers',
+    fallbackDescription:
+      "Meet the office bearers who serve St. Basil's Syriac Orthodox Church in Boston.",
+  })
+}
+
+export default async function OfficeBearersPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/our-clergy/page.tsx
+++ b/src/app/(public)/our-clergy/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'our-clergy'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Our Clergy',
+    fallbackDescription:
+      "Meet the clergy of St. Basil's Syriac Orthodox Church in Boston, Massachusetts.",
+  })
+}
+
+export default async function OurClergyPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/our-organizations/page.tsx
+++ b/src/app/(public)/our-organizations/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'our-organizations'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Our Organizations',
+    fallbackDescription:
+      "Discover the organizations and ministries at St. Basil's Syriac Orthodox Church in Boston.",
+  })
+}
+
+export default async function OurOrganizationsPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/privacy-policy/page.tsx
+++ b/src/app/(public)/privacy-policy/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'privacy-policy'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Privacy Policy',
+    fallbackDescription:
+      "Privacy policy for St. Basil's Syriac Orthodox Church website.",
+  })
+}
+
+export default async function PrivacyPolicyPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/spiritual-leaders/page.tsx
+++ b/src/app/(public)/spiritual-leaders/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'spiritual-leaders'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Our Spiritual Fathers',
+    fallbackDescription:
+      "Meet the spiritual fathers and leaders of St. Basil's Syriac Orthodox Church in Boston.",
+  })
+}
+
+export default async function SpiritualLeadersPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/terms-of-use/page.tsx
+++ b/src/app/(public)/terms-of-use/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'terms-of-use'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Terms of Use',
+    fallbackDescription:
+      "Terms of use for St. Basil's Syriac Orthodox Church website.",
+  })
+}
+
+export default async function TermsOfUsePage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/app/(public)/useful-links/page.tsx
+++ b/src/app/(public)/useful-links/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { generatePageContentMetadata } from '@/lib/sanity/metadata'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { PageHero } from '@/components/ui'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SLUG = 'useful-links'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return generatePageContentMetadata({
+    slug: SLUG,
+    fallbackTitle: 'Useful Links',
+    fallbackDescription:
+      "Helpful links and resources from St. Basil's Syriac Orthodox Church in Boston.",
+  })
+}
+
+export default async function UsefulLinksPage() {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: SLUG },
+    tags: [`pageContent:${SLUG}`],
+  })
+
+  if (!page) notFound()
+
+  return (
+    <>
+      {page.heroStyle === 'parallax-image' && page.heroImage ? (
+        <PageHero
+          title={page.title}
+          backgroundImage={urlFor(page.heroImage).auto('format').url()}
+        />
+      ) : (
+        <section className="bg-burgundy-700 py-16 md:py-22">
+          <h1 className="text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+            {page.title}
+          </h1>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/lib/sanity/metadata.ts
+++ b/src/lib/sanity/metadata.ts
@@ -1,0 +1,62 @@
+import type { Metadata } from 'next'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+const SITE_NAME = "St. Basil's Syriac Orthodox Church"
+
+interface PageContentMetadataConfig {
+  slug: string
+  fallbackTitle: string
+  fallbackDescription: string
+}
+
+export async function generatePageContentMetadata({
+  slug,
+  fallbackTitle,
+  fallbackDescription,
+}: PageContentMetadataConfig): Promise<Metadata> {
+  const page = await sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug },
+    tags: [`pageContent:${slug}`],
+  })
+
+  const title = page?.title ?? fallbackTitle
+  const description = page?.metaDescription ?? fallbackDescription
+
+  const metadata: Metadata = {
+    title,
+    description,
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+  }
+
+  if (page?.heroImage) {
+    const ogImageUrl = urlFor(page.heroImage)
+      .width(1200)
+      .height(630)
+      .fit('crop')
+      .auto('format')
+      .url()
+
+    metadata.openGraph = {
+      ...metadata.openGraph,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+    }
+  }
+
+  return metadata
+}


### PR DESCRIPTION
## Summary
- Add `generateMetadata()` to all 8 Sanity-powered pages (privacy-policy, terms-of-use, spiritual-leaders, our-clergy, office-bearers, our-organizations, useful-links, acolytes-choir)
- Create shared `generatePageContentMetadata()` helper in `src/lib/sanity/metadata.ts` that fetches title, description, and hero image from Sanity `pageContent` documents
- OG images cropped to 1200x630 via Sanity image URL builder with `fit('crop')` and `auto('format')`
- Fallback values for all metadata fields when Sanity data is missing

Implements georgenijo/St-Basils-Boston-Web#73

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (TypeScript compiles cleanly)
- [ ] With Sanity env vars configured, verify each page renders proper `<meta>` tags
- [ ] Verify OG image URLs use `w=1200&h=630&fit=crop` params
- [ ] Verify fallback titles/descriptions render when Sanity data is empty
- [ ] Verify pages return 404 when no matching `pageContent` document exists