### PR TITLE
feat/P3-03-login-page

### DIFF
--- a/src/actions/login.ts
+++ b/src/actions/login.ts
@@ -1,0 +1,47 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+import { createClient } from '@/lib/supabase/server'
+
+type LoginState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+export async function login(prevState: LoginState, formData: FormData): Promise<LoginState> {
+  const email = formData.get('email') as string
+  const password = formData.get('password') as string
+
+  const errors: Record<string, string[]> = {}
+
+  if (!email) {
+    errors.email = ['Email is required']
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    errors.email = ['Please enter a valid email address']
+  }
+
+  if (!password) {
+    errors.password = ['Password is required']
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { success: false, message: 'Validation failed', errors }
+  }
+
+  const supabase = await createClient()
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  })
+
+  if (error) {
+    return { success: false, message: 'Invalid email or password' }
+  }
+
+  revalidatePath('/', 'layout')
+  redirect('/admin/dashboard')
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,14 +1,33 @@
+import Image from 'next/image'
+
 import type { Metadata } from 'next'
+
+import { LoginForm } from '@/components/features/LoginForm'
 
 export const metadata: Metadata = {
   title: 'Login',
+  description: 'Sign in to the St. Basil\'s church admin portal.',
 }
 
 export default function LoginPage() {
   return (
-    <main className="w-full max-w-md px-4 font-body text-wood-800">
-      <h1 className="font-heading text-3xl font-semibold text-wood-900">Auth Group</h1>
-      <p className="mt-4">Login placeholder — (auth) route group.</p>
+    <main className="w-full max-w-md px-4">
+      <div className="rounded-2xl bg-white p-8 shadow-md sm:p-10">
+        <div className="mb-8 flex flex-col items-center gap-4">
+          <Image
+            src="/logo.png"
+            alt="St. Basil's Syriac Orthodox Church"
+            width={220}
+            height={42}
+            priority
+          />
+          <h1 className="font-heading text-2xl font-semibold text-wood-900">
+            Admin Login
+          </h1>
+        </div>
+
+        <LoginForm />
+      </div>
     </main>
   )
 }

--- a/src/components/features/LoginForm.tsx
+++ b/src/components/features/LoginForm.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useActionState } from 'react'
+
+import { login } from '@/actions/login'
+import { Button } from '@/components/ui'
+
+export function LoginForm() {
+  const [state, formAction, pending] = useActionState(login, {
+    success: false,
+    message: '',
+  })
+
+  return (
+    <form action={formAction} className="space-y-5">
+      {state.message && !state.errors && (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          {state.message}
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <label htmlFor="email" className="block text-sm font-medium text-wood-800">
+          Email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          className="block w-full rounded-lg border border-wood-800/20 bg-cream-50 px-4 py-3 text-wood-800 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-2 focus:ring-burgundy-700/20"
+          placeholder="you@example.com"
+        />
+        {state.errors?.email && (
+          <p className="text-sm text-red-600">{state.errors.email[0]}</p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <label htmlFor="password" className="block text-sm font-medium text-wood-800">
+          Password
+        </label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          required
+          className="block w-full rounded-lg border border-wood-800/20 bg-cream-50 px-4 py-3 text-wood-800 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-2 focus:ring-burgundy-700/20"
+          placeholder="Enter your password"
+        />
+        {state.errors?.password && (
+          <p className="text-sm text-red-600">{state.errors.password[0]}</p>
+        )}
+      </div>
+
+      <Button type="submit" disabled={pending} className="w-full">
+        {pending ? (
+          <span className="inline-flex items-center gap-2">
+            <svg
+              className="h-4 w-4 animate-spin"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            Signing in...
+          </span>
+        ) : (
+          'Sign in'
+        )}
+      </Button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/login` page in `(auth)` route group with centered minimal layout (no Navbar/Footer)
- Server Action (`src/actions/login.ts`) validates email/password and calls `signInWithPassword()`
- Client-side `LoginForm` component with loading spinner, field validation errors, and credential error display
- Church logo displayed above the form
- Successful login redirects to `/admin/dashboard`

Implements georgenijo/St-Basils-Boston-Web#76

## Dependencies

- P3-01: profiles table + RLS (not yet merged — login will work once Supabase auth is configured)
- P3-02: Auth trigger function (not yet merged)

## Test plan

- [ ] Visit `/login` — page renders centered card with logo, email/password fields
- [ ] Submit empty form — validation errors shown for required fields
- [ ] Submit invalid credentials — error message displayed
- [ ] Submit valid credentials — redirects to `/admin/dashboard`
- [ ] Loading spinner appears during submission
- [ ] No Navbar/Footer visible on the page
- [ ] Responsive: card is usable on mobile viewports