### PR TITLE
feat/P2-25-og-tags

### DIFF
--- a/src/app/(public)/office-bearers/page.tsx
+++ b/src/app/(public)/office-bearers/page.tsx
@@ -7,15 +7,18 @@ import { SectionHeader, ScrollReveal } from '@/components/ui'
 
 import type { OfficeBearer } from '@/lib/sanity/types'
 
-export const metadata: Metadata = {
-  title: 'Our Office Bearers',
-  description:
-    "Meet the office bearers of St. Basil's Syriac Orthodox Church — the executive committee and board members who serve our community.",
-  openGraph: {
-    title: "Our Office Bearers | St. Basil's Syriac Orthodox Church",
-    description:
-      "Meet the office bearers of St. Basil's Syriac Orthodox Church — the executive committee and board members who serve our community.",
-  },
+const fallbackDescription =
+  "Meet the office bearers of St. Basil's Syriac Orthodox Church — the executive committee and board members who serve our community."
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Our Office Bearers',
+    description: fallbackDescription,
+    openGraph: {
+      title: "Our Office Bearers | St. Basil's Syriac Orthodox Church",
+      description: fallbackDescription,
+    },
+  }
 }
 
 export const revalidate = 60

--- a/src/app/(public)/our-clergy/page.tsx
+++ b/src/app/(public)/our-clergy/page.tsx
@@ -10,15 +10,19 @@ import { CandleFlame } from '@/components/features/CandleFlame'
 
 import type { Clergy } from '@/lib/sanity/types'
 
-export const metadata: Metadata = {
-  title: 'Our Clergy',
-  description:
-    "Meet the clergy of St. Basil's Syriac Orthodox Church in Boston — past and present servants who have shepherded our community.",
-  openGraph: {
-    title: "Our Clergy | St. Basil's Syriac Orthodox Church",
-    description:
-      "Meet the clergy of St. Basil's Syriac Orthodox Church in Boston — past and present servants who have shepherded our community.",
-  },
+const fallbackDescription =
+  "Meet the clergy of St. Basil's Syriac Orthodox Church in Boston — past and present servants who have shepherded our community."
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Our Clergy',
+    description: fallbackDescription,
+    openGraph: {
+      title: "Our Clergy | St. Basil's Syriac Orthodox Church",
+      description: fallbackDescription,
+      images: ['/images/our-clergy-hero.jpg'],
+    },
+  }
 }
 
 export const revalidate = 60

--- a/src/app/(public)/our-organizations/page.tsx
+++ b/src/app/(public)/our-organizations/page.tsx
@@ -10,15 +10,19 @@ import { GoldDivider, ScrollReveal } from '@/components/ui'
 
 import type { Organization } from '@/lib/sanity/types'
 
-export const metadata: Metadata = {
-  title: 'Our Organizations',
-  description:
-    "Explore the organizations of St. Basil's Syriac Orthodox Church in Boston — Sunday School, youth groups, men's and women's fellowships serving our community.",
-  openGraph: {
-    title: "Our Organizations | St. Basil's Syriac Orthodox Church",
-    description:
-      "Explore the organizations of St. Basil's Syriac Orthodox Church in Boston — Sunday School, youth groups, men's and women's fellowships serving our community.",
-  },
+const fallbackDescription =
+  "Explore the organizations of St. Basil's Syriac Orthodox Church in Boston — Sunday School, youth groups, men's and women's fellowships serving our community."
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Our Organizations',
+    description: fallbackDescription,
+    openGraph: {
+      title: "Our Organizations | St. Basil's Syriac Orthodox Church",
+      description: fallbackDescription,
+      images: ['/images/our-organizations-hero.jpg'],
+    },
+  }
 }
 
 export const revalidate = 60

--- a/src/app/(public)/privacy-policy/page.tsx
+++ b/src/app/(public)/privacy-policy/page.tsx
@@ -2,12 +2,16 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
 import { pageContentBySlugQuery } from '@/lib/sanity/queries'
 import { LegalPageLayout } from '@/components/features/LegalPageLayout'
 
 import type { PageContent } from '@/lib/sanity/types'
 
 export const revalidate = 60
