### PR TITLE
feat: auth middleware for /admin routes (#77)

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -32,7 +32,17 @@ export async function updateSession(request: NextRequest) {
   // randomly logged out.
 
   // IMPORTANT: DO NOT REMOVE auth.getUser()
-  await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  // Protect /admin routes — redirect unauthenticated users to login
+  if (request.nextUrl.pathname.startsWith('/admin') && !user) {
+    const loginUrl = request.nextUrl.clone()
+    loginUrl.pathname = '/login'
+    loginUrl.searchParams.set('redirectTo', request.nextUrl.pathname)
+    return NextResponse.redirect(loginUrl)
+  }
 
   return supabaseResponse
 }


### PR DESCRIPTION
## Summary

- Adds auth guard to `/admin/*` routes in the Supabase middleware
- Uses `getUser()` (server-validated, not `getSession()`) to check authentication
- Redirects unauthenticated users to `/login?redirectTo={path}` preserving their intended destination
- Expired tokens are auto-refreshed by the existing `@supabase/ssr` cookie exchange (already in place)

Implements georgenijo/St-Basils-Boston-Web#77

## Test plan

- [ ] Visit `/admin/dashboard` while logged out → redirected to `/login?redirectTo=/admin/dashboard`
- [ ] Visit `/admin/dashboard` while logged in → page renders normally
- [ ] Visit public pages while logged out → no redirect, pages load normally
- [ ] Let session expire, then visit `/admin/dashboard` → token refreshes automatically, page loads