### PR TITLE
feat/P2-07-useful-link

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -1,11 +1,20 @@
 import { defineConfig } from 'sanity'
 import { structureTool } from 'sanity/structure'
 import { visionTool } from '@sanity/vision'
+import type { StructureBuilder } from 'sanity/structure'
 
 import { schemaTypes } from '@/sanity/schemas'
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
+
+const singletonTypes = new Set(['usefulLinksPage'])
+
+const singletonListItem = (S: StructureBuilder, typeName: string, title: string) =>
+  S.listItem()
+    .title(title)
+    .id(typeName)
+    .child(S.document().schemaType(typeName).documentId(typeName))
 
 export default defineConfig({
   name: 'st-basils-boston',
@@ -14,9 +23,26 @@ export default defineConfig({
   projectId,
   dataset,
 
-  plugins: [structureTool(), visionTool()],
+  plugins: [
+    structureTool({
+      structure: (S) =>
+        S.list()
+          .title('Content')
+          .items([
+            // Singleton pages
+            singletonListItem(S, 'usefulLinksPage', 'Useful Links Page'),
+            S.divider(),
+            // All other document types (excluding singletons)
+            ...S.documentTypeListItems().filter(
+              (listItem) => !singletonTypes.has(listItem.getId() as string)
+            ),
+          ]),
+    }),
+    visionTool(),
+  ],
 
   schema: {
     types: schemaTypes,
+    templates: (templates) => templates.filter(({ schemaType }) => !singletonTypes.has(schemaType)),
   },
 })

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -71,3 +71,23 @@ export const allSpiritualLeadersQuery = groq`
     order
   }
 `
+
+export const allUsefulLinksQuery = groq`
+  *[_type == "usefulLink" && isActive == true] | order(order asc) {
+    _id,
+    title,
+    "fileUrl": file.asset->url,
+    category,
+    order
+  }
+`
+
+export const usefulLinksPageQuery = groq`
+  *[_type == "usefulLinksPage"][0] {
+    _id,
+    pageTitle,
+    heroImage,
+    introText,
+    sectionTitle
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -67,3 +67,19 @@ export interface SpiritualLeader {
   biography: PortableTextBlock[]
   order: number
 }
+
+export interface UsefulLink {
+  _id: string
+  title: string
+  fileUrl?: string
+  category?: string
+  order: number
+}
+
+export interface UsefulLinksPage {
+  _id: string
+  pageTitle: string
+  heroImage?: SanityImageSource
+  introText?: string
+  sectionTitle?: string
+}

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -5,5 +5,15 @@ import officeBearer from './officeBearer'
 import organization from './organization'
 import pageContent from './pageContent'
 import spiritualLeader from './spiritualLeader'
+import usefulLink from './usefulLink'
+import usefulLinksPage from './usefulLinksPage'
 
-export const schemaTypes: SchemaTypeDefinition[] = [clergy, officeBearer, organization, pageContent, spiritualLeader]
+export const schemaTypes: SchemaTypeDefinition[] = [
+  clergy,
+  officeBearer,
+  organization,
+  pageContent,
+  spiritualLeader,
+  usefulLink,
+  usefulLinksPage,
+]

--- a/src/sanity/schemas/usefulLink.ts
+++ b/src/sanity/schemas/usefulLink.ts
@@ -1,0 +1,50 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'usefulLink',
+  title: 'Useful Link',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'file',
+      title: 'File',
+      type: 'file',
+      options: {
+        accept: '.pdf',
+      },
+      description: 'Upload a PDF document',
+    }),
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+    }),
+    defineField({
+      name: 'isActive',
+      title: 'Active',
+      type: 'boolean',
+      initialValue: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Display Order',
+      name: 'orderAsc',
+      by: [{ field: 'order', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: { title: 'title', subtitle: 'category' },
+  },
+})

--- a/src/sanity/schemas/usefulLinksPage.ts
+++ b/src/sanity/schemas/usefulLinksPage.ts
@@ -1,0 +1,35 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'usefulLinksPage',
+  title: 'Useful Links Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'pageTitle',
+      title: 'Page Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'introText',
+      title: 'Intro Text',
+      type: 'text',
+    }),
+    defineField({
+      name: 'sectionTitle',
+      title: 'Section Title',
+      type: 'string',
+      description: 'Heading above the links list',
+    }),
+  ],
+  preview: {
+    select: { title: 'pageTitle' },
+  },
+})


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#55

## Summary
- Add `usefulLink` document schema with title, PDF file upload, category, order, and isActive fields
- Add `usefulLinksPage` singleton schema with pageTitle, heroImage, introText, and sectionTitle fields
- Set up Structure Builder singleton pattern to prevent duplicate page creation
- Add GROQ queries (`allUsefulLinksQuery`, `usefulLinksPageQuery`) and TypeScript types

## Test plan
- [ ] Verify both schemas appear in Sanity Studio
- [ ] Confirm `usefulLinksPage` shows as a single editable document (no "create new" option)
- [ ] Upload a PDF to a `usefulLink` document and confirm the file field works
- [ ] Verify ordering and `isActive` filtering in Vision tool with GROQ queries