### PR TITLE
feat: add acolytesChoirPage singleton Sanity schema (#56)

### DIFF
--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -8,7 +8,7 @@ import { schemaTypes } from '@/sanity/schemas'
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID!
 const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET!
 
-const singletonTypes = new Set(['usefulLinksPage'])
+const singletonTypes = new Set(['acolytesChoirPage', 'usefulLinksPage'])
 
 const singletonListItem = (S: StructureBuilder, typeName: string, title: string) =>
   S.listItem()
@@ -30,6 +30,7 @@ export default defineConfig({
           .title('Content')
           .items([
             // Singleton pages
+            singletonListItem(S, 'acolytesChoirPage', 'Acolytes & Choir Page'),
             singletonListItem(S, 'usefulLinksPage', 'Useful Links Page'),
             S.divider(),
             // All other document types (excluding singletons)

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -91,3 +91,14 @@ export const usefulLinksPageQuery = groq`
     sectionTitle
   }
 `
+
+export const acolytesChoirPageQuery = groq`
+  *[_type == "acolytesChoirPage"][0] {
+    _id,
+    pageTitle,
+    heroImage,
+    description,
+    groupPhoto,
+    metaDescription
+  }
+`

--- a/src/lib/sanity/types.ts
+++ b/src/lib/sanity/types.ts
@@ -83,3 +83,12 @@ export interface UsefulLinksPage {
   introText?: string
   sectionTitle?: string
 }
+
+export interface AcolytesChoirPage {
+  _id: string
+  pageTitle: string
+  heroImage?: SanityImageSource
+  description?: PortableTextBlock[]
+  groupPhoto?: SanityImageSource
+  metaDescription?: string
+}

--- a/src/sanity/schemas/acolytesChoirPage.ts
+++ b/src/sanity/schemas/acolytesChoirPage.ts
@@ -1,0 +1,53 @@
+import { defineType, defineField } from 'sanity'
+
+export default defineType({
+  name: 'acolytesChoirPage',
+  title: 'Acolytes & Choir Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'pageTitle',
+      title: 'Page Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero Image',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'description',
+      title: 'Description',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          marks: {
+            decorators: [
+              { title: 'Bold', value: 'strong' },
+              { title: 'Italic', value: 'em' },
+              { title: 'Burgundy Highlight', value: 'burgundyHighlight' },
+            ],
+          },
+        },
+      ],
+    }),
+    defineField({
+      name: 'groupPhoto',
+      title: 'Group Photo',
+      type: 'image',
+      options: { hotspot: true },
+    }),
+    defineField({
+      name: 'metaDescription',
+      title: 'Meta Description',
+      type: 'text',
+      description: 'SEO meta description for the page',
+    }),
+  ],
+  preview: {
+    select: { title: 'pageTitle' },
+  },
+})

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,5 +1,6 @@
 import { SchemaTypeDefinition } from 'sanity'
 
+import acolytesChoirPage from './acolytesChoirPage'
 import clergy from './clergy'
 import officeBearer from './officeBearer'
 import organization from './organization'
@@ -9,6 +10,7 @@ import usefulLink from './usefulLink'
 import usefulLinksPage from './usefulLinksPage'
 
 export const schemaTypes: SchemaTypeDefinition[] = [
+  acolytesChoirPage,
   clergy,
   officeBearer,
   organization,


### PR DESCRIPTION
## Summary
- Adds `acolytesChoirPage` singleton Sanity schema with `pageTitle`, `heroImage`, `description` (Portable Text with burgundy highlight mark), `groupPhoto`, and `metaDescription` fields
- Registers singleton in Sanity Studio Structure Builder (prevents duplicate creation)
- Adds GROQ query and TypeScript type

Implements georgenijo/St-Basils-Boston-Web#56