### PR TITLE
feat/P3-07-logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "react-dom": "^19.1.0",
         "sanity": "^4.22.0",
         "styled-components": "^6.3.12",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.4",
@@ -5381,6 +5382,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@sanity/codegen/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@sanity/color": {
@@ -19646,9 +19656,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-dom": "^19.1.0",
     "sanity": "^4.22.0",
     "styled-components": "^6.3.12",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.4",

--- a/src/actions/login.ts
+++ b/src/actions/login.ts
@@ -1,0 +1,55 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { z } from 'zod'
+
+import { createClient } from '@/lib/supabase/server'
+
+const loginSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(1, 'Password is required'),
+})
+
+type LoginState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+function isValidRedirectTo(url: string): boolean {
+  if (!url.startsWith('/') || url.startsWith('//')) return false
+  if (url.includes('\\')) return false
+  return true
+}
+
+export async function login(
+  prevState: LoginState,
+  formData: FormData
+): Promise<LoginState> {
+  const parsed = loginSchema.safeParse({
+    email: formData.get('email'),
+    password: formData.get('password'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors,
+    }
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase.auth.signInWithPassword(parsed.data)
+
+  if (error) {
+    return { success: false, message: 'Invalid email or password' }
+  }
+
+  const redirectTo = formData.get('redirectTo') as string | null
+  if (redirectTo && isValidRedirectTo(redirectTo)) {
+    redirect(redirectTo)
+  }
+
+  redirect('/admin/dashboard')
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,3 +1,5 @@
+import { LogoutButton } from '@/components/features/LogoutButton'
+
 export default function AdminLayout({
   children,
 }: Readonly<{
@@ -5,7 +7,12 @@ export default function AdminLayout({
 }>) {
   return (
     <div className="flex min-h-screen">
-      {/* AdminSidebar will be added here */}
+      <aside className="flex w-64 flex-col bg-charcoal p-6">
+        <div className="flex-1">
+          {/* AdminSidebar nav will be added here */}
+        </div>
+        <LogoutButton />
+      </aside>
       <div className="flex-1">{children}</div>
     </div>
   )

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,14 +1,39 @@
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/lib/supabase/server'
+import { LoginForm } from '@/components/features/LoginForm'
+
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Login',
 }
 
-export default function LoginPage() {
+interface LoginPageProps {
+  searchParams: Promise<{ redirectTo?: string }>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (user) {
+    redirect('/admin/dashboard')
+  }
+
+  const { redirectTo } = await searchParams
+
   return (
     <main className="w-full max-w-md px-4 font-body text-wood-800">
-      <h1 className="font-heading text-3xl font-semibold text-wood-900">Auth Group</h1>
-      <p className="mt-4">Login placeholder — (auth) route group.</p>
+      <h1 className="font-heading text-3xl font-semibold text-wood-900">
+        Sign In
+      </h1>
+      <p className="mt-2 text-wood-800/60">
+        Sign in to the admin dashboard.
+      </p>
+      <LoginForm redirectTo={redirectTo} />
     </main>
   )
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(request: Request) {
+  const supabase = await createClient()
+  await supabase.auth.signOut()
+
+  const url = new URL('/', request.url)
+  return NextResponse.redirect(url)
+}

--- a/src/components/features/LoginForm.tsx
+++ b/src/components/features/LoginForm.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useActionState } from 'react'
+
+import { login } from '@/actions/login'
+
+interface LoginFormProps {
+  redirectTo?: string
+}
+
+export function LoginForm({ redirectTo }: LoginFormProps) {
+  const [state, formAction, pending] = useActionState(login, {
+    success: false,
+    message: '',
+  })
+
+  return (
+    <form action={formAction} className="mt-8 space-y-5">
+      {redirectTo && (
+        <input type="hidden" name="redirectTo" value={redirectTo} />
+      )}
+
+      <div>
+        <label
+          htmlFor="email"
+          className="block text-sm font-medium text-wood-800"
+        >
+          Email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          className="mt-1 block w-full rounded-lg border border-wood-800/20 bg-cream-50 px-4 py-2.5 text-wood-800 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-1 focus:ring-burgundy-700"
+        />
+        {state.errors?.email && (
+          <p className="mt-1 text-sm text-red-600">{state.errors.email[0]}</p>
+        )}
+      </div>
+
+      <div>
+        <label
+          htmlFor="password"
+          className="block text-sm font-medium text-wood-800"
+        >
+          Password
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          required
+          className="mt-1 block w-full rounded-lg border border-wood-800/20 bg-cream-50 px-4 py-2.5 text-wood-800 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-1 focus:ring-burgundy-700"
+        />
+        {state.errors?.password && (
+          <p className="mt-1 text-sm text-red-600">
+            {state.errors.password[0]}
+          </p>
+        )}
+      </div>
+
+      {state.message && !state.success && (
+        <p role="alert" className="text-sm text-red-600">
+          {state.message}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={pending}
+        className="w-full rounded-lg bg-burgundy-700 px-6 py-3 font-medium text-cream-50 transition-colors hover:bg-burgundy-800 disabled:opacity-50"
+      >
+        {pending ? 'Signing in...' : 'Sign In'}
+      </button>
+    </form>
+  )
+}

--- a/src/components/features/LogoutButton.tsx
+++ b/src/components/features/LogoutButton.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+interface LogoutButtonProps {
+  className?: string
+}
+
+export function LogoutButton({ className }: LogoutButtonProps) {
+  return (
+    <form action="/api/auth/logout" method="post">
+      <button
+        type="submit"
+        className={
+          className ??
+          'text-sm text-cream-50/70 transition-colors hover:text-cream-50'
+        }
+      >
+        Sign Out
+      </button>
+    </form>
+  )
+}


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#80

## Summary
- **Logout route** (`POST /api/auth/logout`): Signs out via Supabase and redirects to homepage
- **Login server action** (`actions/login.ts`): Zod-validated email/password login with `redirectTo` param support
- **Open redirect prevention**: `redirectTo` validated to only allow internal paths (must start with `/`, rejects `//` and `\`)
- **Auth guard on /login**: Already-authenticated users are redirected to `/admin/dashboard`
- **Logout button**: Wired into admin sidebar layout via `LogoutButton` client component
- **zod** added as dependency for form validation

## Test plan
- [ ] Visit `/login` while unauthenticated — see login form
- [ ] Visit `/login` while authenticated — redirected to `/admin/dashboard`
- [ ] Login with valid credentials — redirected to dashboard
- [ ] Login with `?redirectTo=/admin/events` — redirected to `/admin/events` after login
- [ ] Login with `?redirectTo=https://evil.com` — ignored, redirected to dashboard
- [ ] Login with `?redirectTo=//evil.com` — ignored, redirected to dashboard
- [ ] Click "Sign Out" in admin sidebar — signed out and redirected to `/`
- [ ] Submit login with invalid credentials — see error message
- [ ] Submit login with empty fields — see validation errors