+
+const fallbackDescription =
+  "Privacy Policy for St. Basil's Syriac Orthodox Church website."
 
 async function getPage() {
   return sanityFetch<PageContent | null>({
@@ -20,11 +24,19 @@ async function getPage() {
 export async function generateMetadata(): Promise<Metadata> {
   const page = await getPage()
 
+  const title = page?.title ?? 'Privacy Policy'
+  const description = page?.metaDescription ?? fallbackDescription
+
   return {
-    title: page?.title ?? 'Privacy Policy',
-    description:
-      page?.metaDescription ??
-      "Privacy Policy for St. Basil's Syriac Orthodox Church website.",
+    title,
+    description,
+    openGraph: {
+      title: `${title} | St. Basil's Syriac Orthodox Church`,
+      description,
+      ...(page?.heroImage
+        ? { images: [urlFor(page.heroImage).width(1200).height(630).url()] }
+        : {}),
+    },
   }
 }
 

--- a/src/app/(public)/spiritual-leaders/page.tsx
+++ b/src/app/(public)/spiritual-leaders/page.tsx
@@ -2,22 +2,35 @@ import type { Metadata } from 'next'
 import { PortableText } from 'next-sanity'
 
 import { sanityFetch } from '@/lib/sanity/client'
-import { SanityImage } from '@/lib/sanity/image'
+import { urlFor, SanityImage } from '@/lib/sanity/image'
 import { allSpiritualLeadersQuery } from '@/lib/sanity/queries'
 import { cn } from '@/lib/utils'
 import { GoldDivider, ScrollReveal } from '@/components/ui'
 
 import type { SpiritualLeader } from '@/lib/sanity/types'
 
-export const metadata: Metadata = {
-  title: 'Our Spiritual Fathers',
-  description:
-    "Meet the spiritual fathers who guide St. Basil's Syriac Orthodox Church in Boston, Massachusetts.",
-  openGraph: {
-    title: "Our Spiritual Fathers | St. Basil's Syriac Orthodox Church",
-    description:
-      "Meet the spiritual fathers who guide St. Basil's Syriac Orthodox Church in Boston, Massachusetts.",
-  },
+const fallbackDescription =
+  "Meet the spiritual fathers who guide St. Basil's Syriac Orthodox Church in Boston, Massachusetts."
+
+export async function generateMetadata(): Promise<Metadata> {
+  const leaders = await sanityFetch<SpiritualLeader[]>({
+    query: allSpiritualLeadersQuery,
+    tags: ['spiritualLeader'],
+  })
+
+  const firstLeaderPhoto = leaders[0]?.photo
+
+  return {
+    title: 'Our Spiritual Fathers',
+    description: fallbackDescription,
+    openGraph: {
+      title: "Our Spiritual Fathers | St. Basil's Syriac Orthodox Church",
+      description: fallbackDescription,
+      ...(firstLeaderPhoto
+        ? { images: [urlFor(firstLeaderPhoto).width(1200).height(630).url()] }
+        : {}),
+    },
+  }
 }
 
 export const revalidate = 60

--- a/src/app/(public)/terms-of-use/page.tsx
+++ b/src/app/(public)/terms-of-use/page.tsx
@@ -2,12 +2,16 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 
 import { sanityFetch } from '@/lib/sanity/client'
+import { urlFor } from '@/lib/sanity/image'
 import { pageContentBySlugQuery } from '@/lib/sanity/queries'
 import { LegalPageLayout } from '@/components/features/LegalPageLayout'
 
 import type { PageContent } from '@/lib/sanity/types'
 
 export const revalidate = 60
+
+const fallbackDescription =
+  "Terms of Use for St. Basil's Syriac Orthodox Church website."
 
 async function getPage() {
   return sanityFetch<PageContent | null>({
@@ -20,11 +24,19 @@ async function getPage() {
 export async function generateMetadata(): Promise<Metadata> {
   const page = await getPage()
 
+  const title = page?.title ?? 'Terms of Use'
+  const description = page?.metaDescription ?? fallbackDescription
+
   return {
-    title: page?.title ?? 'Terms of Use',
-    description:
-      page?.metaDescription ??
-      "Terms of Use for St. Basil's Syriac Orthodox Church website.",
+    title,
+    description,
+    openGraph: {
+      title: `${title} | St. Basil's Syriac Orthodox Church`,
+      description,
+      ...(page?.heroImage
+        ? { images: [urlFor(page.heroImage).width(1200).height(630).url()] }
+        : {}),
+    },
   }
 }
 

--- a/src/app/(public)/useful-links/page.tsx
+++ b/src/app/(public)/useful-links/page.tsx
@@ -1,21 +1,35 @@
 import type { Metadata } from 'next'
 
 import { sanityFetch } from '@/lib/sanity/client'
-import { SanityImage } from '@/lib/sanity/image'
+import { urlFor, SanityImage } from '@/lib/sanity/image'
 import { allUsefulLinksQuery, usefulLinksPageQuery } from '@/lib/sanity/queries'
 import { SectionHeader, ScrollReveal } from '@/components/ui'
 
 import type { UsefulLink, UsefulLinksPage } from '@/lib/sanity/types'
 
-export const metadata: Metadata = {
-  title: 'Useful Links',
-  description:
-    "Download liturgical texts, prayer books, and other resources from St. Basil's Syriac Orthodox Church in Boston.",
-  openGraph: {
-    title: "Useful Links | St. Basil's Syriac Orthodox Church",
-    description:
-      "Download liturgical texts, prayer books, and other resources from St. Basil's Syriac Orthodox Church in Boston.",
-  },
+const fallbackDescription =
+  "Download liturgical texts, prayer books, and other resources from St. Basil's Syriac Orthodox Church in Boston."
+
+export async function generateMetadata(): Promise<Metadata> {
+  const pageContent = await sanityFetch<UsefulLinksPage | null>({
+    query: usefulLinksPageQuery,
+    tags: ['usefulLinksPage'],
+  })
+
+  const title = pageContent?.pageTitle || 'Useful Links'
+  const description = fallbackDescription
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title: `${title} | St. Basil's Syriac Orthodox Church`,
+      description,
+      ...(pageContent?.heroImage
+        ? { images: [urlFor(pageContent.heroImage).width(1200).height(630).url()] }
+        : {}),
+    },
+  }
 }
 
 export const revalidate = 60


### PR DESCRIPTION
## Summary

- All 8 Sanity-powered pages now export `generateMetadata()` with OpenGraph tags
- Pages with Sanity hero images (privacy-policy, terms-of-use, useful-links, acolytes-choir) use `urlFor().width(1200).height(630)` for OG images
- Pages with static hero images (our-clergy, our-organizations) reference those as OG images
- Spiritual leaders page uses first leader's photo as OG image
- All pages have proper title, description, and fallback values

Implements georgenijo/St-Basils-Boston-Web#73

## Test plan

- [ ] Verify each page's `<meta property="og:title">` renders correctly
- [ ] Verify `<meta property="og:description">` is populated on all 8 pages
- [ ] Verify OG images are 1200x630 on pages with hero images
- [ ] Verify pages without Sanity data fall back to hardcoded descriptions
- [ ] Verify no duplicate meta tags via View Source