### PR TITLE
feat/4b-01-events-schema

### DIFF
--- a/supabase/migrations/20260325000001_create_events.sql
+++ b/supabase/migrations/20260325000001_create_events.sql
@@ -1,0 +1,188 @@
+-- Migration: Create events tables (events, recurrence_rules, event_instances)
+-- Phase: 4b
+-- Ticket: 4b-01
+
+-- Create enum type for event categories
+CREATE TYPE event_category AS ENUM ('liturgical', 'community', 'special');
+
+-- Create events table
+CREATE TABLE public.events (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  title TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  description JSONB,
+  location TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ,
+  is_recurring BOOLEAN DEFAULT false NOT NULL,
+  category event_category NOT NULL DEFAULT 'community',
+  created_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Create indexes
+CREATE INDEX idx_events_slug ON public.events(slug);
+CREATE INDEX idx_events_start_at ON public.events(start_at);
+CREATE INDEX idx_events_category ON public.events(category);
+CREATE INDEX idx_events_is_recurring ON public.events(is_recurring);
+
+-- Enable RLS
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: anyone can read events
+CREATE POLICY "Public can read events"
+  ON public.events FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- INSERT: admin only
+CREATE POLICY "Admins can insert events"
+  ON public.events FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- UPDATE: admin only
+CREATE POLICY "Admins can update events"
+  ON public.events FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- DELETE: admin only
+CREATE POLICY "Admins can delete events"
+  ON public.events FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at (reuse existing function from profiles migration)
+CREATE TRIGGER set_events_updated_at
+  BEFORE UPDATE ON public.events
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================================
+-- Recurrence rules table
+-- ============================================================
+
+CREATE TABLE public.recurrence_rules (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  rrule_string TEXT NOT NULL,
+  dtstart TIMESTAMPTZ NOT NULL,
+  until TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Create indexes
+CREATE INDEX idx_recurrence_rules_event_id ON public.recurrence_rules(event_id);
+
+-- Enable RLS
+ALTER TABLE public.recurrence_rules ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies (same pattern: public read, admin write)
+
+CREATE POLICY "Public can read recurrence rules"
+  ON public.recurrence_rules FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+CREATE POLICY "Admins can insert recurrence rules"
+  ON public.recurrence_rules FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can update recurrence rules"
+  ON public.recurrence_rules FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can delete recurrence rules"
+  ON public.recurrence_rules FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_recurrence_rules_updated_at
+  BEFORE UPDATE ON public.recurrence_rules
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================================
+-- Event instances table (exceptions/cancellations of recurring events)
+-- ============================================================
+
+CREATE TABLE public.event_instances (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  original_date TIMESTAMPTZ NOT NULL,
+  start_at TIMESTAMPTZ,
+  end_at TIMESTAMPTZ,
+  is_cancelled BOOLEAN DEFAULT false NOT NULL,
+  title TEXT,
+  description JSONB,
+  location TEXT,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Create indexes
+CREATE INDEX idx_event_instances_event_id ON public.event_instances(event_id);
+CREATE INDEX idx_event_instances_original_date ON public.event_instances(original_date);
+
+-- Enable RLS
+ALTER TABLE public.event_instances ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies (same pattern: public read, admin write)
+
+CREATE POLICY "Public can read event instances"
+  ON public.event_instances FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+CREATE POLICY "Admins can insert event instances"
+  ON public.event_instances FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can update event instances"
+  ON public.event_instances FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can delete event instances"
+  ON public.event_instances FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_event_instances_updated_at
+  BEFORE UPDATE ON public.event_instances
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,269 @@
+-- Seed: Events and recurrence rules
+-- Source: Existing events-calendar.html (2024-2026 hardcoded events)
+-- Location: 73 Ellis Street, Newton, MA 02464
+
+-- ============================================================
+-- Recurring Sunday Services
+-- ============================================================
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category)
+VALUES
+  (
+    'a0000000-0000-0000-0000-000000000001',
+    'Morning Prayer',
+    'morning-prayer',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Sunday Morning Prayer service."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2024-01-07T08:30:00-05:00',
+    '2024-01-07T09:15:00-05:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000002',
+    'Holy Qurbono',
+    'holy-qurbono',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Sunday Holy Qurbono (Eucharist) service."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2024-01-07T09:15:00-05:00',
+    '2024-01-07T11:00:00-05:00',
+    true,
+    'liturgical'
+  );
+
+-- Recurrence rules for Sunday services (RFC 5545 RRULE)
+INSERT INTO public.recurrence_rules (event_id, rrule_string, dtstart, until)
+VALUES
+  (
+    'a0000000-0000-0000-0000-000000000001',
+    'FREQ=WEEKLY;BYDAY=SU',
+    '2024-01-07T08:30:00-05:00',
+    NULL
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000002',
+    'FREQ=WEEKLY;BYDAY=SU',
+    '2024-01-07T09:15:00-05:00',
+    NULL
+  );
+
+-- ============================================================
+-- Recurring Annual Liturgical Events (fixed-date feasts)
+-- ============================================================
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category)
+VALUES
+  (
+    'a0000000-0000-0000-0000-000000000010',
+    'Circumcision of Christ',
+    'circumcision-of-christ',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Circumcision of our Lord."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-01-01T09:00:00-05:00',
+    '2026-01-01T11:00:00-05:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000011',
+    'Denho / Epiphany',
+    'denho-epiphany',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of Denho (Epiphany) — Baptism of our Lord."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-01-06T09:00:00-05:00',
+    '2026-01-06T11:00:00-05:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000012',
+    'Annunciation',
+    'annunciation',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Annunciation to the Blessed Virgin Mary."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-03-25T09:00:00-04:00',
+    '2026-03-25T11:00:00-04:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000013',
+    'Apostles Feast',
+    'apostles-feast',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Holy Apostles Peter and Paul."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-06-29T09:00:00-04:00',
+    '2026-06-29T11:00:00-04:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000014',
+    'Transfiguration',
+    'transfiguration',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Transfiguration of our Lord."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-08-05T09:00:00-04:00',
+    '2026-08-05T11:00:00-04:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000015',
+    'Assumption of the Blessed Virgin Mary',
+    'assumption',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Assumption (Shoonoyo) of the Blessed Virgin Mary."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-08-15T09:00:00-04:00',
+    '2026-08-15T11:00:00-04:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000016',
+    'Nativity of the Blessed Virgin Mary',
+    'nativity-of-blessed-virgin-mary',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Nativity of the Blessed Virgin Mary."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-09-08T09:00:00-04:00',
+    '2026-09-08T11:00:00-04:00',
+    true,
+    'liturgical'
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000017',
+    'Christmas',
+    'christmas',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Nativity of our Lord Jesus Christ."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2025-12-25T09:00:00-05:00',
+    '2025-12-25T11:00:00-05:00',
+    true,
+    'liturgical'
+  );
+
+-- Recurrence rules for annual feasts
+INSERT INTO public.recurrence_rules (event_id, rrule_string, dtstart, until)
+VALUES
+  ('a0000000-0000-0000-0000-000000000010', 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1', '2026-01-01T09:00:00-05:00', NULL),
+  ('a0000000-0000-0000-0000-000000000011', 'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=6', '2026-01-06T09:00:00-05:00', NULL),
+  ('a0000000-0000-0000-0000-000000000012', 'FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=25', '2026-03-25T09:00:00-04:00', NULL),
+  ('a0000000-0000-0000-0000-000000000013', 'FREQ=YEARLY;BYMONTH=6;BYMONTHDAY=29', '2026-06-29T09:00:00-04:00', NULL),
+  ('a0000000-0000-0000-0000-000000000014', 'FREQ=YEARLY;BYMONTH=8;BYMONTHDAY=5', '2026-08-05T09:00:00-04:00', NULL),
+  ('a0000000-0000-0000-0000-000000000015', 'FREQ=YEARLY;BYMONTH=8;BYMONTHDAY=15', '2026-08-15T09:00:00-04:00', NULL),
+  ('a0000000-0000-0000-0000-000000000016', 'FREQ=YEARLY;BYMONTH=9;BYMONTHDAY=8', '2026-09-08T09:00:00-04:00', NULL),
+  ('a0000000-0000-0000-0000-000000000017', 'FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=25', '2025-12-25T09:00:00-05:00', NULL);
+
+-- ============================================================
+-- Non-recurring Liturgical Events (moveable feasts / specific dates)
+-- ============================================================
+
+INSERT INTO public.events (title, slug, description, location, start_at, end_at, is_recurring, category)
+VALUES
+  (
+    'Nativity Lent',
+    'nativity-lent-2025',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Nativity Lent — 10-day fast in preparation for Christmas."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2025-12-15T00:00:00-05:00',
+    '2025-12-24T23:59:59-05:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Great Lent',
+    'great-lent-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Great Lenten season — 48-day period of fasting and prayer."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-02-16T00:00:00-05:00',
+    '2026-04-04T23:59:59-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Palm Sunday',
+    'palm-sunday-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Hosanna Sunday — Triumphal entry of our Lord into Jerusalem."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-03-29T08:30:00-04:00',
+    '2026-03-29T11:00:00-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Holy Thursday',
+    'holy-thursday-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Pesaha (Passover) Thursday — Institution of the Holy Eucharist."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-04-02T18:00:00-04:00',
+    '2026-04-02T20:00:00-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Good Friday',
+    'good-friday-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Great Friday — Commemoration of the Crucifixion and Burial of our Lord."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-04-03T09:00:00-04:00',
+    '2026-04-03T15:00:00-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Holy Saturday',
+    'holy-saturday-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Holy Saturday — Vigil of the Resurrection."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-04-04T20:00:00-04:00',
+    '2026-04-04T23:59:59-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Easter',
+    'easter-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Resurrection of our Lord Jesus Christ."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-04-05T08:30:00-04:00',
+    '2026-04-05T12:00:00-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Ascension',
+    'ascension-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Ascension of our Lord."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-05-14T09:00:00-04:00',
+    '2026-05-14T11:00:00-04:00',
+    false,
+    'liturgical'
+  ),
+  (
+    'Pentecost',
+    'pentecost-2026',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of Pentecost — Descent of the Holy Spirit."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2026-05-24T08:30:00-04:00',
+    '2026-05-24T11:00:00-04:00',
+    false,
+    'liturgical'
+  );
+
+-- ============================================================
+-- Community Events
+-- ============================================================
+
+INSERT INTO public.events (title, slug, description, location, start_at, end_at, is_recurring, category)
+VALUES
+  (
+    'Church Perunnal',
+    'church-perunnal-2025',
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Annual Church Feast (Perunnal) celebration."}]}]}',
+    '73 Ellis Street, Newton, MA 02464',
+    '2025-09-27T09:00:00-04:00',
+    '2025-09-28T17:00:00-04:00',
+    false,
+    'community'
+  );


### PR DESCRIPTION
## Summary
- Create `events`, `recurrence_rules`, and `event_instances` tables with `event_category` enum type
- RLS policies: public read for all three tables, admin-only write (insert/update/delete)
- Seed data: recurring Sunday services (Morning Prayer, Holy Qurbono), 8 annual fixed-date feasts, 9 moveable/year-specific liturgical events, 1 community event (Church Perunnal)
- Foreign keys with `ON DELETE CASCADE` for child tables, `ON DELETE SET NULL` for `created_by`
- `updated_at` triggers on all three tables, indexes on slug, start_at, category, event_id, original_date

Implements georgenijo/St-Basils-Ralph-Run#85