### PR TITLE
feat: add public announcements feed and homepage banner (#91)

### DIFF
--- a/src/app/(public)/announcements/[slug]/page.tsx
+++ b/src/app/(public)/announcements/[slug]/page.tsx
@@ -1,0 +1,228 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { createClient } from '@/lib/supabase/server'
+import { renderTiptapHTML } from '@/lib/tiptap'
+import { Button, Card, GoldDivider, ScrollReveal } from '@/components/ui'
+
+interface AnnouncementRow {
+  id: string
+  title: string
+  slug: string
+  body: unknown
+  priority: number
+  is_pinned: boolean
+  published_at: string
+  expires_at: string | null
+  created_at: string
+}
+
+const PRIORITY_LABELS: Record<number, string> = {
+  1: 'Low',
+  5: 'Medium',
+  10: 'High',
+}
+
+const PRIORITY_COLORS: Record<number, string> = {
+  1: 'bg-sand text-wood-800',
+  5: 'bg-gold-500/15 text-wood-800',
+  10: 'bg-burgundy-700 text-cream-50',
+}
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const supabase = await createClient()
+
+  const { data: announcement } = await supabase
+    .from('announcements')
+    .select('title')
+    .eq('slug', slug)
+    .single()
+
+  if (!announcement) {
+    return { title: 'Announcement Not Found' }
+  }
+
+  return {
+    title: announcement.title,
+    description: `${announcement.title} — an announcement from St. Basil's Syriac Orthodox Church.`,
+    openGraph: {
+      title: `${announcement.title} | St. Basil's Syriac Orthodox Church`,
+      description: `${announcement.title} — an announcement from St. Basil's Syriac Orthodox Church.`,
+    },
+  }
+}
+
+export default async function AnnouncementDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const supabase = await createClient()
+
+  // RLS ensures only published + non-expired are returned for public users
+  const { data: announcement } = await supabase
+    .from('announcements')
+    .select('*')
+    .eq('slug', slug)
+    .single<AnnouncementRow>()
+
+  if (!announcement) notFound()
+
+  const bodyHtml = renderTiptapHTML(announcement.body)
+
+  return (
+    <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+        <ScrollReveal>
+          {/* Back link */}
+          <Link
+            href="/announcements"
+            className="group mb-8 inline-flex items-center gap-1.5 text-sm font-medium text-burgundy-700 transition-colors hover:text-burgundy-800"
+          >
+            <svg
+              className="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 19 5 12 12 5" />
+            </svg>
+            Back to Announcements
+          </Link>
+
+          {/* Header */}
+          <div className="mb-8">
+            <div className="mb-4 flex flex-wrap items-center gap-3">
+              <time
+                dateTime={announcement.published_at}
+                className="text-sm font-medium text-burgundy-700"
+              >
+                {formatDate(announcement.published_at)}
+              </time>
+              {announcement.priority > 0 && PRIORITY_LABELS[announcement.priority] && (
+                <span
+                  className={`inline-block rounded-full px-3 py-1 text-xs font-medium ${PRIORITY_COLORS[announcement.priority]}`}
+                >
+                  {PRIORITY_LABELS[announcement.priority]}
+                </span>
+              )}
+              {announcement.is_pinned && (
+                <span className="inline-block rounded-full border border-gold-500/40 bg-gold-500/10 px-3 py-1 text-xs font-medium text-wood-800">
+                  Pinned
+                </span>
+              )}
+            </div>
+
+            <h1 className="font-heading text-[2rem] font-semibold leading-[1.2] text-wood-900 md:text-[3rem]">
+              {announcement.title}
+            </h1>
+
+            <GoldDivider className="my-6 mx-0" />
+          </div>
+
+          {/* Announcement details card */}
+          <Card variant="outlined" className="mb-8">
+            <Card.Body className="space-y-3">
+              <DetailRow
+                icon={
+                  <svg
+                    className="h-5 w-5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                    <line x1="16" y1="2" x2="16" y2="6" />
+                    <line x1="8" y1="2" x2="8" y2="6" />
+                    <line x1="3" y1="10" x2="21" y2="10" />
+                  </svg>
+                }
+                label="Published"
+                value={formatDate(announcement.published_at)}
+              />
+              {announcement.expires_at && (
+                <DetailRow
+                  icon={
+                    <svg
+                      className="h-5 w-5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <polyline points="12 6 12 12 16 14" />
+                    </svg>
+                  }
+                  label="Expires"
+                  value={formatDate(announcement.expires_at)}
+                />
+              )}
+            </Card.Body>
+          </Card>
+
+          {/* Body */}
+          {bodyHtml && (
+            <div className="mb-10">
+              <div
+                className="prose prose-wood max-w-none font-body text-wood-800 prose-headings:font-heading prose-headings:text-wood-900 prose-a:text-burgundy-700 prose-a:underline-offset-4 hover:prose-a:text-burgundy-800"
+                dangerouslySetInnerHTML={{ __html: bodyHtml }}
+              />
+            </div>
+          )}
+
+          {/* Back to announcements */}
+          <div className="border-t border-wood-800/10 pt-8">
+            <Button href="/announcements" variant="ghost" size="sm">
+              View All Announcements
+            </Button>
+          </div>
+        </ScrollReveal>
+      </div>
+    </section>
+  )
+}
+
+function DetailRow({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="mt-0.5 shrink-0 text-burgundy-700">{icon}</div>
+      <div>
+        <p className="text-sm font-medium text-wood-800/60">{label}</p>
+        <p className="text-wood-800">{value}</p>
+      </div>
+    </div>
+  )
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}

