### PR TITLE
feat: add subscriber table + signup infrastructure (#93)

### DIFF
--- a/src/actions/newsletter.ts
+++ b/src/actions/newsletter.ts
@@ -1,0 +1,108 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import { resend } from '@/lib/resend'
+import { verifyTurnstile } from '@/lib/turnstile'
+import { newsletterSchema } from '@/lib/validators/newsletter'
+import { NewsletterConfirmation } from '@/emails/newsletter-confirmation'
+
+type NewsletterState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+export async function subscribeNewsletter(
+  prevState: NewsletterState,
+  formData: FormData
+): Promise<NewsletterState> {
+  // 1. Honeypot check
+  const honeypot = formData.get('website')
+  if (honeypot) {
+    return { success: false, message: 'Spam detected' }
+  }
+
+  // 2. Validate with Zod
+  const parsed = newsletterSchema.safeParse({
+    email: formData.get('email'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 3. Turnstile CAPTCHA verification
+  const turnstileToken = formData.get('cf-turnstile-response') as string
+  if (!turnstileToken) {
+    return { success: false, message: 'Please complete the CAPTCHA' }
+  }
+
+  const turnstileValid = await verifyTurnstile(turnstileToken)
+  if (!turnstileValid) {
+    return { success: false, message: 'CAPTCHA verification failed' }
+  }
+
+  const { email } = parsed.data
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://stbasilsboston.org'
+  const supabase = await createClient()
+
+  // 4. Check for existing subscriber
+  const { data: existing } = await supabase
+    .from('email_subscribers')
+    .select('id, confirmed, confirmation_token')
+    .eq('email', email)
+    .single()
+
+  if (existing) {
+    if (existing.confirmed) {
+      return { success: true, message: 'You are already subscribed.' }
+    }
+
+    // Re-send confirmation email for unconfirmed subscribers
+    const confirmUrl = `${siteUrl}/api/newsletter/confirm?token=${existing.confirmation_token}`
+    const { error: emailError } = await resend.emails.send({
+      from: "St. Basil's Church <noreply@stbasilsboston.org>",
+      to: email,
+      subject: 'Confirm your subscription',
+      react: NewsletterConfirmation({ confirmUrl, siteUrl }),
+    })
+
+    if (emailError) {
+      return { success: false, message: 'Failed to send confirmation email. Please try again.' }
+    }
+
+    return { success: true, message: 'A confirmation email has been sent. Please check your inbox.' }
+  }
+
+  // 5. Insert new subscriber
+  const { data: subscriber, error: dbError } = await supabase
+    .from('email_subscribers')
+    .insert({ email })
+    .select('confirmation_token')
+    .single()
+
+  if (dbError) {
+    console.error('Failed to create subscriber:', dbError)
+    return { success: false, message: 'Something went wrong. Please try again.' }
+  }
+
+  // 6. Send confirmation email
+  const confirmUrl = `${siteUrl}/api/newsletter/confirm?token=${subscriber.confirmation_token}`
+  const { error: emailError } = await resend.emails.send({
+    from: "St. Basil's Church <noreply@stbasilsboston.org>",
+    to: email,
+    subject: 'Confirm your subscription',
+    react: NewsletterConfirmation({ confirmUrl, siteUrl }),
+  })
+
+  if (emailError) {
+    console.error('Failed to send confirmation email:', emailError)
+    return { success: false, message: 'Failed to send confirmation email. Please try again.' }
+  }
+
+  return { success: true, message: 'A confirmation email has been sent. Please check your inbox.' }
+}

--- a/src/app/api/newsletter/confirm/route.ts
+++ b/src/app/api/newsletter/confirm/route.ts
@@ -1,0 +1,46 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token')
+
+  if (!token) {
+    return NextResponse.redirect(new URL('/?confirmed=invalid', req.url))
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  // Look up subscriber by confirmation token
+  const { data: subscriber, error: fetchError } = await supabase
+    .from('email_subscribers')
+    .select('id, confirmed')
+    .eq('confirmation_token', token)
+    .single()
+
+  if (fetchError || !subscriber) {
+    return NextResponse.redirect(new URL('/?confirmed=invalid', req.url))
+  }
+
+  if (subscriber.confirmed) {
+    return NextResponse.redirect(new URL('/?confirmed=already', req.url))
+  }
+
+  // Activate subscription
+  const { error: updateError } = await supabase
+    .from('email_subscribers')
+    .update({
+      confirmed: true,
+      confirmed_at: new Date().toISOString(),
+    })
+    .eq('id', subscriber.id)
+
+  if (updateError) {
+    console.error('Failed to confirm subscriber:', updateError)
+    return NextResponse.redirect(new URL('/?confirmed=error', req.url))
+  }
+
+  return NextResponse.redirect(new URL('/?confirmed=success', req.url))
+}

--- a/src/app/api/newsletter/unsubscribe/route.ts
+++ b/src/app/api/newsletter/unsubscribe/route.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token')
+
+  if (!token) {
+    return NextResponse.redirect(new URL('/?unsubscribed=invalid', req.url))
+  }
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  // Deactivate subscription
+  const { data: subscriber, error } = await supabase
+    .from('email_subscribers')
+    .update({
+      confirmed: false,
+      confirmed_at: null,
+    })
+    .eq('unsubscribe_token', token)
+    .select('id')
+    .single()
+
+  if (error || !subscriber) {
+    return NextResponse.redirect(new URL('/?unsubscribed=invalid', req.url))
+  }
+
+  return NextResponse.redirect(new URL('/?unsubscribed=success', req.url))
+}

--- a/src/emails/newsletter-confirmation.tsx
+++ b/src/emails/newsletter-confirmation.tsx
@@ -1,0 +1,169 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+
+interface NewsletterConfirmationProps {
+  confirmUrl: string
+  siteUrl?: string
+}
+
+const CHURCH_NAME = "St. Basil's Syriac Orthodox Church"
+const CHURCH_ADDRESS = '73 Ellis Street, Newton, MA 02464'
+
+export function NewsletterConfirmation({
+  confirmUrl = 'https://stbasilsboston.org/api/newsletter/confirm?token=example',
+  siteUrl = 'https://stbasilsboston.org',
+}: NewsletterConfirmationProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Confirm your subscription to {CHURCH_NAME}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          <Section style={header}>
+            <Text style={headerText}>{CHURCH_NAME}</Text>
+          </Section>
+          <Section style={content}>
+            <Heading style={heading}>Confirm Your Subscription</Heading>
+            <Hr style={goldDivider} />
+            <Text style={paragraph}>
+              Thank you for subscribing to announcements from {CHURCH_NAME}.
+              Please confirm your email address by clicking the button below.
+            </Text>
+            <Section style={ctaSection}>
+              <Link href={confirmUrl} style={ctaButton}>
+                Confirm Subscription
+              </Link>
+            </Section>
+            <Text style={smallText}>
+              If you didn&apos;t request this, you can safely ignore this email.
+            </Text>
+          </Section>
+          <Section style={footerSection}>
+            <Text style={footerText}>
+              {CHURCH_NAME}
+              {'\n'}
+              {CHURCH_ADDRESS}
+            </Text>
+            <Text style={footerText}>
+              <Link href={siteUrl} style={footerLink}>
+                stbasilsboston.org
+              </Link>
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+export default NewsletterConfirmation
+
+// ─── Styles ──────────────────────────────────────────────────────────
+
+const body = {
+  backgroundColor: '#f6f6f6',
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  margin: '0',
+  padding: '0',
+}
+
+const container = {
+  backgroundColor: '#ffffff',
+  margin: '40px auto',
+  borderRadius: '8px',
+  maxWidth: '560px',
+  overflow: 'hidden' as const,
+}
+
+const header = {
+  backgroundColor: '#253341',
+  padding: '24px 32px',
+  textAlign: 'center' as const,
+}
+
+const headerText = {
+  fontSize: '18px',
+  fontWeight: '600' as const,
+  color: '#FFFDF8',
+  letterSpacing: '0.02em',
+  margin: '0',
+}
+
+const content = {
+  padding: '32px',
+}
+
+const heading = {
+  fontSize: '24px',
+  fontWeight: '600' as const,
+  color: '#352618',
+  lineHeight: '1.3',
+  margin: '0 0 16px',
+}
+
+const goldDivider = {
+  borderColor: '#D4A017',
+  borderWidth: '2px',
+  borderStyle: 'solid' as const,
+  width: '60px',
+  margin: '0 0 24px',
+}
+
+const paragraph = {
+  fontSize: '14px',
+  color: '#4A3729',
+  lineHeight: '1.6',
+  margin: '0 0 24px',
+}
+
+const ctaSection = {
+  marginBottom: '24px',
+}
+
+const ctaButton = {
+  display: 'inline-block' as const,
+  padding: '12px 28px',
+  backgroundColor: '#9B1B3D',
+  color: '#FFFDF8',
+  textDecoration: 'none',
+  borderRadius: '8px',
+  fontSize: '14px',
+  fontWeight: '500' as const,
+}
+
+const smallText = {
+  fontSize: '12px',
+  color: '#9ca3af',
+  lineHeight: '1.5',
+  margin: '0',
+}
+
+const footerSection = {
+  padding: '24px 32px',
+  borderTop: '1px solid #e5e5e5',
+}
+
+const footerText = {
+  fontSize: '12px',
+  color: '#9ca3af',
+  textAlign: 'center' as const,
+  margin: '0 0 8px',
+  lineHeight: '1.5',
+  whiteSpace: 'pre-line' as const,
+}
+
+const footerLink = {
+  color: '#9ca3af',
+  textDecoration: 'underline',
+}

--- a/src/lib/validators/newsletter.ts
+++ b/src/lib/validators/newsletter.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const newsletterSchema = z.object({
+  email: z
+    .string()
+    .min(1, 'Email is required')
+    .email('Please enter a valid email address'),
+})
+
+export type NewsletterFormData = z.infer<typeof newsletterSchema>

--- a/supabase/migrations/20260325000005_add_confirmation_token.sql
+++ b/supabase/migrations/20260325000005_add_confirmation_token.sql
@@ -1,0 +1,9 @@
+-- Migration: Add confirmation_token to email_subscribers
+-- Phase: 4d
+-- Ticket: 4d-01
+
+ALTER TABLE public.email_subscribers
+  ADD COLUMN confirmation_token UUID DEFAULT gen_random_uuid() NOT NULL UNIQUE;
+
+CREATE INDEX idx_email_subscribers_confirmation_token
+  ON public.email_subscribers(confirmation_token);


### PR DESCRIPTION
## Summary

Implements georgenijo/St-Basils-Boston-Web#93

- **Migration**: Adds `confirmation_token` column to `email_subscribers` table for double opt-in flow
- **Server Action** (`src/actions/newsletter.ts`): Validates email with Zod, verifies Turnstile CAPTCHA, checks honeypot, handles duplicate emails gracefully (re-sends confirmation), inserts new subscriber with `confirmed=false`, sends confirmation email via Resend
- **Confirmation email** (`src/emails/newsletter-confirmation.tsx`): React Email template with church branding (charcoal header, gold divider, burgundy CTA button, CAN-SPAM footer)
- **Confirm endpoint** (`/api/newsletter/confirm?token=`): Sets `confirmed=true` and `confirmed_at` timestamp, redirects to homepage with status query param
- **Unsubscribe endpoint** (`/api/newsletter/unsubscribe?token=`): Deactivates subscription, redirects to homepage with status query param
- **Validator** (`src/lib/validators/newsletter.ts`): Zod schema for email validation

## Test plan

- [ ] Run migration against Supabase to add `confirmation_token` column
- [ ] Submit newsletter signup form — verify subscriber row created with `confirmed=false`
- [ ] Verify confirmation email arrives with correct branding and token link
- [ ] Click confirm link — verify `confirmed=true` and `confirmed_at` set
- [ ] Re-submit same email — verify graceful handling (re-sends confirmation or shows "already subscribed")
- [ ] Submit with invalid email — verify Zod validation error
- [ ] Submit without Turnstile — verify CAPTCHA required message
- [ ] Click unsubscribe link from announcement email — verify subscription deactivated