### PR TITLE
feat: add officeBearer Sanity schema with category support (#53)

### DIFF
--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -29,6 +29,20 @@ export const allClergyQuery = groq`
   }
 `
 
+export const allOfficeBearersQuery = groq`
+  *[_type == "officeBearer" && isActive == true] | order(category asc, order asc) {
+    _id,
+    name,
+    role,
+    photo,
+    photoPosition,
+    "photoLqip": photo.asset->metadata.lqip,
+    category,
+    year,
+    order
+  }
+`
+
 export const allSpiritualLeadersQuery = groq`
   *[_type == "spiritualLeader" && isActive == true] | order(order asc) {
     _id,

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -28,6 +28,18 @@ export interface Clergy {
   order: number
 }
 
+export interface OfficeBearer {
+  _id: string
+  name: string
+  role?: string
+  photo?: SanityImageSource
+  photoPosition?: string
+  photoLqip?: string
+  category: 'executive' | 'board'
+  year?: string
+  order: number
+}
+
 export interface SpiritualLeader {
   _id: string
   name: string

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,7 +1,8 @@
 import { SchemaTypeDefinition } from 'sanity'
 
 import clergy from './clergy'
+import officeBearer from './officeBearer'
 import pageContent from './pageContent'
 import spiritualLeader from './spiritualLeader'
 
-export const schemaTypes: SchemaTypeDefinition[] = [clergy, pageContent, spiritualLeader]
+export const schemaTypes: SchemaTypeDefinition[] = [clergy, officeBearer, pageContent, spiritualLeader]

--- a/src/sanity/schemas/officeBearer.ts
+++ b/src/sanity/schemas/officeBearer.ts
@@ -1,0 +1,90 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'officeBearer',
+  title: 'Office Bearer',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'role',
+      title: 'Role',
+      type: 'string',
+      description: 'Position or title (e.g., "President", "Secretary")',
+    }),
+    defineField({
+      name: 'photo',
+      title: 'Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'photoPosition',
+      title: 'Photo Position',
+      type: 'string',
+      description: 'CSS object-position override (e.g., "center top", "50% 30%")',
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      options: {
+        list: [
+          { title: 'Executive', value: 'executive' },
+          { title: 'Board', value: 'board' },
+        ],
+        layout: 'radio',
+      },
+      initialValue: 'executive',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'year',
+      title: 'Term Year',
+      type: 'string',
+      description: 'Term year (e.g., "2025")',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Category, then Order',
+      name: 'categoryOrder',
+      by: [
+        { field: 'category', direction: 'asc' },
+        { field: 'order', direction: 'asc' },
+      ],
+    },
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: { title: 'name', subtitle: 'role', year: 'year', media: 'photo' },
+    prepare({ title, subtitle, year, media }) {
+      return {
+        title,
+        subtitle: [subtitle, year].filter(Boolean).join(' — '),
+        media,
+      }
+    },
+  },
+})


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#53

## Summary
- Add `officeBearer` Sanity document schema with fields: name, role, photo (hotspot), photoPosition, category (executive/board), year, order, isActive
- Add GROQ query `allOfficeBearersQuery` filtered by isActive, ordered by category then order
- Add `OfficeBearer` TypeScript interface
- Register schema in schema index

## Acceptance Criteria
- [x] Schema registered in Sanity
- [x] Category field with executive/board options
- [x] Year field for term tracking
- [x] Photo supports hotspot/crop
- [x] Preview shows name + role + year