### PR TITLE
feat: events database schema + RLS

### DIFF
--- a/supabase/migrations/20260325000001_create_events.sql
+++ b/supabase/migrations/20260325000001_create_events.sql
@@ -1,0 +1,186 @@
+-- Migration: Create events, recurrence_rules, and event_instances tables
+-- Phase: 4b
+-- Ticket: 4b-01
+
+-- ─── Enum Types ────────────────────────────────────────────────────────
+
+CREATE TYPE event_category AS ENUM ('liturgical', 'community', 'special');
+
+-- ─── Events Table ──────────────────────────────────────────────────────
+
+CREATE TABLE public.events (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  title TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  description JSONB,
+  location TEXT,
+  start_at TIMESTAMPTZ NOT NULL,
+  end_at TIMESTAMPTZ,
+  is_recurring BOOLEAN DEFAULT false NOT NULL,
+  category event_category NOT NULL DEFAULT 'community',
+  created_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_events_slug ON public.events(slug);
+CREATE INDEX idx_events_start_at ON public.events(start_at);
+CREATE INDEX idx_events_category ON public.events(category);
+CREATE INDEX idx_events_is_recurring ON public.events(is_recurring);
+
+-- Enable RLS
+ALTER TABLE public.events ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Public can read events"
+  ON public.events FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+CREATE POLICY "Admins can insert events"
+  ON public.events FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can update events"
+  ON public.events FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can delete events"
+  ON public.events FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_events_updated_at
+  BEFORE UPDATE ON public.events
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─── Recurrence Rules Table ────────────────────────────────────────────
+
+CREATE TABLE public.recurrence_rules (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  rrule_string TEXT NOT NULL,
+  dtstart TIMESTAMPTZ NOT NULL,
+  until TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_recurrence_rules_event_id ON public.recurrence_rules(event_id);
+
+-- Enable RLS
+ALTER TABLE public.recurrence_rules ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Public can read recurrence rules"
+  ON public.recurrence_rules FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+CREATE POLICY "Admins can insert recurrence rules"
+  ON public.recurrence_rules FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can update recurrence rules"
+  ON public.recurrence_rules FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can delete recurrence rules"
+  ON public.recurrence_rules FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_recurrence_rules_updated_at
+  BEFORE UPDATE ON public.recurrence_rules
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─── Event Instances Table ─────────────────────────────────────────────
+-- Stores exceptions and cancellations for recurring events.
+-- When a single occurrence of a recurring event needs to be modified
+-- or cancelled, an instance row is created.
+
+CREATE TABLE public.event_instances (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  original_date TIMESTAMPTZ NOT NULL,
+  is_cancelled BOOLEAN DEFAULT false NOT NULL,
+  title_override TEXT,
+  description_override JSONB,
+  location_override TEXT,
+  start_at_override TIMESTAMPTZ,
+  end_at_override TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_event_instances_event_id ON public.event_instances(event_id);
+CREATE INDEX idx_event_instances_original_date ON public.event_instances(original_date);
+
+-- Unique constraint: one instance row per event per original date
+CREATE UNIQUE INDEX idx_event_instances_event_date
+  ON public.event_instances(event_id, original_date);
+
+-- Enable RLS
+ALTER TABLE public.event_instances ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Public can read event instances"
+  ON public.event_instances FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+CREATE POLICY "Admins can insert event instances"
+  ON public.event_instances FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can update event instances"
+  ON public.event_instances FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+CREATE POLICY "Admins can delete event instances"
+  ON public.event_instances FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_event_instances_updated_at
+  BEFORE UPDATE ON public.event_instances
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -100,3 +100,419 @@ INSERT INTO auth.identities (
 UPDATE public.profiles
 SET role = 'admin', updated_at = now()
 WHERE id = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
+-- ─── Seed Events ──────────────────────────────────────────────────────
+-- Phase: 4b
+-- Ticket: 4b-01
+--
+-- Seeds recurring Sunday services and liturgical events from the
+-- existing hardcoded calendar (events-calendar.html, 2024-2026).
+-- All events are created_by the seeded admin user.
+
+-- ── Recurring: Sunday Morning Prayer ──────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111101',
+  'Morning Prayer',
+  'sunday-morning-prayer',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Weekly Sunday morning prayer service."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2024-01-07T08:30:00-05:00',
+  '2024-01-07T09:15:00-05:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222201',
+  '11111111-1111-1111-1111-111111111101',
+  'FREQ=WEEKLY;BYDAY=SU',
+  '2024-01-07T08:30:00-05:00'
+);
+
+-- ── Recurring: Sunday Holy Qurbono ────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111102',
+  'Holy Qurbono',
+  'sunday-holy-qurbono',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Weekly Sunday Holy Qurbono (Divine Liturgy)."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2024-01-07T09:15:00-05:00',
+  '2024-01-07T11:00:00-05:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222202',
+  '11111111-1111-1111-1111-111111111102',
+  'FREQ=WEEKLY;BYDAY=SU',
+  '2024-01-07T09:15:00-05:00'
+);
+
+-- ── Recurring Annual: Christmas ───────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111103',
+  'Christmas — Nativity of Our Lord',
+  'christmas',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Celebration of the Nativity of Our Lord Jesus Christ."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2024-12-25T09:00:00-05:00',
+  '2024-12-25T12:00:00-05:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222203',
+  '11111111-1111-1111-1111-111111111103',
+  'FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=25',
+  '2024-12-25T09:00:00-05:00'
+);
+
+-- ── Recurring Annual: Circumcision of Christ / New Year ───────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111104',
+  'Circumcision of Christ',
+  'circumcision-of-christ',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Circumcision of Our Lord."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-01-01T09:00:00-05:00',
+  '2025-01-01T12:00:00-05:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222204',
+  '11111111-1111-1111-1111-111111111104',
+  'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1',
+  '2025-01-01T09:00:00-05:00'
+);
+
+-- ── Recurring Annual: Denho / Epiphany ────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111105',
+  'Denho (Epiphany)',
+  'denho-epiphany',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of Denho — the Baptism of Our Lord (Epiphany)."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-01-06T09:00:00-05:00',
+  '2025-01-06T12:00:00-05:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222205',
+  '11111111-1111-1111-1111-111111111105',
+  'FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=6',
+  '2025-01-06T09:00:00-05:00'
+);
+
+-- ── Recurring Annual: Annunciation ────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111106',
+  'Annunciation to the Blessed Virgin Mary',
+  'annunciation',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Annunciation to the Blessed Virgin Mary."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-03-25T09:00:00-04:00',
+  '2025-03-25T12:00:00-04:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222206',
+  '11111111-1111-1111-1111-111111111106',
+  'FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=25',
+  '2025-03-25T09:00:00-04:00'
+);
+
+-- ── Recurring Annual: Feast of the Apostles ───────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111107',
+  'Feast of the Holy Apostles',
+  'feast-of-the-apostles',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Holy Apostles Peter and Paul."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-06-29T09:00:00-04:00',
+  '2025-06-29T12:00:00-04:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222207',
+  '11111111-1111-1111-1111-111111111107',
+  'FREQ=YEARLY;BYMONTH=6;BYMONTHDAY=29',
+  '2025-06-29T09:00:00-04:00'
+);
+
+-- ── Recurring Annual: Transfiguration ─────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111108',
+  'Transfiguration of Our Lord',
+  'transfiguration',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Transfiguration of Our Lord on Mount Tabor."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-08-06T09:00:00-04:00',
+  '2025-08-06T12:00:00-04:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222208',
+  '11111111-1111-1111-1111-111111111108',
+  'FREQ=YEARLY;BYMONTH=8;BYMONTHDAY=6',
+  '2025-08-06T09:00:00-04:00'
+);
+
+-- ── Recurring Annual: Assumption of the Blessed Virgin Mary ───────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111109',
+  'Assumption of the Blessed Virgin Mary',
+  'assumption',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Assumption (Shunaya) of the Blessed Virgin Mary."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-08-15T09:00:00-04:00',
+  '2025-08-15T12:00:00-04:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222209',
+  '11111111-1111-1111-1111-111111111109',
+  'FREQ=YEARLY;BYMONTH=8;BYMONTHDAY=15',
+  '2025-08-15T09:00:00-04:00'
+);
+
+-- ── Recurring Annual: Nativity of the Blessed Virgin Mary ─────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111110',
+  'Nativity of the Blessed Virgin Mary',
+  'nativity-of-st-mary',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Nativity of the Blessed Virgin Mary."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-09-08T09:00:00-04:00',
+  '2025-09-08T12:00:00-04:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222210',
+  '11111111-1111-1111-1111-111111111110',
+  'FREQ=YEARLY;BYMONTH=9;BYMONTHDAY=8',
+  '2025-09-08T09:00:00-04:00'
+);
+
+-- ── Recurring Annual: Nativity Lent ───────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'Nativity Lent',
+  'nativity-lent',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Nativity Lent (December 15–24) — period of fasting and preparation for the feast of the Nativity."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2024-12-15T00:00:00-05:00',
+  '2024-12-24T23:59:59-05:00',
+  true,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+INSERT INTO public.recurrence_rules (id, event_id, rrule_string, dtstart)
+VALUES (
+  '22222222-2222-2222-2222-222222222211',
+  '11111111-1111-1111-1111-111111111111',
+  'FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=15',
+  '2024-12-15T00:00:00-05:00'
+);
+
+-- ── One-Time: Church Perunnal 2025 ────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111112',
+  'Church Perunnal',
+  'church-perunnal-2025',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Annual parish feast (Perunnal) of St. Basil''s Syriac Orthodox Church."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2025-09-27T09:00:00-04:00',
+  '2025-09-28T17:00:00-04:00',
+  false,
+  'special',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Great Lent 2026 ─────────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111113',
+  'Great Lent',
+  'great-lent-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"The Great Lent — 50-day fasting period leading up to Easter."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-02-16T00:00:00-05:00',
+  '2026-04-04T23:59:59-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Palm Sunday 2026 ────────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111114',
+  'Palm Sunday (Hosanna)',
+  'palm-sunday-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Palm Sunday — commemorating the triumphant entry of Our Lord into Jerusalem."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-03-29T08:30:00-04:00',
+  '2026-03-29T12:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Holy Thursday 2026 ──────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111115',
+  'Holy Thursday',
+  'holy-thursday-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Holy Thursday — commemoration of the Last Supper and the Washing of Feet."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-04-02T18:00:00-04:00',
+  '2026-04-02T21:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Good Friday 2026 ────────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111116',
+  'Good Friday',
+  'good-friday-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Good Friday — solemn commemoration of the Crucifixion of Our Lord."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-04-03T09:00:00-04:00',
+  '2026-04-03T15:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Holy Saturday 2026 ──────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111117',
+  'Holy Saturday',
+  'holy-saturday-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Holy Saturday — the day of rest and waiting before the Resurrection."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-04-04T18:00:00-04:00',
+  '2026-04-04T22:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Easter 2026 ─────────────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111118',
+  'Easter — Resurrection of Our Lord',
+  'easter-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Easter — the glorious Resurrection of Our Lord Jesus Christ."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-04-05T06:00:00-04:00',
+  '2026-04-05T12:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Ascension 2026 ──────────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111119',
+  'Ascension of Our Lord',
+  'ascension-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of the Ascension of Our Lord — 40 days after Easter."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-05-14T09:00:00-04:00',
+  '2026-05-14T12:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);
+
+-- ── One-Time: Pentecost 2026 ──────────────────────────────────────────
+
+INSERT INTO public.events (id, title, slug, description, location, start_at, end_at, is_recurring, category, created_by)
+VALUES (
+  '11111111-1111-1111-1111-111111111120',
+  'Pentecost',
+  'pentecost-2026',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Feast of Pentecost — the descent of the Holy Spirit upon the Apostles, 50 days after Easter."}]}]}'::jsonb,
+  'St. Basil''s Syriac Orthodox Church, 73 Ellis Street, Newton, MA 02464',
+  '2026-05-24T09:00:00-04:00',
+  '2026-05-24T12:00:00-04:00',
+  false,
+  'liturgical',
+  'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+);


### PR DESCRIPTION
## Summary

- Creates `events`, `recurrence_rules`, and `event_instances` tables with `event_category` enum (`liturgical`, `community`, `special`)
- RLS: public read on all three tables, admin-only write (insert/update/delete)
- Seeds recurring Sunday services (Morning Prayer, Holy Qurbono) and annual liturgical feasts (Christmas, Epiphany, Annunciation, Transfiguration, Assumption, etc.)
- Seeds one-time 2025-2026 events (Church Perunnal, Great Lent, Holy Week, Easter, Ascension, Pentecost)

Implements georgenijo/St-Basils-Boston-Web#85

## Test plan

- [ ] `supabase db reset` runs migration and seed without errors
- [ ] All three tables created with correct columns and types
- [ ] `event_category` enum exists with three values
- [ ] Foreign keys cascade correctly (delete event → deletes rules + instances)
- [ ] Anon user can SELECT from all three tables
- [ ] Unauthenticated user cannot INSERT/UPDATE/DELETE
- [ ] Admin user can INSERT/UPDATE/DELETE on all three tables
- [ ] Seed data populates 20 events with recurrence rules for recurring ones