### PR TITLE
feat/P2-03-spiritual-leader

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -15,11 +15,12 @@ export const pageContentBySlugQuery = groq`
 `
 
 export const allSpiritualLeadersQuery = groq`
-  *[_type == "spiritualLeader"] | order(order asc) {
+  *[_type == "spiritualLeader" && isActive == true] | order(order asc) {
     _id,
     name,
     title,
     photo,
+    photoPosition,
     "photoLqip": photo.asset->metadata.lqip,
     biography,
     order

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -20,6 +20,7 @@ export interface SpiritualLeader {
   name: string
   title: string
   photo: SanityImageSource
+  photoPosition?: string
   photoLqip?: string
   biography: PortableTextBlock[]
   order: number

--- a/src/sanity/schemas/spiritualLeader.ts
+++ b/src/sanity/schemas/spiritualLeader.ts
@@ -26,6 +26,12 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'photoPosition',
+      title: 'Photo Position',
+      type: 'string',
+      description: 'CSS object-position override (e.g., "center top", "50% 30%")',
+    }),
+    defineField({
       name: 'biography',
       title: 'Biography',
       type: 'array',
@@ -64,6 +70,12 @@ export default defineType({
       title: 'Display Order',
       type: 'number',
       validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
     }),
   ],
   orderings: [


### PR DESCRIPTION
## Summary
- Adds missing `photoPosition` (CSS object-position override) and `isActive` (boolean with default `true`) fields to the `spiritualLeader` Sanity schema
- Updates GROQ query to filter by `isActive == true` and project `photoPosition`
- Adds `photoPosition` to the `SpiritualLeader` TypeScript interface

Implements georgenijo/St-Basils-Boston-Web#51