### PR TITLE
feat/4b-03-calendar-page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -45,6 +45,11 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: '/events-calendar',
+        destination: '/events',
+        permanent: true,
+      },
+      {
         source: '/useful-links.html',
         destination: '/useful-links',
         permanent: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,13 @@
       "name": "st-basils-boston-web",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.20",
+        "@fullcalendar/daygrid": "^6.1.20",
+        "@fullcalendar/interaction": "^6.1.20",
+        "@fullcalendar/list": "^6.1.20",
+        "@fullcalendar/react": "^6.1.20",
+        "@fullcalendar/rrule": "^6.1.20",
+        "@fullcalendar/timegrid": "^6.1.20",
         "@marsidev/react-turnstile": "^1.4.2",
         "@react-email/components": "^1.0.10",
         "@sanity/image-url": "^2.0.3",
@@ -24,6 +31,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "resend": "^6.9.4",
+        "rrule": "^2.8.1",
         "sanity": "^4.22.0",
         "styled-components": "^6.3.12",
         "tailwind-merge": "^3.5.0",
@@ -2989,6 +2997,75 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.20.tgz",
+      "integrity": "sha512-1cukXLlePFiJ8YKXn/4tMKsy0etxYLCkXk8nUCFi11nRONF2Ba2CD5b21/ovtOO2tL6afTJfwmc1ed3HG7eB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.20.tgz",
+      "integrity": "sha512-AO9vqhkLP77EesmJzuU+IGXgxNulsA8mgQHynclJ8U70vSwAVnbcLG9qftiTAFSlZjiY/NvhE7sflve6cJelyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.20.tgz",
+      "integrity": "sha512-p6txmc5txL0bMiPaJxe2ip6o0T384TyoD2KGdsU6UjZ5yoBlaY+dg7kxfnYKpYMzEJLG58n+URrHr2PgNL2fyA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/list": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-6.1.20.tgz",
+      "integrity": "sha512-7Hzkbb7uuSqrXwTyD0Ld/7SwWNxPD6SlU548vtkIpH55rZ4qquwtwYdMPgorHos5OynHA4OUrZNcH51CjrCf2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.20.tgz",
+      "integrity": "sha512-1w0pZtceaUdfAnxMSCGHCQalhi+mR1jOe76sXzyAXpcPz/Lf0zHSdcGK/U2XpZlnQgQtBZW+d+QBnnzVQKCxAA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@fullcalendar/rrule": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/rrule/-/rrule-6.1.20.tgz",
+      "integrity": "sha512-5Awk7bmaA97hSZRpIBehenXkYreVIvx8nnaMFZ/LDGRuK1mgbR4vSUrDTvVU+oEqqKnj/rqMBByWqN5NeehQxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20",
+        "rrule": "^2.6.0"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.20",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.20.tgz",
+      "integrity": "sha512-4H+/MWbz3ntA50lrPif+7TsvMeX3R1GSYjiLULz0+zEJ7/Yfd9pupZmAwUs/PBpA6aAcFmeRr0laWfcz1a9V1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.20"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.20"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -16781,6 +16858,16 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/preferred-pm": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-4.1.1.tgz",
@@ -17957,6 +18044,15 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.20",
+    "@fullcalendar/daygrid": "^6.1.20",
+    "@fullcalendar/interaction": "^6.1.20",
+    "@fullcalendar/list": "^6.1.20",
+    "@fullcalendar/react": "^6.1.20",
+    "@fullcalendar/rrule": "^6.1.20",
+    "@fullcalendar/timegrid": "^6.1.20",
     "@marsidev/react-turnstile": "^1.4.2",
     "@react-email/components": "^1.0.10",
     "@sanity/image-url": "^2.0.3",
@@ -28,6 +35,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "resend": "^6.9.4",
+    "rrule": "^2.8.1",
     "sanity": "^4.22.0",
     "styled-components": "^6.3.12",
     "tailwind-merge": "^3.5.0",

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from 'next'
+
+import { createClient } from '@/lib/supabase/server'
+import { PageHero, SectionHeader, ScrollReveal } from '@/components/ui'
+import { EventCalendar } from '@/components/features/EventCalendar'
+
+import type { CalendarEvent } from '@/components/features/EventCalendar'
+
+export const metadata: Metadata = {
+  title: 'Events Calendar',
+  description:
+    "View upcoming services, community gatherings, and special events at St. Basil's Syriac Orthodox Church in Boston.",
+  openGraph: {
+    title: "Events Calendar | St. Basil's Syriac Orthodox Church",
+    description:
+      "View upcoming services, community gatherings, and special events at St. Basil's Syriac Orthodox Church.",
+  },
+}
+
+interface EventRow {
+  id: string
+  title: string
+  slug: string
+  description: unknown
+  location: string | null
+  start_at: string
+  end_at: string | null
+  is_recurring: boolean
+  category: 'liturgical' | 'community' | 'special'
+  recurrence_rules: {
+    rrule_string: string
+    dtstart: string
+    until: string | null
+  }[]
+}
+
+function transformEvents(events: EventRow[]): CalendarEvent[] {
+  return events.map((event) => {
+    const base = {
+      id: event.id,
+      title: event.title,
+      extendedProps: {
+        slug: event.slug,
+        category: event.category,
+        location: event.location,
+      },
+    }
+
+    if (event.is_recurring && event.recurrence_rules.length > 0) {
+      const rule = event.recurrence_rules[0]
+      const dtstart = new Date(rule.dtstart)
+        .toISOString()
+        .replace(/[-:]/g, '')
+        .split('.')[0]
+      const rruleStr = `DTSTART:${dtstart}Z\nRRULE:${rule.rrule_string}`
+
+      let duration: string | undefined
+      if (event.end_at) {
+        const diffMs = new Date(event.end_at).getTime() - new Date(event.start_at).getTime()
+        const hours = Math.floor(diffMs / 3600000)
+        const minutes = Math.floor((diffMs % 3600000) / 60000)
+        duration = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
+      }
+
+      return { ...base, rrule: rruleStr, duration }
+    }
+
+    return {
+      ...base,
+      start: event.start_at,
+      end: event.end_at || undefined,
+    }
+  })
+}
+
+export default async function EventsPage() {
+  const supabase = await createClient()
+
+  const { data: events } = await supabase
+    .from('events')
+    .select('*, recurrence_rules(*)')
+    .order('start_at', { ascending: true })
+
+  const calendarEvents = transformEvents((events as EventRow[]) || [])
+
+  return (
+    <>
+      <PageHero title="Events Calendar" backgroundImage="/images/about/church-exterior.jpg" />
+
+      <section className="py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Upcoming Events"
+              subtitle="Stay connected with services, community gatherings, and special celebrations."
+              as="h2"
+            />
+          </ScrollReveal>
+
+          <div className="mt-10 md:mt-14">
+            <EventCalendar events={calendarEvents} />
+          </div>
+        </div>
+      </section>
+    </>
+  )
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,3 +84,82 @@ h6 {
     animation: none;
   }
 }
+
+/* FullCalendar theme overrides */
+.fc {
+  --fc-border-color: rgba(74, 55, 41, 0.12);
+  --fc-button-bg-color: #9b1b3d;
+  --fc-button-active-bg-color: #7a1530;
+  --fc-button-hover-bg-color: #7a1530;
+  --fc-button-border-color: #9b1b3d;
+  --fc-button-active-border-color: #7a1530;
+  --fc-button-hover-border-color: #7a1530;
+  --fc-button-text-color: #fffdf8;
+  --fc-today-bg-color: #f5e6eb;
+  --fc-page-bg-color: #fffdf8;
+  --fc-neutral-bg-color: #faedcd;
+  --fc-list-event-hover-bg-color: #f5e6eb;
+  --fc-event-text-color: #fffdf8;
+}
+
+.fc .fc-toolbar-title {
+  font-family: var(--font-heading);
+  color: #352618;
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .fc .fc-toolbar-title {
+    font-size: 1.5rem;
+  }
+}
+
+.fc .fc-col-header-cell-cushion,
+.fc .fc-daygrid-day-number,
+.fc .fc-list-day-text,
+.fc .fc-list-day-side-text {
+  font-family: var(--font-body);
+  color: #4a3729;
+}
+
+.fc .fc-col-header-cell-cushion {
+  font-weight: 500;
+}
+
+.fc .fc-button {
+  font-family: var(--font-body);
+  font-weight: 500;
+}
+
+.fc .fc-button-group > .fc-button {
+  border-radius: 0;
+}
+
+.fc .fc-button-group > .fc-button:first-child {
+  border-top-left-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
+.fc .fc-button-group > .fc-button:last-child {
+  border-top-right-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
+.fc .fc-today-button {
+  border-radius: 0.5rem;
+}
+
+.fc .fc-event {
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+.fc .fc-daygrid-event {
+  padding: 1px 4px;
+}
+
+.fc .fc-toolbar {
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/src/components/features/CalendarSkeleton.tsx
+++ b/src/components/features/CalendarSkeleton.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils'
+
+export function CalendarSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn('animate-pulse', className)}>
+      {/* Filter bar skeleton */}
+      <div className="mb-6 flex gap-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-9 w-24 rounded-lg bg-sand" />
+        ))}
+      </div>
+
+      {/* Calendar skeleton */}
+      <div className="rounded-2xl bg-cream-50 p-4 shadow">
+        {/* Header toolbar */}
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex gap-2">
+            <div className="h-9 w-9 rounded bg-sand" />
+            <div className="h-9 w-9 rounded bg-sand" />
+            <div className="h-9 w-16 rounded bg-sand" />
+          </div>
+          <div className="h-8 w-48 rounded bg-sand" />
+          <div className="hidden gap-1 sm:flex">
+            <div className="h-9 w-16 rounded bg-sand" />
+            <div className="h-9 w-14 rounded bg-sand" />
+            <div className="h-9 w-12 rounded bg-sand" />
+          </div>
+        </div>
+
+        {/* Day headers */}
+        <div className="mb-2 grid grid-cols-7 gap-px">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="h-8 rounded bg-sand" />
+          ))}
+        </div>
+
+        {/* Calendar grid */}
+        <div className="grid grid-cols-7 gap-px">
+          {Array.from({ length: 35 }).map((_, i) => (
+            <div key={i} className="h-20 rounded bg-sand/50" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/features/CalendarView.tsx
+++ b/src/components/features/CalendarView.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import FullCalendar from '@fullcalendar/react'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import listPlugin from '@fullcalendar/list'
+import interactionPlugin from '@fullcalendar/interaction'
+import rrulePlugin from '@fullcalendar/rrule'
+
+import type { EventClickArg } from '@fullcalendar/core'
+import type { CalendarEvent } from '@/components/features/EventCalendar'
+
+const CATEGORY_COLORS: Record<string, { bg: string; border: string }> = {
+  liturgical: { bg: '#9B1B3D', border: '#7A1530' },
+  community: { bg: '#253341', border: '#1c2831' },
+  special: { bg: '#4A3729', border: '#352618' },
+}
+
+interface CalendarViewProps {
+  events: CalendarEvent[]
+}
+
+export function CalendarView({ events }: CalendarViewProps) {
+  const router = useRouter()
+
+  const [initialView] = useState(() =>
+    typeof window !== 'undefined' && window.innerWidth < 768 ? 'listWeek' : 'dayGridMonth'
+  )
+
+  const coloredEvents = events.map((event) => ({
+    ...event,
+    backgroundColor: CATEGORY_COLORS[event.extendedProps.category]?.bg,
+    borderColor: CATEGORY_COLORS[event.extendedProps.category]?.border,
+    textColor: '#FFFDF8',
+  }))
+
+  const handleEventClick = useCallback(
+    (info: EventClickArg) => {
+      const slug = info.event.extendedProps.slug
+      if (slug) {
+        router.push(`/events/${slug}`)
+      }
+    },
+    [router]
+  )
+
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin, rrulePlugin]}
+      initialView={initialView}
+      headerToolbar={{
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridMonth,timeGridWeek,listWeek',
+      }}
+      events={coloredEvents}
+      eventClick={handleEventClick}
+      height="auto"
+      dayMaxEvents={3}
+      eventDisplay="block"
+      nowIndicator
+      fixedWeekCount={false}
+      buttonText={{
+        today: 'Today',
+        month: 'Month',
+        week: 'Week',
+        list: 'List',
+      }}
+    />
+  )
+}

