### PR TITLE
feat/4c-04-email-broadcast

### DIFF
--- a/src/emails/announcement-broadcast.tsx
+++ b/src/emails/announcement-broadcast.tsx
@@ -1,0 +1,159 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+
+interface AnnouncementBroadcastProps {
+  title: string
+  bodyHtml: string
+  slug: string
+  unsubscribeToken: string
+  siteUrl?: string
+}
+
+const CHURCH_NAME = "St. Basil's Syriac Orthodox Church"
+const CHURCH_ADDRESS = '73 Ellis Street, Newton, MA 02464'
+
+export function AnnouncementBroadcast({
+  title = 'Announcement Title',
+  bodyHtml = '<p>Announcement content goes here.</p>',
+  slug = 'example-announcement',
+  unsubscribeToken = '00000000-0000-0000-0000-000000000000',
+  siteUrl = 'https://stbasilsboston.org',
+}: AnnouncementBroadcastProps) {
+  const readUrl = `${siteUrl}/announcements/${slug}`
+  const unsubscribeUrl = `${siteUrl}/unsubscribe?token=${unsubscribeToken}`
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{title}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Section style={header}>
+            <Text style={headerText}>{CHURCH_NAME}</Text>
+          </Section>
+          <Section style={content}>
+            <Heading style={heading}>{title}</Heading>
+            <Hr style={goldDivider} />
+            <div dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+            <Section style={ctaSection}>
+              <Link href={readUrl} style={ctaButton}>
+                Read on our website
+              </Link>
+            </Section>
+          </Section>
+          <Section style={footerSection}>
+            <Text style={footerText}>
+              {CHURCH_NAME}
+              {'\n'}
+              {CHURCH_ADDRESS}
+            </Text>
+            <Text style={footerText}>
+              <Link href={unsubscribeUrl} style={unsubscribeLink}>
+                Unsubscribe
+              </Link>{' '}
+              from future announcements.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+export default AnnouncementBroadcast
+
+// ─── Styles ──────────────────────────────────────────────────────────
+
+const body = {
+  backgroundColor: '#f6f6f6',
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  margin: '0',
+  padding: '0',
+}
+
+const container = {
+  backgroundColor: '#ffffff',
+  margin: '40px auto',
+  borderRadius: '8px',
+  maxWidth: '560px',
+  overflow: 'hidden' as const,
+}
+
+const header = {
+  backgroundColor: '#253341',
+  padding: '24px 32px',
+  textAlign: 'center' as const,
+}
+
+const headerText = {
+  fontSize: '18px',
+  fontWeight: '600' as const,
+  color: '#FFFDF8',
+  letterSpacing: '0.02em',
+  margin: '0',
+}
+
+const content = {
+  padding: '32px',
+}
+
+const heading = {
+  fontSize: '24px',
+  fontWeight: '600' as const,
+  color: '#352618',
+  lineHeight: '1.3',
+  margin: '0 0 16px',
+}
+
+const goldDivider = {
+  borderColor: '#D4A017',
+  borderWidth: '2px',
+  borderStyle: 'solid' as const,
+  width: '60px',
+  margin: '0 0 24px',
+}
+
+const ctaSection = {
+  marginTop: '24px',
+}
+
+const ctaButton = {
+  display: 'inline-block' as const,
+  padding: '10px 24px',
+  backgroundColor: '#9B1B3D',
+  color: '#FFFDF8',
+  textDecoration: 'none',
+  borderRadius: '8px',
+  fontSize: '14px',
+  fontWeight: '500' as const,
+}
+
+const footerSection = {
+  padding: '24px 32px',
+  borderTop: '1px solid #e5e5e5',
+}
+
+const footerText = {
+  fontSize: '12px',
+  color: '#9ca3af',
+  textAlign: 'center' as const,
+  margin: '0 0 8px',
+  lineHeight: '1.5',
+  whiteSpace: 'pre-line' as const,
+}
+
+const unsubscribeLink = {
+  color: '#9ca3af',
+  textDecoration: 'underline',
+}

--- a/supabase/functions/announcement-email/index.ts
+++ b/supabase/functions/announcement-email/index.ts
@@ -1,0 +1,336 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const RESEND_API_URL = "https://api.resend.com/emails/batch";
+const CHURCH_NAME = "St. Basil's Syriac Orthodox Church";
+const CHURCH_ADDRESS = "73 Ellis Street, Newton, MA 02464";
+const FROM_EMAIL = "announcements@stbasilsboston.org";
+const SITE_URL = Deno.env.get("SITE_URL") ?? "https://stbasilsboston.org";
+const RESEND_BATCH_LIMIT = 100;
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+interface WebhookPayload {
+  type: "INSERT" | "UPDATE";
+  table: string;
+  schema: string;
+  record: AnnouncementRecord;
+}
+
+interface AnnouncementRecord {
+  id: string;
+  title: string;
+  slug: string;
+  body: TiptapNode | null;
+  send_email: boolean;
+  email_sent_at: string | null;
+  published_at: string | null;
+}
+
+interface TiptapNode {
+  type: string;
+  content?: TiptapNode[];
+  text?: string;
+  attrs?: Record<string, unknown>;
+  marks?: TiptapMark[];
+}
+
+interface TiptapMark {
+  type: string;
+  attrs?: Record<string, unknown>;
+}
+
+interface Subscriber {
+  email: string;
+  name: string | null;
+  unsubscribe_token: string;
+}
+
+// ─── Tiptap JSON → HTML ─────────────────────────────────────────────
+
+function tiptapToHtml(node: TiptapNode): string {
+  if (node.type === "text") {
+    let html = escapeHtml(node.text ?? "");
+    if (node.marks) {
+      for (const mark of node.marks) {
+        switch (mark.type) {
+          case "bold":
+            html = `<strong>${html}</strong>`;
+            break;
+          case "italic":
+            html = `<em>${html}</em>`;
+            break;
+          case "strike":
+            html = `<s>${html}</s>`;
+            break;
+          case "code":
+            html = `<code>${html}</code>`;
+            break;
+          case "link": {
+            const href = escapeAttr(String(mark.attrs?.href ?? ""));
+            html = `<a href="${href}" style="color:#9B1B3D;text-decoration:underline;">${html}</a>`;
+            break;
+          }
+        }
+      }
+    }
+    return html;
+  }
+
+  const children = (node.content ?? []).map(tiptapToHtml).join("");
+
+  switch (node.type) {
+    case "doc":
+      return children;
+    case "paragraph":
+      return `<p style="margin:0 0 12px;line-height:1.6;color:#4A3729;">${children}</p>`;
+    case "heading": {
+      const level = node.attrs?.level ?? 2;
+      const fontSize = level === 1 ? "24px" : level === 2 ? "20px" : "18px";
+      return `<h${level} style="margin:20px 0 8px;font-size:${fontSize};font-weight:600;color:#352618;">${children}</h${level}>`;
+    }
+    case "bulletList":
+      return `<ul style="margin:0 0 12px;padding-left:24px;color:#4A3729;">${children}</ul>`;
+    case "orderedList":
+      return `<ol style="margin:0 0 12px;padding-left:24px;color:#4A3729;">${children}</ol>`;
+    case "listItem":
+      return `<li style="margin:0 0 4px;line-height:1.6;">${children}</li>`;
+    case "blockquote":
+      return `<blockquote style="margin:0 0 12px;padding:8px 16px;border-left:3px solid #D4A017;color:#4A3729;font-style:italic;">${children}</blockquote>`;
+    case "codeBlock":
+      return `<pre style="margin:0 0 12px;padding:12px;background:#f5f5f5;border-radius:4px;overflow-x:auto;"><code>${children}</code></pre>`;
+    case "horizontalRule":
+      return `<hr style="border:none;border-top:1px solid #e5e5e5;margin:20px 0;" />`;
+    case "hardBreak":
+      return "<br />";
+    default:
+      return children;
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function escapeAttr(str: string): string {
+  return str.replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+// ─── Email HTML Builder ──────────────────────────────────────────────
+
+function buildEmailHtml(
+  announcement: AnnouncementRecord,
+  unsubscribeUrl: string
+): string {
+  const bodyHtml = announcement.body
+    ? tiptapToHtml(announcement.body)
+    : "<p>No content</p>";
+
+  return `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8" /><meta name="viewport" content="width=device-width,initial-scale=1" /></head>
+<body style="margin:0;padding:0;background-color:#f6f6f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f6f6f6;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;">
+        <!-- Header -->
+        <tr>
+          <td style="background-color:#253341;padding:24px 32px;text-align:center;">
+            <span style="font-size:18px;font-weight:600;color:#FFFDF8;letter-spacing:0.02em;">${escapeHtml(CHURCH_NAME)}</span>
+          </td>
+        </tr>
+        <!-- Body -->
+        <tr>
+          <td style="padding:32px;">
+            <h1 style="margin:0 0 16px;font-size:24px;font-weight:600;color:#352618;line-height:1.3;">
+              ${escapeHtml(announcement.title)}
+            </h1>
+            <hr style="border:none;border-top:2px solid #D4A017;width:60px;margin:0 0 24px;" />
+            ${bodyHtml}
+            <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:24px;">
+              <tr><td>
+                <a href="${SITE_URL}/announcements/${encodeURIComponent(announcement.slug)}"
+                   style="display:inline-block;padding:10px 24px;background-color:#9B1B3D;color:#FFFDF8;text-decoration:none;border-radius:8px;font-size:14px;font-weight:500;">
+                  Read on our website
+                </a>
+              </td></tr>
+            </table>
+          </td>
+        </tr>
+        <!-- Footer -->
+        <tr>
+          <td style="padding:24px 32px;border-top:1px solid #e5e5e5;">
+            <p style="margin:0 0 8px;font-size:12px;color:#9ca3af;text-align:center;line-height:1.5;">
+              ${escapeHtml(CHURCH_NAME)}<br />
+              ${escapeHtml(CHURCH_ADDRESS)}
+            </p>
+            <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;line-height:1.5;">
+              <a href="${unsubscribeUrl}" style="color:#9ca3af;text-decoration:underline;">Unsubscribe</a>
+              from future announcements.
+            </p>
+          </td>
+        </tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+// ─── Resend Batch Send ───────────────────────────────────────────────
+
+async function sendBatch(
+  emails: { from: string; to: string; subject: string; html: string }[],
+  apiKey: string
+): Promise<{ success: boolean; error?: string }> {
+  const res = await fetch(RESEND_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(emails),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    return { success: false, error: `Resend API ${res.status}: ${body}` };
+  }
+
+  return { success: true };
+}
+
+// ─── Main Handler ────────────────────────────────────────────────────
+
+Deno.serve(async (req) => {
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  // Verify authorization
+  const authHeader = req.headers.get("Authorization");
+  const expectedKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!authHeader || authHeader !== `Bearer ${expectedKey}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const resendApiKey = Deno.env.get("RESEND_API_KEY");
+  if (!resendApiKey) {
+    return new Response(
+      JSON.stringify({ error: "RESEND_API_KEY not configured" }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  let payload: WebhookPayload;
+  try {
+    payload = await req.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Invalid JSON payload" }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  const { record } = payload;
+
+  // Idempotency: skip if already sent or conditions not met
+  if (!record.send_email || record.email_sent_at || !record.published_at) {
+    return new Response(
+      JSON.stringify({ skipped: true, reason: "Conditions not met for sending" }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Create Supabase admin client
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  // Double-check idempotency from DB (race condition guard)
+  const { data: freshRecord, error: fetchError } = await supabase
+    .from("announcements")
+    .select("email_sent_at")
+    .eq("id", record.id)
+    .single();
+
+  if (fetchError || freshRecord?.email_sent_at) {
+    return new Response(
+      JSON.stringify({ skipped: true, reason: "Already sent (DB check)" }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Fetch active, confirmed subscribers
+  const { data: subscribers, error: subError } = await supabase
+    .from("email_subscribers")
+    .select("email, name, unsubscribe_token")
+    .eq("confirmed", true);
+
+  if (subError) {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch subscribers", details: subError.message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  if (!subscribers || subscribers.length === 0) {
+    // Mark as sent even with no subscribers to avoid retrying
+    await supabase
+      .from("announcements")
+      .update({ email_sent_at: new Date().toISOString() })
+      .eq("id", record.id);
+
+    return new Response(
+      JSON.stringify({ sent: 0, reason: "No active subscribers" }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  // Build and send emails in batches
+  const subject = record.title;
+  let totalSent = 0;
+  const errors: string[] = [];
+
+  for (let i = 0; i < subscribers.length; i += RESEND_BATCH_LIMIT) {
+    const batch = (subscribers as Subscriber[]).slice(i, i + RESEND_BATCH_LIMIT);
+    const emails = batch.map((sub) => {
+      const unsubscribeUrl = `${SITE_URL}/unsubscribe?token=${sub.unsubscribe_token}`;
+      return {
+        from: `${CHURCH_NAME} <${FROM_EMAIL}>`,
+        to: sub.email,
+        subject,
+        html: buildEmailHtml(record, unsubscribeUrl),
+      };
+    });
+
+    const result = await sendBatch(emails, resendApiKey);
+    if (result.success) {
+      totalSent += batch.length;
+    } else {
+      errors.push(result.error ?? "Unknown error");
+    }
+  }
+
+  // Update email_sent_at if any emails were sent successfully
+  if (totalSent > 0) {
+    await supabase
+      .from("announcements")
+      .update({ email_sent_at: new Date().toISOString() })
+      .eq("id", record.id);
+  }
+
+  const status = errors.length === 0 ? 200 : 207;
+  return new Response(
+    JSON.stringify({
+      sent: totalSent,
+      total: subscribers.length,
+      errors: errors.length > 0 ? errors : undefined,
+    }),
+    { status, headers: { "Content-Type": "application/json" } }
+  );
+});

--- a/supabase/migrations/20260325000003_create_email_subscribers.sql
+++ b/supabase/migrations/20260325000003_create_email_subscribers.sql
@@ -1,0 +1,63 @@
+-- Migration: Create email_subscribers table
+-- Phase: 4d
+-- Ticket: 4d-01 (created as dependency for 4c-04)
+
+-- ─── Email Subscribers Table ────────────────────────────────────────
+
+CREATE TABLE public.email_subscribers (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  email TEXT NOT NULL UNIQUE,
+  name TEXT,
+  confirmed BOOLEAN NOT NULL DEFAULT false,
+  confirmed_at TIMESTAMPTZ,
+  unsubscribe_token UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_email_subscribers_confirmed ON public.email_subscribers(confirmed);
+CREATE INDEX idx_email_subscribers_unsubscribe_token ON public.email_subscribers(unsubscribe_token);
+
+-- Enable RLS
+ALTER TABLE public.email_subscribers ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: admins only
+CREATE POLICY "Admins can read subscribers"
+  ON public.email_subscribers FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- INSERT: anonymous can subscribe (public signup form)
+CREATE POLICY "Anyone can subscribe"
+  ON public.email_subscribers FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+-- UPDATE: admins only (for confirming, etc.)
+CREATE POLICY "Admins can update subscribers"
+  ON public.email_subscribers FOR UPDATE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- DELETE: admins only
+CREATE POLICY "Admins can delete subscribers"
+  ON public.email_subscribers FOR DELETE
+  TO authenticated
+  USING (
+    EXISTS (SELECT 1 FROM public.profiles WHERE id = auth.uid() AND role = 'admin')
+  );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_email_subscribers_updated_at
+  BEFORE UPDATE ON public.email_subscribers
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260325000004_create_announcement_email_webhook.sql
+++ b/supabase/migrations/20260325000004_create_announcement_email_webhook.sql
@@ -1,0 +1,72 @@
+-- Migration: Create announcement email webhook trigger
+-- Phase: 4c
+-- Ticket: 4c-04
+--
+-- This trigger fires when an announcement is inserted or updated with
+-- send_email = true, email_sent_at IS NULL, and published_at IS NOT NULL.
+-- It calls the announcement-email Edge Function via pg_net.
+--
+-- SETUP REQUIRED:
+--   1. Deploy the Edge Function: supabase functions deploy announcement-email
+--   2. Store secrets in Supabase Vault (Dashboard → Settings → Vault):
+--      - edge_function_base_url: e.g. https://<project-ref>.supabase.co/functions/v1
+--      - service_role_key: your project's service_role key
+
+-- Enable pg_net extension for HTTP calls from triggers
+CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA extensions;
+
+-- ─── Trigger Function ───────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.trigger_announcement_email()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  _base_url TEXT;
+  _service_key TEXT;
+BEGIN
+  -- Only fire when conditions are met
+  IF NEW.send_email = true
+    AND NEW.email_sent_at IS NULL
+    AND NEW.published_at IS NOT NULL
+  THEN
+    -- Read Edge Function URL and service key from Supabase Vault
+    SELECT decrypted_secret INTO _base_url
+      FROM vault.decrypted_secrets
+      WHERE name = 'edge_function_base_url'
+      LIMIT 1;
+
+    SELECT decrypted_secret INTO _service_key
+      FROM vault.decrypted_secrets
+      WHERE name = 'service_role_key'
+      LIMIT 1;
+
+    -- Call the Edge Function via pg_net
+    IF _base_url IS NOT NULL AND _service_key IS NOT NULL THEN
+      PERFORM net.http_post(
+        url := _base_url || '/announcement-email',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || _service_key
+        ),
+        body := jsonb_build_object(
+          'type', TG_OP,
+          'table', TG_TABLE_NAME,
+          'schema', TG_TABLE_SCHEMA,
+          'record', row_to_json(NEW)
+        )
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ─── Trigger ────────────────────────────────────────────────────────
+
+CREATE TRIGGER on_announcement_email_broadcast
+  AFTER INSERT OR UPDATE ON public.announcements
+  FOR EACH ROW
+  EXECUTE FUNCTION public.trigger_announcement_email();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## Summary
- Implements georgenijo/St-Basils-Boston-Web#92
- Creates `email_subscribers` table with RLS policies (dependency 4d-01 not yet merged, included here)
- Adds `pg_net` database trigger on `announcements` table that fires when `send_email = true`, `email_sent_at IS NULL`, and `published_at IS NOT NULL`
- Adds Supabase Edge Function (`announcement-email`) that receives the webhook, fetches confirmed subscribers, converts Tiptap JSON to HTML, and sends via Resend batch API
- Adds React Email template (`announcement-broadcast.tsx`) for development preview
- CAN-SPAM compliant: unsubscribe link + physical church address in every email footer
- Idempotent: double-checks `email_sent_at` from DB before sending

## Setup Required
After deploying, add these secrets to Supabase Vault:
- `edge_function_base_url` — e.g. `https://<project-ref>.supabase.co/functions/v1`
- `service_role_key` — project service role key

Edge Function env vars (set via Supabase dashboard):
- `RESEND_API_KEY`
- `SITE_URL`

## Test plan
- [ ] Run migrations against Supabase project
- [ ] Deploy Edge Function: `supabase functions deploy announcement-email`
- [ ] Configure Vault secrets
- [ ] Create a test subscriber (confirmed = true)
- [ ] Create/publish an announcement with `send_email = true`
- [ ] Verify email is received with correct content, unsubscribe link, and church address
- [ ] Verify `email_sent_at` is set after send
- [ ] Verify re-saving the announcement does NOT re-send (idempotency)
- [ ] Verify no emails sent when `send_email = false`
- [ ] Verify no emails sent for unpublished announcements