### PR TITLE
feat/4a-03-contact-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "st-basils-boston-web",
       "version": "0.1.0",
       "dependencies": {
+        "@marsidev/react-turnstile": "^1.4.2",
         "@sanity/image-url": "^2.0.3",
         "@sanity/vision": "^4.22.0",
         "@supabase/ssr": "^0.9.0",
@@ -20,7 +21,8 @@
         "react-dom": "^19.1.0",
         "sanity": "^4.22.0",
         "styled-components": "^6.3.12",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.4",
@@ -4005,6 +4007,16 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.4.2.tgz",
+      "integrity": "sha512-xs1qOuyeMOz6t9BXXCXWiukC0/0+48vR08B7uwNdG05wCMnbcNgxiFmdFKDOFbM76qFYFRYlGeRfhfq1U/iZmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
+      }
+    },
     "node_modules/@mux/mux-data-google-ima": {
       "version": "0.3.15",
       "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.3.15.tgz",
@@ -5381,6 +5393,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@sanity/codegen/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@sanity/color": {
@@ -19646,9 +19667,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.4.2",
     "@sanity/image-url": "^2.0.3",
     "@sanity/vision": "^4.22.0",
     "@supabase/ssr": "^0.9.0",
@@ -24,7 +25,8 @@
     "react-dom": "^19.1.0",
     "sanity": "^4.22.0",
     "styled-components": "^6.3.12",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.4",

--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -1,0 +1,60 @@
+'use server'
+
+import { contactSchema } from '@/lib/validators/contact'
+import { verifyTurnstileToken } from '@/lib/turnstile'
+
+type ContactState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+export async function submitContactForm(
+  prevState: ContactState,
+  formData: FormData
+): Promise<ContactState> {
+  // Honeypot check — bots fill hidden fields
+  const honeypot = formData.get('website')
+  if (honeypot) {
+    // Silently succeed to not tip off bots
+    return { success: true, message: 'Thank you for your message. We will be in touch soon.' }
+  }
+
+  // Turnstile verification
+  const turnstileToken = formData.get('cf-turnstile-response') as string
+  if (!turnstileToken) {
+    return { success: false, message: 'Please complete the verification challenge.' }
+  }
+
+  const turnstileValid = await verifyTurnstileToken(turnstileToken)
+  if (!turnstileValid) {
+    return { success: false, message: 'Verification failed. Please try again.' }
+  }
+
+  // Validate form data
+  const result = contactSchema.safeParse({
+    name: formData.get('name'),
+    email: formData.get('email'),
+    subject: formData.get('subject'),
+    message: formData.get('message'),
+  })
+
+  if (!result.success) {
+    const errors: Record<string, string[]> = {}
+    for (const issue of result.error.issues) {
+      const field = issue.path[0] as string
+      if (!errors[field]) errors[field] = []
+      errors[field].push(issue.message)
+    }
+    return { success: false, message: 'Please fix the errors below.', errors }
+  }
+
+  // TODO: Send email via Resend once email templates are set up (ticket 4a-02)
+  // For now, log the submission
+  console.log('Contact form submission:', result.data)
+
+  return {
+    success: true,
+    message: 'Thank you for your message. We will be in touch soon.',
+  }
+}

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from 'next'
+
+import { PageHero, SectionHeader, Card } from '@/components/ui'
+import { ScrollReveal } from '@/components/ui/ScrollReveal'
+import { ContactForm } from '@/components/features/ContactForm'
+
+export const metadata: Metadata = {
+  title: 'Contact Us',
+  description:
+    "Get in touch with St. Basil's Syriac Orthodox Church in Boston. Reach us by phone, email, or visit us at 73 Ellis Street, Newton, MA 02464.",
+  openGraph: {
+    title: "Contact Us | St. Basil's Syriac Orthodox Church",
+    description:
+      "Get in touch with St. Basil's Syriac Orthodox Church in Boston. We'd love to hear from you.",
+  },
+}
+
+const contactInfo = [
+  {
+    title: 'Visit Us',
+    detail: '73 Ellis Street\nNewton, MA 02464',
+    href: 'https://maps.google.com/?q=73+Ellis+Street+Newton+MA+02464',
+    linkLabel: 'Get Directions',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-7 w-7"
+        aria-hidden="true"
+      >
+        <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+        <circle cx="12" cy="10" r="3" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Call Us',
+    detail: '(617) 527-0560',
+    href: 'tel:+16175270560',
+    linkLabel: 'Call Now',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-7 w-7"
+        aria-hidden="true"
+      >
+        <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Email Us',
+    detail: 'stbasilsboston@gmail.com',
+    href: 'mailto:stbasilsboston@gmail.com',
+    linkLabel: 'Send Email',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-7 w-7"
+        aria-hidden="true"
+      >
+        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+        <polyline points="22,6 12,13 2,6" />
+      </svg>
+    ),
+  },
+]
+
+export default function ContactPage() {
+  return (
+    <main>
+      <PageHero title="Contact Us" backgroundImage="/images/contact/hero.jpg" />
+
+      {/* Contact Info Cards */}
+      <section className="bg-sand py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Get in Touch"
+              subtitle="We would love to hear from you. Whether you have a question, want to learn more about our parish, or would like to visit, please reach out."
+            />
+          </ScrollReveal>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {contactInfo.map((info, i) => (
+              <ScrollReveal key={info.title} delay={i * 0.12}>
+                <Card className="h-full text-center transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
+                  <Card.Body className="flex flex-col items-center space-y-4">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-full bg-burgundy-700/10 text-burgundy-700">
+                      {info.icon}
+                    </div>
+                    <h3 className="font-heading text-xl font-semibold text-wood-900">
+                      {info.title}
+                    </h3>
+                    <p className="whitespace-pre-line font-body text-base text-wood-800/80">
+                      {info.detail}
+                    </p>
+                    <a
+                      href={info.href}
+                      className="font-body text-sm font-medium text-burgundy-700 underline underline-offset-4 hover:text-burgundy-800"
+                      {...(info.href.startsWith('http') && {
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                      })}
+                    >
+                      {info.linkLabel}
+                    </a>
+                  </Card.Body>
+                </Card>
+              </ScrollReveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Contact Form */}
+      <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Send Us a Message"
+              subtitle="Fill out the form below and we will get back to you as soon as possible."
+            />
+          </ScrollReveal>
+
+          <ScrollReveal className="relative mt-12">
+            <ContactForm />
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* Service Times */}
+      <section className="bg-charcoal py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Join Us for Worship"
+              subtitle="We gather every Sunday to celebrate the Holy Qurbono. All are welcome."
+              className="[&_h2]:text-cream-50 [&_p]:text-cream-50/60"
+            />
+          </ScrollReveal>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+            <ScrollReveal>
+              <Card variant="dark" className="text-center">
+                <Card.Body className="space-y-2">
+                  <h3 className="font-heading text-xl font-semibold text-cream-50">
+                    Morning Prayer
+                  </h3>
+                  <p className="font-body text-2xl font-medium text-gold-500">8:30 AM</p>
+                  <p className="font-body text-sm text-cream-50/60">Every Sunday</p>
+                </Card.Body>
+              </Card>
+            </ScrollReveal>
+
+            <ScrollReveal delay={0.12}>
+              <Card variant="dark" className="text-center">
+                <Card.Body className="space-y-2">
+                  <h3 className="font-heading text-xl font-semibold text-cream-50">
+                    Holy Qurbono
+                  </h3>
+                  <p className="font-body text-2xl font-medium text-gold-500">9:15 AM</p>
+                  <p className="font-body text-sm text-cream-50/60">Every Sunday</p>
+                </Card.Body>
+              </Card>
+            </ScrollReveal>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/features/ContactForm.tsx
+++ b/src/components/features/ContactForm.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useActionState, useRef } from 'react'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
+
+import { submitContactForm } from '@/actions/contact'
+import { Button } from '@/components/ui'
+
+const inputClassName =
+  'block w-full rounded-lg border border-wood-800/20 bg-cream-50 px-4 py-3 text-wood-800 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-2 focus:ring-burgundy-700/20'
+
+export function ContactForm() {
+  const [state, formAction, pending] = useActionState(submitContactForm, {
+    success: false,
+    message: '',
+  })
+  const formRef = useRef<HTMLFormElement>(null)
+  const turnstileRef = useRef<TurnstileInstance>(null)
+
+  return (
+    <>
+      {state.success && state.message ? (
+        <div
+          role="status"
+          className="rounded-2xl border border-green-200 bg-green-50 p-8 text-center"
+        >
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="h-6 w-6 text-green-600"
+              aria-hidden="true"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          </div>
+          <h3 className="font-heading text-xl font-semibold text-wood-900">Message Sent</h3>
+          <p className="mt-2 font-body text-wood-800/80">{state.message}</p>
+        </div>
+      ) : (
+        <form ref={formRef} action={formAction} className="space-y-6">
+          {state.message && !state.success && !state.errors && (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+            >
+              {state.message}
+            </div>
+          )}
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            {/* Name */}
+            <div className="space-y-1.5">
+              <label htmlFor="contact-name" className="block text-sm font-medium text-wood-800">
+                Name
+              </label>
+              <input
+                id="contact-name"
+                name="name"
+                type="text"
+                autoComplete="name"
+                required
+                className={inputClassName}
+                placeholder="Your full name"
+              />
+              {state.errors?.name && (
+                <p className="text-sm text-red-600">{state.errors.name[0]}</p>
+              )}
+            </div>
+
+            {/* Email */}
+            <div className="space-y-1.5">
+              <label htmlFor="contact-email" className="block text-sm font-medium text-wood-800">
+                Email
+              </label>
+              <input
+                id="contact-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                className={inputClassName}
+                placeholder="you@example.com"
+              />
+              {state.errors?.email && (
+                <p className="text-sm text-red-600">{state.errors.email[0]}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Subject */}
+          <div className="space-y-1.5">
+            <label htmlFor="contact-subject" className="block text-sm font-medium text-wood-800">
+              Subject
+            </label>
+            <input
+              id="contact-subject"
+              name="subject"
+              type="text"
+              required
+              className={inputClassName}
+              placeholder="How can we help?"
+            />
+            {state.errors?.subject && (
+              <p className="text-sm text-red-600">{state.errors.subject[0]}</p>
+            )}
+          </div>
+
+          {/* Message */}
+          <div className="space-y-1.5">
+            <label htmlFor="contact-message" className="block text-sm font-medium text-wood-800">
+              Message
+            </label>
+            <textarea
+              id="contact-message"
+              name="message"
+              rows={6}
+              required
+              className={inputClassName}
+              placeholder="Tell us more about your inquiry..."
+            />
+            {state.errors?.message && (
+              <p className="text-sm text-red-600">{state.errors.message[0]}</p>
+            )}
+          </div>
+
+          {/* Honeypot — hidden from users, visible to bots */}
+          <div className="absolute -left-[9999px]" aria-hidden="true">
+            <label htmlFor="contact-website">Website</label>
+            <input id="contact-website" name="website" type="text" tabIndex={-1} autoComplete="off" />
+          </div>
+
+          {/* Turnstile */}
+          <Turnstile
+            ref={turnstileRef}
+            siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ''}
+            options={{ theme: 'light', size: 'normal' }}
+          />
+
+          <Button type="submit" disabled={pending} className="w-full sm:w-auto">
+            {pending ? (
+              <span className="inline-flex items-center gap-2">
+                <svg
+                  className="h-4 w-4 animate-spin"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Sending...
+              </span>
+            ) : (
+              'Send Message'
+            )}
+          </Button>
+        </form>
+      )}
+    </>
+  )
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -44,7 +44,7 @@ const navigation: NavItem[] = [
     ],
   },
   { label: 'Giving', href: '/giving' },
-  { label: 'Contact Us', href: '/contact-us' },
+  { label: 'Contact Us', href: '/contact' },
 ]
 
 // ─── Component ───────────────────────────────────────────────────────

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,23 @@
+const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+interface TurnstileResult {
+  success: boolean
+  'error-codes'?: string[]
+}
+
+export async function verifyTurnstileToken(token: string): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY
+  if (!secret) {
+    console.error('TURNSTILE_SECRET_KEY is not set')
+    return false
+  }
+
+  const response = await fetch(TURNSTILE_VERIFY_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ secret, response: token }),
+  })
+
+  const result: TurnstileResult = await response.json()
+  return result.success
+}

