### PR TITLE
feat/4a-03-contact-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "st-basils-boston-web",
       "version": "0.1.0",
       "dependencies": {
+        "@marsidev/react-turnstile": "^1.4.2",
         "@react-email/components": "^1.0.10",
         "@sanity/image-url": "^2.0.3",
         "@sanity/vision": "^4.22.0",
@@ -4007,6 +4008,16 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.4.2.tgz",
+      "integrity": "sha512-xs1qOuyeMOz6t9BXXCXWiukC0/0+48vR08B7uwNdG05wCMnbcNgxiFmdFKDOFbM76qFYFRYlGeRfhfq1U/iZmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
+      }
     },
     "node_modules/@mux/mux-data-google-ima": {
       "version": "0.3.15",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.4.2",
     "@react-email/components": "^1.0.10",
     "@sanity/image-url": "^2.0.3",
     "@sanity/vision": "^4.22.0",

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from 'next'
+
+import { PageHero, SectionHeader, Card } from '@/components/ui'
+import { ScrollReveal } from '@/components/ui/ScrollReveal'
+import { ContactForm } from '@/components/features/ContactForm'
+
+export const metadata: Metadata = {
+  title: 'Contact Us',
+  description:
+    "Get in touch with St. Basil's Syriac Orthodox Church in Boston. Reach us by phone, email, or visit us at 73 Ellis Street, Newton, MA 02464.",
+  openGraph: {
+    title: "Contact Us | St. Basil's Syriac Orthodox Church",
+    description:
+      "Get in touch with St. Basil's Syriac Orthodox Church in Boston. Reach us by phone, email, or visit us.",
+  },
+}
+
+const contactInfo = [
+  {
+    title: 'Visit Us',
+    detail: '73 Ellis Street\nNewton, MA 02464',
+    href: 'https://maps.google.com/?q=73+Ellis+Street+Newton+MA+02464',
+    linkLabel: 'Get Directions',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-7 w-7"
+      >
+        <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+        <circle cx="12" cy="10" r="3" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Call Us',
+    detail: '(617) 244-0608',
+    href: 'tel:+16172440608',
+    linkLabel: 'Call Now',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-7 w-7"
+      >
+        <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+      </svg>
+    ),
+  },
+  {
+    title: 'Email Us',
+    detail: 'info@stbasilsboston.org',
+    href: 'mailto:info@stbasilsboston.org',
+    linkLabel: 'Send Email',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="h-7 w-7"
+      >
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+      </svg>
+    ),
+  },
+]
+
+export default function ContactPage() {
+  return (
+    <main>
+      <PageHero title="Contact Us" backgroundImage="/images/about/church-exterior.jpg" />
+
+      {/* Contact Info Cards */}
+      <section className="bg-sand py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Get in Touch"
+              subtitle="We would love to hear from you. Whether you have a question, need prayer, or want to learn more about our community, please reach out."
+            />
+          </ScrollReveal>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {contactInfo.map((info, i) => (
+              <ScrollReveal key={info.title} delay={i * 0.12}>
+                <Card className="h-full text-center transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
+                  <Card.Body className="flex flex-col items-center space-y-4">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-full bg-burgundy-700/10 text-burgundy-700">
+                      {info.icon}
+                    </div>
+                    <h3 className="font-heading text-xl font-semibold text-wood-900">
+                      {info.title}
+                    </h3>
+                    <p className="whitespace-pre-line font-body text-base text-wood-800/80">
+                      {info.detail}
+                    </p>
+                    <a
+                      href={info.href}
+                      className="font-body text-sm font-medium text-burgundy-700 underline underline-offset-4 hover:text-burgundy-800"
+                      {...(info.href.startsWith('http')
+                        ? { target: '_blank', rel: 'noopener noreferrer' }
+                        : {})}
+                    >
+                      {info.linkLabel}
+                    </a>
+                  </Card.Body>
+                </Card>
+              </ScrollReveal>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Contact Form */}
+      <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Send Us a Message"
+              subtitle="Fill out the form below and we will get back to you as soon as possible."
+            />
+          </ScrollReveal>
+
+          <ScrollReveal className="relative mt-12">
+            <ContactForm />
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* Service Times */}
+      <section className="bg-charcoal py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Sunday Services"
+              className="[&_h2]:text-cream-50 [&_p]:text-cream-50/60"
+            />
+          </ScrollReveal>
+
+          <div className="mt-12 grid gap-6 sm:grid-cols-2">
+            <ScrollReveal delay={0}>
+              <Card variant="outlined" className="border-cream-50/10 bg-cream-50/5 text-center">
+                <Card.Body className="space-y-2">
+                  <h3 className="font-heading text-xl font-semibold text-cream-50">
+                    Morning Prayer
+                  </h3>
+                  <p className="font-body text-2xl font-medium text-gold-500">8:30 AM</p>
+                </Card.Body>
+              </Card>
+            </ScrollReveal>
+            <ScrollReveal delay={0.12}>
+              <Card variant="outlined" className="border-cream-50/10 bg-cream-50/5 text-center">
+                <Card.Body className="space-y-2">
+                  <h3 className="font-heading text-xl font-semibold text-cream-50">
+                    Holy Qurbono
+                  </h3>
+                  <p className="font-body text-2xl font-medium text-gold-500">9:15 AM</p>
+                </Card.Body>
+              </Card>
+            </ScrollReveal>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/features/ContactForm.tsx
+++ b/src/components/features/ContactForm.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useActionState, useRef, useEffect } from 'react'
+import { Turnstile, type TurnstileInstance } from '@marsidev/react-turnstile'
+
+import { submitContact } from '@/actions/contact'
+import { Button } from '@/components/ui'
+import { cn } from '@/lib/utils'
+
+const initialState = {
+  success: false,
+  message: '',
+  errors: undefined as Record<string, string[]> | undefined,
+}
+
+function FieldError({ errors }: { errors?: string[] }) {
+  if (!errors?.length) return null
+  return (
+    <p className="mt-1.5 font-body text-sm text-red-600" role="alert">
+      {errors[0]}
+    </p>
+  )
+}
+
+export function ContactForm() {
+  const [state, action, isPending] = useActionState(submitContact, initialState)
+  const formRef = useRef<HTMLFormElement>(null)
+  const turnstileRef = useRef<TurnstileInstance>(null)
+
+  useEffect(() => {
+    if (state.success) {
+      formRef.current?.reset()
+      turnstileRef.current?.reset()
+    }
+  }, [state])
+
+  if (state.success) {
+    return (
+      <div className="rounded-2xl border border-green-200 bg-green-50 p-8 text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+          <svg
+            className="h-6 w-6 text-green-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+          </svg>
+        </div>
+        <h3 className="font-heading text-xl font-semibold text-wood-900">Message Sent</h3>
+        <p className="mt-2 font-body text-base text-wood-800/80">{state.message}</p>
+      </div>
+    )
+  }
+
+  const inputBase =
+    'w-full rounded-lg border bg-cream-50 px-4 py-3 font-body text-base text-wood-800 placeholder:text-wood-800/40 transition-colors focus:border-burgundy-700 focus:outline-none focus:ring-2 focus:ring-burgundy-700/20'
+
+  return (
+    <form ref={formRef} action={action} className="space-y-6">
+      {/* Honeypot — hidden from real users */}
+      <div className="absolute -left-[9999px]" aria-hidden="true">
+        <label htmlFor="website">Website</label>
+        <input type="text" id="website" name="website" tabIndex={-1} autoComplete="off" />
+      </div>
+
+      {/* Server error message */}
+      {!state.success && state.message && !state.errors && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3" role="alert">
+          <p className="font-body text-sm text-red-600">{state.message}</p>
+        </div>
+      )}
+
+      <div className="grid gap-6 sm:grid-cols-2">
+        <div>
+          <label htmlFor="name" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+            Name <span className="text-burgundy-700">*</span>
+          </label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            required
+            maxLength={100}
+            placeholder="Your full name"
+            className={cn(inputBase, state.errors?.name && 'border-red-400')}
+          />
+          <FieldError errors={state.errors?.name} />
+        </div>
+
+        <div>
+          <label htmlFor="email" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+            Email <span className="text-burgundy-700">*</span>
+          </label>
+          <input
+            type="email"
+            id="email"
+            name="email"
+            required
+            placeholder="your@email.com"
+            className={cn(inputBase, state.errors?.email && 'border-red-400')}
+          />
+          <FieldError errors={state.errors?.email} />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="subject" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          Subject <span className="text-burgundy-700">*</span>
+        </label>
+        <input
+          type="text"
+          id="subject"
+          name="subject"
+          required
+          maxLength={200}
+          placeholder="What is this regarding?"
+          className={cn(inputBase, state.errors?.subject && 'border-red-400')}
+        />
+        <FieldError errors={state.errors?.subject} />
+      </div>
+
+      <div>
+        <label htmlFor="message" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          Message <span className="text-burgundy-700">*</span>
+        </label>
+        <textarea
+          id="message"
+          name="message"
+          required
+          rows={6}
+          maxLength={5000}
+          placeholder="How can we help you?"
+          className={cn(inputBase, 'resize-y', state.errors?.message && 'border-red-400')}
+        />
+        <FieldError errors={state.errors?.message} />
+      </div>
+
+      <Turnstile
+        ref={turnstileRef}
+        siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!}
+        options={{ theme: 'light' }}
+      />
+
+      <Button type="submit" disabled={isPending} className="w-full sm:w-auto">
+        {isPending ? (
+          <span className="flex items-center gap-2">
+            <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Sending...
+          </span>
+        ) : (
+          'Send Message'
+        )}
+      </Button>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- Add `/contact` page with PageHero, contact info cards (address, phone, email), and a contact form section with service times
- Add `ContactForm` client component with `useActionState` wiring to the `submitContact` server action, honeypot field, Cloudflare Turnstile widget, field validation feedback, loading spinner, and success state
- Install `@marsidev/react-turnstile` for CAPTCHA integration
- Page metadata configured with Open Graph tags

Implements georgenijo/St-Basils-Boston-Web#84

## Test plan
- [ ] Verify page loads at `/contact` with hero, info cards, form, and service times sections
- [ ] Verify form validates required fields and shows error messages
- [ ] Verify honeypot field is hidden from users
- [ ] Verify Turnstile widget renders (requires `NEXT_PUBLIC_TURNSTILE_SITE_KEY`)
- [ ] Verify loading state shows spinner on submit
- [ ] Verify success message displays after successful submission
- [ ] Verify server error messages display correctly
- [ ] Verify responsive layout at 375px, 768px, 1024px, 1280px
- [ ] Verify keyboard navigation through all form fields