--- a/src/app/(public)/announcements/page.tsx
+++ b/src/app/(public)/announcements/page.tsx
@@ -1,0 +1,214 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { createClient } from '@/lib/supabase/server'
+import { PageHero, SectionHeader, Card, ScrollReveal, Button } from '@/components/ui'
+
+export const metadata: Metadata = {
+  title: 'Announcements',
+  description:
+    "Stay up to date with the latest announcements from St. Basil's Syriac Orthodox Church in Boston.",
+  openGraph: {
+    title: "Announcements | St. Basil's Syriac Orthodox Church",
+    description:
+      "Stay up to date with the latest announcements from St. Basil's Syriac Orthodox Church.",
+  },
+}
+
+const PAGE_SIZE = 10
+
+const PRIORITY_LABELS: Record<number, string> = {
+  1: 'Low',
+  5: 'Medium',
+  10: 'High',
+}
+
+const PRIORITY_COLORS: Record<number, string> = {
+  1: 'bg-sand text-wood-800',
+  5: 'bg-gold-500/15 text-wood-800',
+  10: 'bg-burgundy-700 text-cream-50',
+}
+
+interface AnnouncementRow {
+  id: string
+  title: string
+  slug: string
+  body: unknown
+  priority: number
+  is_pinned: boolean
+  published_at: string
+  expires_at: string | null
+  created_at: string
+}
+
+interface PageProps {
+  searchParams: Promise<{ page?: string }>
+}
+
+export default async function AnnouncementsPage({ searchParams }: PageProps) {
+  const { page: pageParam } = await searchParams
+  const currentPage = Math.max(1, parseInt(pageParam || '1', 10) || 1)
+  const offset = (currentPage - 1) * PAGE_SIZE
+
+  const supabase = await createClient()
+
+  // RLS handles filtering to published + non-expired
+  const { data: announcements, count } = await supabase
+    .from('announcements')
+    .select('id, title, slug, body, priority, is_pinned, published_at, expires_at, created_at', {
+      count: 'exact',
+    })
+    .order('priority', { ascending: false })
+    .order('published_at', { ascending: false })
+    .range(offset, offset + PAGE_SIZE - 1)
+
+  const items = (announcements as AnnouncementRow[]) || []
+  const totalCount = count || 0
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
+
+  return (
+    <>
+      <PageHero title="Announcements" backgroundImage="/images/about/church-exterior.jpg" />
+
+      <section className="py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader
+              title="Parish Announcements"
+              subtitle="Stay up to date with the latest from our parish."
+              as="h2"
+            />
+          </ScrollReveal>
+
+          {items.length === 0 ? (
+            <ScrollReveal>
+              <p className="mt-12 text-center text-wood-800/60">
+                No announcements at this time. Check back soon.
+              </p>
+            </ScrollReveal>
+          ) : (
+            <>
+              <div className="mt-12 space-y-6">
+                {items.map((item) => (
+                  <ScrollReveal key={item.id}>
+                    <Link href={`/announcements/${item.slug}`} className="group block">
+                      <Card
+                        variant="outlined"
+                        className="transition-shadow duration-200 group-hover:shadow-md"
+                      >
+                        <Card.Body>
+                          <div className="flex flex-wrap items-center gap-3">
+                            <time
+                              dateTime={item.published_at}
+                              className="text-sm font-medium text-burgundy-700"
+                            >
+                              {formatDate(item.published_at)}
+                            </time>
+                            {item.priority > 0 && PRIORITY_LABELS[item.priority] && (
+                              <span
+                                className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${PRIORITY_COLORS[item.priority]}`}
+                              >
+                                {PRIORITY_LABELS[item.priority]}
+                              </span>
+                            )}
+                            {item.is_pinned && (
+                              <span className="inline-block rounded-full border border-gold-500/40 bg-gold-500/10 px-2.5 py-0.5 text-xs font-medium text-wood-800">
+                                Pinned
+                              </span>
+                            )}
+                          </div>
+                          <h3 className="mt-2 font-heading text-xl font-semibold text-wood-900 transition-colors group-hover:text-burgundy-700 md:text-2xl">
+                            {item.title}
+                          </h3>
+                          {extractPlainText(item.body) && (
+                            <p className="mt-3 line-clamp-2 text-sm leading-relaxed text-wood-800/80">
+                              {extractPlainText(item.body)}
+                            </p>
+                          )}
+                        </Card.Body>
+                      </Card>
+                    </Link>
+                  </ScrollReveal>
+                ))}
+              </div>
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <nav
+                  className="mt-12 flex items-center justify-center gap-4"
+                  aria-label="Announcements pagination"
+                >
+                  {currentPage > 1 ? (
+                    <Button
+                      href={`/announcements?page=${currentPage - 1}`}
+                      variant="secondary"
+                      size="sm"
+                    >
+                      Previous
+                    </Button>
+                  ) : (
+                    <span className="inline-flex items-center rounded-lg border border-wood-800/20 px-4 py-2 text-sm font-medium text-wood-800/40">
+                      Previous
+                    </span>
+                  )}
+
+                  <span className="text-sm text-wood-800/60">
+                    Page {currentPage} of {totalPages}
+                  </span>
+
+                  {currentPage < totalPages ? (
+                    <Button
+                      href={`/announcements?page=${currentPage + 1}`}
+                      variant="secondary"
+                      size="sm"
+                    >
+                      Next
+                    </Button>
+                  ) : (
+                    <span className="inline-flex items-center rounded-lg border border-wood-800/20 px-4 py-2 text-sm font-medium text-wood-800/40">
+                      Next
+                    </span>
+                  )}
+                </nav>
+              )}
+            </>
+          )}
+        </div>
+      </section>
+    </>
+  )
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function extractPlainText(body: unknown): string {
+  if (!body) return ''
+
+  let parsed: unknown = body
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      return body as string
+    }
+  }
+
+  if (typeof parsed === 'object' && parsed !== null && 'content' in parsed) {
+    const doc = parsed as { content: Array<{ content?: Array<{ text?: string }> }> }
+    const texts: string[] = []
+    for (const node of doc.content || []) {
+      for (const child of node.content || []) {
+        if (child.text) texts.push(child.text)
+      }
+    }
+    return texts.join(' ')
+  }
+
+  return ''
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 
+import { createClient } from '@/lib/supabase/server'
 import { Button, Card, GoldDivider, ScrollReveal, SectionHeader } from '@/components/ui'
+import { PinnedAnnouncementsBanner } from '@/components/features/PinnedAnnouncementsBanner'
 
 export const metadata: Metadata = {
   title: {
@@ -15,30 +18,42 @@ export const metadata: Metadata = {
   },
 }
 
-const announcements = [
-  {
-    title: 'Great Lent Begins',
-    date: 'March 10, 2026',
-    description:
-      'The season of Great Lent begins this Monday. Join us for special evening prayers throughout the Lenten season.',
-  },
-  {
-    title: 'Annual General Body Meeting',
-    date: 'April 5, 2026',
-    description:
-      'The annual general body meeting will be held following Holy Qurbono. All members are encouraged to attend.',
-  },
-  {
-    title: 'Sunday School Registration',
-    date: 'Open Now',
-    description:
-      'Registration for the upcoming Sunday School year is now open. Contact the Sunday School superintendent for details.',
-  },
-]
+interface AnnouncementRow {
+  id: string
+  title: string
+  slug: string
+  body: unknown
+  priority: number
+  is_pinned: boolean
+  published_at: string
+}
 
-export default function HomePage() {
+export default async function HomePage() {
+  const supabase = await createClient()
+
+  // Fetch recent announcements for the section (max 3)
+  const { data: recentAnnouncements } = await supabase
+    .from('announcements')
+    .select('id, title, slug, body, priority, is_pinned, published_at')
+    .order('priority', { ascending: false })
+    .order('published_at', { ascending: false })
+    .limit(3)
+
+  // Fetch pinned announcements for the banner
+  const { data: pinnedAnnouncements } = await supabase
+    .from('announcements')
+    .select('id, title, slug, priority')
+    .eq('is_pinned', true)
+    .order('priority', { ascending: false })
+
+  const recent = (recentAnnouncements as AnnouncementRow[]) || []
+  const pinned = (pinnedAnnouncements as { id: string; title: string; slug: string; priority: number }[]) || []
+
   return (
     <>
+      {/* ── Pinned Announcements Banner ────────────────────────── */}
+      <PinnedAnnouncementsBanner announcements={pinned} />
+
       {/* ── Hero ─────────────────────────────────────────────── */}
       <section className="relative flex min-h-[calc(100svh-4rem)] items-center justify-center bg-charcoal">
         {/* TODO: Replace gradient with video/image background */}
@@ -128,26 +143,57 @@ export default function HomePage() {
         </ScrollReveal>
       </section>
 
-      {/* ── Announcements (static placeholder) ───────────────── */}
+      {/* ── Announcements ──────────────────────────────────────── */}
       <section className="bg-sand py-16 md:py-22 lg:py-28">
         <ScrollReveal className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
           <SectionHeader
             title="Announcements"
             subtitle="Stay up to date with the latest from our parish."
           />
-          <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {announcements.map((item) => (
-              <Card key={item.title} variant="outlined" className="h-full">
-                <Card.Body>
-                  <p className="text-sm font-medium text-burgundy-700">{item.date}</p>
-                  <h3 className="mt-2 font-heading text-xl font-semibold">{item.title}</h3>
-                  <p className="mt-3 text-sm leading-relaxed text-wood-800/80">
-                    {item.description}
-                  </p>
-                </Card.Body>
-              </Card>
-            ))}
-          </div>
+          {recent.length > 0 ? (
+            <>
+              <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {recent.map((item) => (
+                  <Link
+                    key={item.id}
+                    href={`/announcements/${item.slug}`}
+                    className="group block h-full"
+                  >
+                    <Card
+                      variant="outlined"
+                      className="h-full transition-shadow duration-200 group-hover:shadow-md"
+                    >
+                      <Card.Body>
+                        <time
+                          dateTime={item.published_at}
+                          className="text-sm font-medium text-burgundy-700"
+                        >
+                          {formatDate(item.published_at)}
+                        </time>
+                        <h3 className="mt-2 font-heading text-xl font-semibold text-wood-900 transition-colors group-hover:text-burgundy-700">
+                          {item.title}
+                        </h3>
+                        {extractPlainText(item.body) && (
+                          <p className="mt-3 line-clamp-3 text-sm leading-relaxed text-wood-800/80">
+                            {extractPlainText(item.body)}
+                          </p>
+                        )}
+                      </Card.Body>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+              <div className="mt-10 text-center">
+                <Button href="/announcements" variant="secondary">
+                  View All Announcements
+                </Button>
+              </div>
+            </>
+          ) : (
+            <p className="mt-12 text-center text-wood-800/60">
+              No announcements at this time. Check back soon.
+            </p>
+          )}
         </ScrollReveal>
       </section>
 
@@ -196,4 +242,38 @@ export default function HomePage() {
       </section>
     </>
   )
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function extractPlainText(body: unknown): string {
+  if (!body) return ''
+
+  let parsed: unknown = body
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed)
+    } catch {
+      return body as string
+    }
+  }
+
+  if (typeof parsed === 'object' && parsed !== null && 'content' in parsed) {
+    const doc = parsed as { content: Array<{ content?: Array<{ text?: string }> }> }
+    const texts: string[] = []
+    for (const node of doc.content || []) {
+      for (const child of node.content || []) {
+        if (child.text) texts.push(child.text)
+      }
+    }
+    return texts.join(' ')
+  }
+
+  return ''
 }

--- a/src/components/features/PinnedAnnouncementsBanner.tsx
+++ b/src/components/features/PinnedAnnouncementsBanner.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+import { cn } from '@/lib/utils'
+
+interface PinnedAnnouncement {
+  id: string
+  title: string
+  slug: string
+  priority: number
+}
+
+interface PinnedAnnouncementsBannerProps {
+  announcements: PinnedAnnouncement[]
+  className?: string
+}
+
+export function PinnedAnnouncementsBanner({
+  announcements,
+  className,
+}: PinnedAnnouncementsBannerProps) {
+  const [dismissed, setDismissed] = useState(false)
+
+  if (dismissed || announcements.length === 0) return null
+
+  return (
+    <div
+      className={cn('bg-burgundy-700 text-cream-50', className)}
+      role="region"
+      aria-label="Pinned announcements"
+    >
+      <div className="mx-auto flex max-w-[1200px] items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
+        {/* Bell icon */}
+        <svg
+          className="hidden h-5 w-5 shrink-0 sm:block"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+
+        {/* Announcement content */}
+        <div className="min-w-0 flex-1">
+          {announcements.length === 1 ? (
+            <Link
+              href={`/announcements/${announcements[0].slug}`}
+              className="text-sm font-medium text-cream-50 underline-offset-4 hover:underline"
+            >
+              {announcements[0].title}
+            </Link>
+          ) : (
+            <p className="text-sm font-medium">
+              {announcements.map((a, i) => (
+                <span key={a.id}>
+                  {i > 0 && <span className="mx-1.5 text-cream-50/50" aria-hidden="true">&middot;</span>}
+                  <Link
+                    href={`/announcements/${a.slug}`}
+                    className="text-cream-50 underline-offset-4 hover:underline"
+                  >
+                    {a.title}
+                  </Link>
+                </span>
+              ))}
+            </p>
+          )}
+        </div>
+
+        {/* Dismiss button */}
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="shrink-0 rounded-lg p-1.5 text-cream-50/80 transition-colors hover:bg-cream-50/10 hover:text-cream-50"
+          aria-label="Dismiss announcements banner"
+        >
+          <svg
+            className="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `/announcements` paginated feed page (10 per page) with prev/next pagination, priority badges, pinned indicators, and plain-text excerpts from Tiptap body
- Adds `/announcements/[slug]` detail page with full Tiptap body rendering, published/expiry dates, and 404 for missing/expired slugs (via RLS)
- Adds `<PinnedAnnouncementsBanner>` client component that shows pinned announcements in a burgundy bar at the top of the homepage, dismissible via `useState` (resets on refresh)
- Replaces static hardcoded announcements on the homepage with live Supabase data (3 most recent) linked to their detail pages

Implements georgenijo/St-Basils-Boston-Web#91

## Test plan

- [ ] `/announcements` shows paginated feed of published, non-expired announcements
- [ ] Pagination controls work correctly (prev/next, page count)
- [ ] `/announcements/[slug]` renders full announcement with Tiptap body
- [ ] Visiting a non-existent or expired slug returns 404
- [ ] Homepage shows up to 3 recent announcements with links
- [ ] Homepage pinned banner appears when pinned announcements exist
- [ ] Dismiss button hides the banner (reappears on refresh)
- [ ] Responsive at 375px, 768px, 1024px, 1280px
- [ ] No TypeScript errors (`tsc --noEmit` passes)