### PR TITLE
feat/P2-04-clergy

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -14,6 +14,21 @@ export const pageContentBySlugQuery = groq`
   }
 `
 
+export const allClergyQuery = groq`
+  *[_type == "clergy" && isActive == true] | order(category asc, order asc) {
+    _id,
+    name,
+    role,
+    photo,
+    photoPosition,
+    "photoLqip": photo.asset->metadata.lqip,
+    yearsOfService,
+    biography,
+    category,
+    order
+  }
+`
+
 export const allSpiritualLeadersQuery = groq`
   *[_type == "spiritualLeader" && isActive == true] | order(order asc) {
     _id,

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -15,6 +15,19 @@ export interface PageContent {
   lastUpdated?: string
 }
 
+export interface Clergy {
+  _id: string
+  name: string
+  role?: string
+  photo?: SanityImageSource
+  photoPosition?: string
+  photoLqip?: string
+  yearsOfService?: string
+  biography?: PortableTextBlock[]
+  category: 'current' | 'previous' | 'memoriam'
+  order: number
+}
+
 export interface SpiritualLeader {
   _id: string
   name: string

--- a/src/sanity/schemas/clergy.ts
+++ b/src/sanity/schemas/clergy.ts
@@ -1,0 +1,127 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'clergy',
+  title: 'Clergy',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'role',
+      title: 'Role',
+      type: 'string',
+      description: 'Position or title (e.g., "Vicar", "Deacon")',
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'photoPosition',
+      title: 'Photo Position',
+      type: 'string',
+      description: 'CSS object-position override (e.g., "center top", "50% 30%")',
+    }),
+    defineField({
+      name: 'yearsOfService',
+      title: 'Years of Service',
+      type: 'string',
+      description: 'e.g., "2010 – Present" or "1995 – 2020"',
+    }),
+    defineField({
+      name: 'biography',
+      title: 'Biography',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: 'Normal', value: 'normal' }],
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+            ],
+            annotations: [
+              {
+                name: 'link',
+                type: 'object',
+                title: 'Link',
+                fields: [
+                  {
+                    name: 'href',
+                    type: 'url',
+                    title: 'URL',
+                    validation: (Rule) =>
+                      Rule.uri({ allowRelative: true, scheme: ['http', 'https', 'mailto', 'tel'] }),
+                  },
+                ],
+              },
+            ],
+          },
+          lists: [],
+        },
+      ],
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Current', value: 'current' },
+          { title: 'Previous', value: 'previous' },
+          { title: 'In Memoriam', value: 'memoriam' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'current',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Category, then Order',
+      name: 'categoryOrder',
+      by: [
+        { field: 'category', direction: 'asc' },
+        { field: 'order', direction: 'asc' },
+      ],
+    },
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: { title: 'name', subtitle: 'role', category: 'category', media: 'photo' },
+    prepare({ title, subtitle, category, media }) {
+      const categoryLabel =
+        category === 'current' ? 'Current' : category === 'previous' ? 'Previous' : 'In Memoriam'
+      return {
+        title,
+        subtitle: [subtitle, categoryLabel].filter(Boolean).join(' — '),
+        media,
+      }
+    },
+  },
+})

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,6 +1,7 @@
 import { SchemaTypeDefinition } from 'sanity'
 
+import clergy from './clergy'
 import pageContent from './pageContent'
 import spiritualLeader from './spiritualLeader'
 
-export const schemaTypes: SchemaTypeDefinition[] = [pageContent, spiritualLeader]
+export const schemaTypes: SchemaTypeDefinition[] = [clergy, pageContent, spiritualLeader]


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#52

## Summary
- Add `clergy` Sanity document schema with fields: name, role, photo (hotspot), photoPosition, yearsOfService, biography (Portable Text), category (current/previous/memoriam radio), order, isActive
- Category field uses radio layout with current/previous/memoriam options
- Studio ordering by category then display order
- Preview shows name, role, and category label
- Add `allClergyQuery` GROQ query filtered by isActive, ordered by category then order
- Add `Clergy` TypeScript interface in types.ts
- Register schema in index.ts

## Test plan
- [ ] Verify schema appears in Sanity Studio
- [ ] Create a clergy document with all fields populated
- [ ] Confirm category radio buttons render with correct options
- [ ] Verify studio ordering sorts by category then order
- [ ] Confirm preview shows name — role — category
- [ ] Run `npx tsc --noEmit` — passes clean