### PR TITLE
feat/P2-17-terms-of-use

### DIFF
--- a/src/app/(public)/terms-of-use/page.tsx
+++ b/src/app/(public)/terms-of-use/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { LegalPageLayout } from '@/components/features/LegalPageLayout'
+
+import type { PageContent } from '@/lib/sanity/types'
+
+export const revalidate = 60
+
+async function getPage() {
+  return sanityFetch<PageContent | null>({
+    query: pageContentBySlugQuery,
+    params: { slug: 'terms-of-use' },
+    tags: ['pageContent'],
+  })
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const page = await getPage()
+
+  return {
+    title: page?.title ?? 'Terms of Use',
+    description:
+      page?.metaDescription ??
+      "Terms of Use for St. Basil's Syriac Orthodox Church website.",
+  }
+}
+
+export default async function TermsOfUsePage() {
+  const page = await getPage()
+
+  if (!page) {
+    notFound()
+  }
+
+  return <LegalPageLayout page={page} />
+}


### PR DESCRIPTION
## Summary
- Adds `/terms-of-use` route that fetches `pageContent` by slug from Sanity and renders it with the shared `LegalPageLayout` component

## Dependencies
- P2-02: pageContent Sanity schema
- P2-01: Sanity image pipeline
- P2-16: shared `LegalPageLayout` component

Implements georgenijo/St-Basils-Boston-Web#65

## Test plan
- [ ] Verify page renders at `/terms-of-use` with Sanity content seeded (slug: `terms-of-use`)
- [ ] Verify Portable Text blocks (headings, lists, links) render correctly
- [ ] Verify responsive layout at 375px, 768px, 1024px, 1280px
- [ ] Verify `notFound()` is shown when no Sanity document exists
- [ ] Verify metadata (title, description) populates from Sanity data