--- a/src/components/features/EventCalendar.tsx
+++ b/src/components/features/EventCalendar.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import dynamic from 'next/dynamic'
+
+import { cn } from '@/lib/utils'
+import { CalendarSkeleton } from '@/components/features/CalendarSkeleton'
+
+const CalendarView = dynamic(
+  () => import('@/components/features/CalendarView').then((mod) => mod.CalendarView),
+  { ssr: false, loading: () => <CalendarSkeleton className="mt-6" /> }
+)
+
+export interface CalendarEvent {
+  id: string
+  title: string
+  start?: string
+  end?: string
+  rrule?: string
+  duration?: string
+  extendedProps: {
+    slug: string
+    category: 'liturgical' | 'community' | 'special'
+    location: string | null
+  }
+}
+
+interface EventCalendarProps {
+  events: CalendarEvent[]
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  liturgical: '#9B1B3D',
+  community: '#253341',
+  special: '#4A3729',
+}
+
+const CATEGORIES = [
+  { value: 'all', label: 'All Events' },
+  { value: 'liturgical', label: 'Liturgical' },
+  { value: 'community', label: 'Community' },
+  { value: 'special', label: 'Special' },
+] as const
+
+type CategoryFilter = (typeof CATEGORIES)[number]['value']
+
+export function EventCalendar({ events }: EventCalendarProps) {
+  const [activeCategory, setActiveCategory] = useState<CategoryFilter>('all')
+
+  const filteredEvents = useMemo(
+    () =>
+      activeCategory === 'all'
+        ? events
+        : events.filter((e) => e.extendedProps.category === activeCategory),
+    [events, activeCategory]
+  )
+
+  return (
+    <div>
+      {/* Category Filter */}
+      <div className="mb-6 flex flex-wrap gap-2" role="group" aria-label="Filter events by category">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.value}
+            onClick={() => setActiveCategory(cat.value)}
+            aria-pressed={activeCategory === cat.value}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors',
+              activeCategory === cat.value
+                ? 'bg-burgundy-700 text-cream-50'
+                : 'bg-sand text-wood-800 hover:bg-burgundy-100'
+            )}
+          >
+            {cat.label}
+            {cat.value !== 'all' && (
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-full"
+                style={{ backgroundColor: CATEGORY_COLORS[cat.value] }}
+                aria-hidden="true"
+              />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Calendar */}
+      <div className="rounded-2xl bg-cream-50 p-2 shadow sm:p-4">
+        <CalendarView events={filteredEvents} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -38,7 +38,7 @@ const navigation: NavItem[] = [
   {
     label: 'Resources',
     children: [
-      { label: 'Events Calendar', href: '/events-calendar' },
+      { label: 'Events Calendar', href: '/events' },
       { label: 'Useful Links', href: '/useful-links' },
       { label: 'First Time Visiting?', href: '/first-time' },
     ],


### PR DESCRIPTION
## Summary
- Adds public `/events` page with FullCalendar (month, week, list views)
- Recurring events expanded via `@fullcalendar/rrule` plugin from Supabase `recurrence_rules`
- Category filter bar with color-coded event types (liturgical/community/special)
- Cream/burgundy theme overrides, loading skeleton, mobile-first list view
- Navbar link updated to `/events`, redirect from `/events-calendar` added

Implements georgenijo/St-Basils-Boston-Web#87

## Test plan
- [ ] Calendar renders with month/week/list view toggles
- [ ] Recurring events appear on correct dates via RRULE expansion
- [ ] Category filter buttons show/hide events by type
- [ ] Calendar matches brand colors (cream bg, burgundy buttons, today highlight)
- [ ] Clicking an event navigates to `/events/[slug]`
- [ ] Loading skeleton visible while calendar JS loads
- [ ] Mobile viewport defaults to list view
- [ ] No SSR errors (dynamic import with `ssr: false`)
- [ ] Responsive at 375px, 768px, 1024px, 1280px
- [ ] Navbar "Events Calendar" link navigates to `/events`
- [ ] `/events-calendar` redirects to `/events`