### PR TITLE
feat/P3-02-auth-trigger

### DIFF
--- a/supabase/migrations/20260308000001_create_auth_trigger.sql
+++ b/supabase/migrations/20260308000001_create_auth_trigger.sql
@@ -1,0 +1,38 @@
+-- Migration: Create auth trigger for automatic profile creation
+-- Phase: 3
+-- Ticket: P3-02
+
+-- Function: handle_new_user()
+-- Automatically creates a profile row when a new user signs up via Supabase Auth.
+-- Uses SECURITY DEFINER to bypass RLS (auth.users is not accessible to normal roles).
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (
+    id,
+    email,
+    full_name,
+    role,
+    created_at,
+    updated_at
+  ) VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(
+      NEW.raw_user_meta_data ->> 'full_name',
+      NEW.raw_user_meta_data ->> 'name',
+      ''
+    ),
+    'member',
+    now(),
+    now()
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+
+-- Trigger: on_auth_user_created
+-- Fires after a new row is inserted into auth.users (i.e., after signup).
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();


### PR DESCRIPTION
## Summary

- Adds `handle_new_user()` PostgreSQL function with `SECURITY DEFINER` that creates a profile row when a user signs up
- Adds `on_auth_user_created` trigger on `auth.users` INSERT
- New profiles default to `role='member'`, with email and name populated from auth metadata (`full_name` or `name`)
- Migration file: `supabase/migrations/20260308000001_create_auth_trigger.sql`

## Dependencies

- **P3-01** (profiles table + RLS) must be applied first — this migration references `public.profiles`

## Test plan

- [ ] Apply P3-01 profiles migration first
- [ ] Apply this migration against a Supabase instance
- [ ] Sign up a new user via Supabase Auth
- [ ] Verify a row appears in `public.profiles` with `role='member'`, correct email, and name from metadata
- [ ] Verify signing up without metadata still creates profile with empty `full_name`

Implements georgenijo/St-Basils-Boston-Web#75