--- a/src/lib/validators/contact.ts
+++ b/src/lib/validators/contact.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod'
+
+export const contactSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required')
+    .max(100, 'Name must be 100 characters or less'),
+  email: z
+    .string()
+    .trim()
+    .min(1, 'Email is required')
+    .email('Please enter a valid email address'),
+  subject: z
+    .string()
+    .trim()
+    .min(1, 'Subject is required')
+    .max(200, 'Subject must be 200 characters or less'),
+  message: z
+    .string()
+    .trim()
+    .min(10, 'Message must be at least 10 characters')
+    .max(5000, 'Message must be 5,000 characters or less'),
+})
+
+export type ContactFormData = z.infer<typeof contactSchema>


### PR DESCRIPTION
## Summary
- Adds `/contact` page with PageHero, contact info cards (address, phone, email), contact form, and service times section
- Contact form includes name/email/subject/message fields, hidden honeypot field, and Cloudflare Turnstile widget
- Server action handles Zod validation, honeypot check, and Turnstile verification
- Form shows loading spinner, success confirmation, and field-level validation errors
- Updates Navbar link from `/contact-us` to `/contact`

Implements georgenijo/St-Basils-Boston-Web#84

## Notes
- Dependency 4a-02 (email sending via Resend) not yet implemented — server action logs submissions with a TODO for Resend integration
- Hero image placeholder at `/images/contact/hero.jpg` needs to be added
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` env vars required for Turnstile

## Test plan
- [ ] Page renders at `/contact` with hero, info cards, form, and service times
- [ ] Form validates required fields and shows inline errors
- [ ] Honeypot field is invisible to users
- [ ] Turnstile widget renders when site key is configured
- [ ] Submit shows loading spinner, then success message
- [ ] Responsive layout at 375px, 768px, 1024px, 1280px
- [ ] Navbar "Contact Us" link navigates to `/contact`