### PR TITLE
feat/P2-22-useful-links

### DIFF
--- a/src/app/(public)/useful-links/page.tsx
+++ b/src/app/(public)/useful-links/page.tsx
@@ -1,0 +1,199 @@
+import type { Metadata } from 'next'
+
+import { sanityFetch } from '@/lib/sanity/client'
+import { SanityImage } from '@/lib/sanity/image'
+import { allUsefulLinksQuery, usefulLinksPageQuery } from '@/lib/sanity/queries'
+import { SectionHeader, ScrollReveal } from '@/components/ui'
+
+import type { UsefulLink, UsefulLinksPage } from '@/lib/sanity/types'
+
+export const metadata: Metadata = {
+  title: 'Useful Links',
+  description:
+    "Download liturgical texts, prayer books, and other resources from St. Basil's Syriac Orthodox Church in Boston.",
+  openGraph: {
+    title: "Useful Links | St. Basil's Syriac Orthodox Church",
+    description:
+      "Download liturgical texts, prayer books, and other resources from St. Basil's Syriac Orthodox Church in Boston.",
+  },
+}
+
+export const revalidate = 60
+
+export default async function UsefulLinksPageRoute() {
+  const [pageContent, links] = await Promise.all([
+    sanityFetch<UsefulLinksPage>({
+      query: usefulLinksPageQuery,
+      tags: ['usefulLinksPage'],
+    }),
+    sanityFetch<UsefulLink[]>({
+      query: allUsefulLinksQuery,
+      tags: ['usefulLink'],
+    }),
+  ])
+
+  const title = pageContent?.pageTitle || 'Useful Links'
+
+  // Group links by category
+  const grouped = links.reduce<Record<string, UsefulLink[]>>((acc, link) => {
+    const cat = link.category || 'Other'
+    if (!acc[cat]) acc[cat] = []
+    acc[cat].push(link)
+    return acc
+  }, {})
+
+  const categories = Object.keys(grouped)
+
+  return (
+    <>
+      {/* Parallax Hero */}
+      <section className="relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]">
+        {pageContent?.heroImage ? (
+          <SanityImage
+            image={pageContent.heroImage}
+            alt=""
+            fill
+            priority
+            className="object-cover"
+            style={{ position: 'absolute' }}
+            sizes="100vw"
+          />
+        ) : (
+          <div
+            className="absolute inset-0 bg-cover bg-fixed bg-center"
+            style={{ backgroundImage: "url('/images/useful-links-hero.jpg')" }}
+            aria-hidden="true"
+          />
+        )}
+        <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
+        <h1 className="relative z-10 animate-drop-in px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">
+          {title}
+        </h1>
+      </section>
+
+      {/* Intro */}
+      {pageContent?.introText && (
+        <section className="bg-cream-50 py-16 md:py-22">
+          <div className="mx-auto max-w-3xl px-4 text-center sm:px-6 lg:px-8">
+            <ScrollReveal direction="up">
+              <p className="text-base leading-relaxed text-wood-800 md:text-lg">
+                {pageContent.introText}
+              </p>
+            </ScrollReveal>
+          </div>
+        </section>
+      )}
+
+      {/* Links */}
+      {links.length > 0 ? (
+        <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+            {categories.length > 1 ? (
+              // Multiple categories — render with section headers
+              categories.map((category, catIndex) => (
+                <div key={category} className={catIndex > 0 ? 'mt-16' : ''}>
+                  <ScrollReveal direction="up">
+                    <SectionHeader
+                      title={pageContent?.sectionTitle && categories.length === 1
+                        ? pageContent.sectionTitle
+                        : category}
+                      as="h2"
+                      align="left"
+                      className="mb-8"
+                    />
+                  </ScrollReveal>
+                  <div className="space-y-4">
+                    {grouped[category].map((link, index) => (
+                      <LinkCard key={link._id} link={link} index={index} />
+                    ))}
+                  </div>
+                </div>
+              ))
+            ) : (
+              // Single or no category — optional section title
+              <>
+                {pageContent?.sectionTitle && (
+                  <ScrollReveal direction="up">
+                    <SectionHeader
+                      title={pageContent.sectionTitle}
+                      as="h2"
+                      className="mb-10"
+                    />
+                  </ScrollReveal>
+                )}
+                <div className="space-y-4">
+                  {links.map((link, index) => (
+                    <LinkCard key={link._id} link={link} index={index} />
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+      ) : (
+        <section className="py-16 md:py-22 lg:py-28">
+          <div className="mx-auto max-w-[1200px] px-4 text-center sm:px-6 lg:px-8">
+            <p className="text-lg text-wood-800/60">
+              Resources are being updated. Please check back soon.
+            </p>
+          </div>
+        </section>
+      )}
+    </>
+  )
+}
+
+function LinkCard({ link, index }: { link: UsefulLink; index: number }) {
+  if (!link.fileUrl) return null
+
+  return (
+    <ScrollReveal direction="up" delay={index * 0.08}>
+      <a
+        href={link.fileUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        download
+        className="group flex items-center gap-4 rounded-2xl border-l-4 border-burgundy-700 bg-sand p-5 shadow-sm transition-all duration-200 hover:translate-x-[5px] hover:shadow-md sm:p-6"
+      >
+        {/* PDF Icon */}
+        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-burgundy-700/10">
+          <svg
+            className="h-5 w-5 text-burgundy-700"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+        </div>
+
+        {/* Title */}
+        <span className="font-body text-base font-medium text-wood-900 transition-colors group-hover:text-burgundy-700 sm:text-lg">
+          {link.title}
+        </span>
+
+        {/* Arrow */}
+        <svg
+          className="ml-auto h-5 w-5 shrink-0 text-wood-800/40 transition-colors group-hover:text-burgundy-700"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5l7 7-7 7"
+          />
+        </svg>
+      </a>
+    </ScrollReveal>
+  )
+}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -10,6 +10,7 @@ const TYPE_TO_PATHS: Record<string, string[]> = {
   officeBearer: ['/office-bearers'],
   organization: ['/our-organizations'],
   usefulLink: ['/useful-links'],
+  usefulLinksPage: ['/useful-links'],
   pageContent: ['/privacy-policy', '/terms-of-use'],
   acolytesChoirPage: ['/acolytes-choir'],
 }


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#70

## Summary
- Adds `/useful-links` page fetching content and PDF links from Sanity
- Parallax hero with Sanity image or static fallback
- Cream cards with burgundy left border and `translateX(5px)` hover effect
- Groups links by category when multiple categories exist
- Adds `usefulLinksPage` type to webhook revalidation route

## Test plan
- [ ] Page renders with Sanity content (page title, hero image, intro text)
- [ ] PDF links display in styled cards with download icon
- [ ] Hover animation shifts cards right
- [ ] PDFs download correctly from Sanity CDN
- [ ] Responsive at 375px, 768px, 1024px, 1280px
- [ ] Empty state displays when no links exist
- [ ] Webhook revalidation works for both `usefulLink` and `usefulLinksPage` types