### PR TITLE
feat/P3-07-logout

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -7,5 +7,5 @@ import { createClient } from '@/lib/supabase/server'
 export async function logout() {
   const supabase = await createClient()
   await supabase.auth.signOut()
-  redirect('/login')
+  redirect('/')
 }

--- a/src/actions/login.ts
+++ b/src/actions/login.ts
@@ -11,9 +11,18 @@ type LoginState = {
   errors?: Record<string, string[]>
 }
 
+/**
+ * Validates that a redirect URL is internal-only to prevent open redirect attacks.
+ * Must start with `/` and not contain protocol schemes or protocol-relative URLs.
+ */
+function isValidRedirectUrl(url: string): boolean {
+  return url.startsWith('/') && !url.startsWith('//') && !url.includes('://')
+}
+
 export async function login(prevState: LoginState, formData: FormData): Promise<LoginState> {
   const email = formData.get('email') as string
   const password = formData.get('password') as string
+  const redirectTo = formData.get('redirectTo') as string | null
 
   const errors: Record<string, string[]> = {}
 
@@ -43,5 +52,11 @@ export async function login(prevState: LoginState, formData: FormData): Promise<
   }
 
   revalidatePath('/', 'layout')
-  redirect('/admin/dashboard')
+
+  const destination =
+    redirectTo && isValidRedirectUrl(redirectTo)
+      ? redirectTo
+      : '/admin/dashboard'
+
+  redirect(destination)
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,7 +1,9 @@
+import { redirect } from 'next/navigation'
 import Image from 'next/image'
 
 import type { Metadata } from 'next'
 
+import { createClient } from '@/lib/supabase/server'
 import { LoginForm } from '@/components/features/LoginForm'
 
 export const metadata: Metadata = {
@@ -9,7 +11,22 @@ export const metadata: Metadata = {
   description: 'Sign in to the St. Basil\'s church admin portal.',
 }
 
-export default function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirectTo?: string }>
+}) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (user) {
+    redirect('/admin/dashboard')
+  }
+
+  const { redirectTo } = await searchParams
+
   return (
     <main className="w-full max-w-md px-4">
       <div className="rounded-2xl bg-white p-8 shadow-md sm:p-10">
@@ -26,7 +43,7 @@ export default function LoginPage() {
           </h1>
         </div>
 
-        <LoginForm />
+        <LoginForm redirectTo={redirectTo} />
       </div>
     </main>
   )

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,14 @@
+import { type NextRequest, NextResponse } from 'next/server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  await supabase.auth.signOut()
+
+  const url = request.nextUrl.clone()
+  url.pathname = '/'
+  url.search = ''
+
+  return NextResponse.redirect(url, { status: 303 })
+}

--- a/src/components/features/LoginForm.tsx
+++ b/src/components/features/LoginForm.tsx
@@ -5,7 +5,11 @@ import { useActionState } from 'react'
 import { login } from '@/actions/login'
 import { Button } from '@/components/ui'
 
-export function LoginForm() {
+interface LoginFormProps {
+  redirectTo?: string
+}
+
+export function LoginForm({ redirectTo }: LoginFormProps) {
   const [state, formAction, pending] = useActionState(login, {
     success: false,
     message: '',
@@ -13,6 +17,10 @@ export function LoginForm() {
 
   return (
     <form action={formAction} className="space-y-5">
+      {redirectTo && (
+        <input type="hidden" name="redirectTo" value={redirectTo} />
+      )}
+
       {state.message && !state.errors && (
         <div
           role="alert"


### PR DESCRIPTION
## Summary
- Creates `POST /api/auth/logout` route handler that signs out and redirects to homepage
- Updates logout server action to redirect to `/` instead of `/login`
- Adds `redirectTo` query param support to the login flow — middleware already sets it when redirecting unauthenticated users, now the login action reads and validates it (internal URLs only, no open redirects)
- Redirects already-authenticated users visiting `/login` to `/admin/dashboard`

Implements georgenijo/St-Basils-Boston-Web#80

## Test plan
- [ ] Visit `/api/auth/logout` via POST — should sign out and redirect to `/`
- [ ] Log out from admin dashboard — should land on homepage
- [ ] Visit `/admin/events` while logged out — should redirect to `/login?redirectTo=/admin/events`, then after login go to `/admin/events`
- [ ] Manually set `?redirectTo=https://evil.com` on login — should ignore and redirect to `/admin/dashboard`
- [ ] Visit `/login` while already authenticated — should redirect to `/admin/dashboard`