### PR TITLE
feat: add Resend Audiences sync + admin subscribers view (#95)

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 
 import { createClient } from '@/lib/supabase/server'
 import { Card } from '@/components/ui'
@@ -71,20 +72,19 @@ export default async function DashboardPage() {
         </h2>
         <div className="mt-4 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {placeholderCards.map((card) => (
-            <Card key={card.title} variant="outlined" className="p-6">
-              <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-burgundy-100 text-burgundy-700">
-                {card.icon}
-              </div>
-              <h3 className="font-heading text-lg font-semibold text-wood-900">
-                {card.title}
-              </h3>
-              <p className="mt-1 text-sm text-wood-800/60">
-                {card.description}
-              </p>
-              <p className="mt-4 text-xs font-medium text-wood-800/40">
-                Coming soon
-              </p>
-            </Card>
+            <Link key={card.title} href={card.href}>
+              <Card variant="outlined" className="p-6 transition-shadow hover:shadow-md">
+                <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-burgundy-100 text-burgundy-700">
+                  {card.icon}
+                </div>
+                <h3 className="font-heading text-lg font-semibold text-wood-900">
+                  {card.title}
+                </h3>
+                <p className="mt-1 text-sm text-wood-800/60">
+                  {card.description}
+                </p>
+              </Card>
+            </Link>
           ))}
         </div>
       </section>

--- a/src/app/(admin)/admin/subscribers/page.tsx
+++ b/src/app/(admin)/admin/subscribers/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from 'next'
+
+import { createClient } from '@/lib/supabase/server'
+import { SubscribersTable } from '@/components/features/SubscribersTable'
+
+export const metadata: Metadata = {
+  title: 'Subscribers',
+}
+
+export default async function SubscribersPage() {
+  const supabase = await createClient()
+
+  const { data: subscribers } = await supabase
+    .from('email_subscribers')
+    .select('id, email, confirmed, confirmed_at, created_at')
+    .order('created_at', { ascending: false })
+
+  const all = subscribers ?? []
+  const activeCount = all.filter((s) => s.confirmed).length
+  const unconfirmedCount = all.filter((s) => !s.confirmed && s.confirmed_at === null).length
+
+  return (
+    <main className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <h1 className="font-heading text-3xl font-semibold text-wood-900">
+          Subscribers
+        </h1>
+        <p className="mt-1 font-body text-sm text-wood-800/60">
+          View and manage newsletter subscribers.
+        </p>
+      </div>
+
+      {/* Summary cards */}
+      <div className="mb-8 grid gap-4 sm:grid-cols-3">
+        <SummaryCard label="Total" count={all.length} />
+        <SummaryCard label="Active" count={activeCount} accent="green" />
+        <SummaryCard label="Unconfirmed" count={unconfirmedCount} accent="amber" />
+      </div>
+
+      <SubscribersTable subscribers={all} />
+    </main>
+  )
+}
+
+// ─── Summary Card ─────────────────────────────────────────────────
+
+function SummaryCard({
+  label,
+  count,
+  accent,
+}: {
+  label: string
+  count: number
+  accent?: 'green' | 'amber'
+}) {
+  const dotColor =
+    accent === 'green'
+      ? 'bg-emerald-500'
+      : accent === 'amber'
+        ? 'bg-amber-500'
+        : 'bg-burgundy-700'
+
+  return (
+    <div className="rounded-2xl border border-wood-800/10 bg-cream-50 p-5">
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${dotColor}`} aria-hidden="true" />
+        <span className="font-body text-sm font-medium text-wood-800/60">{label}</span>
+      </div>
+      <p className="mt-2 font-heading text-3xl font-semibold text-wood-900">{count}</p>
+    </div>
+  )
+}

--- a/src/app/api/newsletter/confirm/route.ts
+++ b/src/app/api/newsletter/confirm/route.ts
@@ -1,6 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 
+import { addContactToAudience } from '@/lib/resend'
+
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')
 
@@ -16,7 +18,7 @@ export async function GET(req: NextRequest) {
   // Look up subscriber by confirmation token
   const { data: subscriber, error: fetchError } = await supabase
     .from('email_subscribers')
-    .select('id, confirmed')
+    .select('id, email, confirmed')
     .eq('confirmation_token', token)
     .single()
 
@@ -41,6 +43,9 @@ export async function GET(req: NextRequest) {
     console.error('Failed to confirm subscriber:', updateError)
     return NextResponse.redirect(new URL('/?confirmed=error', req.url))
   }
+
+  // Sync to Resend Audience
+  await addContactToAudience(subscriber.email)
 
   return NextResponse.redirect(new URL('/?confirmed=success', req.url))
 }

--- a/src/app/api/newsletter/unsubscribe/route.ts
+++ b/src/app/api/newsletter/unsubscribe/route.ts
@@ -1,6 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 import { NextRequest, NextResponse } from 'next/server'
 
+import { removeContactFromAudience } from '@/lib/resend'
+
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token')
 
@@ -21,12 +23,15 @@ export async function GET(req: NextRequest) {
       confirmed_at: null,
     })
     .eq('unsubscribe_token', token)
-    .select('id')
+    .select('id, email')
     .single()
 
   if (error || !subscriber) {
     return NextResponse.redirect(new URL('/?unsubscribed=invalid', req.url))
   }
+
+  // Remove from Resend Audience
+  await removeContactFromAudience(subscriber.email)
 
   return NextResponse.redirect(new URL('/?unsubscribed=success', req.url))
 }

--- a/src/components/features/SubscribersTable.tsx
+++ b/src/components/features/SubscribersTable.tsx
@@ -1,0 +1,334 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+
+import { cn } from '@/lib/utils'
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+interface Subscriber {
+  id: string
+  email: string
+  confirmed: boolean
+  confirmed_at: string | null
+  created_at: string
+}
+
+interface SubscribersTableProps {
+  subscribers: Subscriber[]
+}
+
+type SortKey = 'email' | 'status' | 'created_at'
+type SortDir = 'asc' | 'desc'
+
+const PAGE_SIZE = 20
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function getStatus(s: Subscriber): 'active' | 'unconfirmed' | 'unsubscribed' {
+  if (s.confirmed) return 'active'
+  if (s.confirmed_at !== null) return 'unsubscribed'
+  return 'unconfirmed'
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  active: 'Active',
+  unconfirmed: 'Unconfirmed',
+  unsubscribed: 'Unsubscribed',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  active: 'bg-emerald-50 text-emerald-700',
+  unconfirmed: 'bg-amber-50 text-amber-700',
+  unsubscribed: 'bg-red-50 text-red-600',
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      className={cn('ml-1 inline-block transition-transform', !active && 'opacity-30')}
+      aria-hidden="true"
+    >
+      <path
+        d="M6 2L9 5H3L6 2Z"
+        fill="currentColor"
+        className={cn(active && dir === 'asc' ? 'opacity-100' : 'opacity-30')}
+      />
+      <path
+        d="M6 10L3 7H9L6 10Z"
+        fill="currentColor"
+        className={cn(active && dir === 'desc' ? 'opacity-100' : 'opacity-30')}
+      />
+    </svg>
+  )
+}
+
+// ─── Component ───────────────────────────────────────────────────────
+
+export function SubscribersTable({ subscribers }: SubscribersTableProps) {
+  const [search, setSearch] = useState('')
+  const [statusFilter, setStatusFilter] = useState<string>('')
+  const [sortKey, setSortKey] = useState<SortKey>('created_at')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [page, setPage] = useState(1)
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortKey(key)
+      setSortDir('asc')
+    }
+    setPage(1)
+  }
+
+  const filtered = useMemo(() => {
+    let result = subscribers
+
+    if (search) {
+      const q = search.toLowerCase()
+      result = result.filter((s) => s.email.toLowerCase().includes(q))
+    }
+
+    if (statusFilter) {
+      result = result.filter((s) => getStatus(s) === statusFilter)
+    }
+
+    return result.sort((a, b) => {
+      let cmp: number
+      if (sortKey === 'status') {
+        cmp = getStatus(a).localeCompare(getStatus(b))
+      } else {
+        cmp = String(a[sortKey]).localeCompare(String(b[sortKey]))
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  }, [subscribers, search, statusFilter, sortKey, sortDir])
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  function exportCsv() {
+    const header = 'Email,Status,Confirmed At,Signed Up\n'
+    const rows = filtered
+      .map((s) => {
+        const status = getStatus(s)
+        const confirmedAt = s.confirmed_at ? new Date(s.confirmed_at).toISOString() : ''
+        const createdAt = new Date(s.created_at).toISOString()
+        return `${s.email},${status},${confirmedAt},${createdAt}`
+      })
+      .join('\n')
+
+    const blob = new Blob([header + rows], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `subscribers-${new Date().toISOString().slice(0, 10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const thClass =
+    'px-4 py-3 text-left font-body text-xs font-medium uppercase tracking-wider text-wood-800/60 cursor-pointer select-none hover:text-wood-900 transition-colors'
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        {/* Search */}
+        <div className="relative flex-1 sm:max-w-xs">
+          <SearchIcon />
+          <input
+            type="search"
+            placeholder="Search by email..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setPage(1)
+            }}
+            className="w-full rounded-lg border border-wood-800/10 bg-cream-50 py-2 pl-9 pr-3 font-body text-sm text-wood-900 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-1 focus:ring-burgundy-700"
+          />
+        </div>
+
+        {/* Status filter pills */}
+        <div className="flex items-center gap-1.5">
+          {['', 'active', 'unconfirmed', 'unsubscribed'].map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                setStatusFilter(value)
+                setPage(1)
+              }}
+              className={cn(
+                'rounded-full px-3 py-1 font-body text-xs font-medium transition-colors',
+                statusFilter === value
+                  ? 'bg-burgundy-700 text-cream-50'
+                  : 'bg-cream-100 text-wood-800 hover:bg-cream-100/80'
+              )}
+            >
+              {value ? STATUS_LABELS[value] : 'All'}
+            </button>
+          ))}
+        </div>
+
+        {/* CSV export */}
+        <button
+          type="button"
+          onClick={exportCsv}
+          className="ml-auto inline-flex items-center gap-1.5 rounded-lg border border-wood-800/10 px-3 py-2 font-body text-xs font-medium text-wood-800 transition-colors hover:bg-cream-100"
+        >
+          <DownloadIcon />
+          Export CSV
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-wood-800/10">
+        <table className="w-full">
+          <thead className="border-b border-wood-800/10 bg-cream-100/50">
+            <tr>
+              <th className={thClass} onClick={() => toggleSort('email')}>
+                Email
+                <SortIcon active={sortKey === 'email'} dir={sortDir} />
+              </th>
+              <th className={thClass} onClick={() => toggleSort('status')}>
+                Status
+                <SortIcon active={sortKey === 'status'} dir={sortDir} />
+              </th>
+              <th className={cn(thClass, 'hidden sm:table-cell')} onClick={() => toggleSort('created_at')}>
+                Signed Up
+                <SortIcon active={sortKey === 'created_at'} dir={sortDir} />
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-wood-800/5">
+            {paginated.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={3}
+                  className="px-4 py-12 text-center font-body text-sm text-wood-800/60"
+                >
+                  {search || statusFilter
+                    ? 'No subscribers match your filters'
+                    : 'No subscribers yet.'}
+                </td>
+              </tr>
+            ) : (
+              paginated.map((subscriber) => {
+                const status = getStatus(subscriber)
+                return (
+                  <tr
+                    key={subscriber.id}
+                    className="transition-colors hover:bg-cream-100/30"
+                  >
+                    <td className="px-4 py-3 font-body text-sm text-wood-900">
+                      {subscriber.email}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={cn(
+                          'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+                          STATUS_COLORS[status]
+                        )}
+                      >
+                        {STATUS_LABELS[status]}
+                      </span>
+                    </td>
+                    <td className="hidden px-4 py-3 font-body text-sm text-wood-800/60 sm:table-cell">
+                      {formatDate(subscriber.created_at)}
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between">
+          <p className="font-body text-sm text-wood-800/60">
+            {filtered.length} subscriber{filtered.length !== 1 ? 's' : ''}
+          </p>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+              className="rounded-lg px-3 py-1.5 font-body text-xs font-medium text-wood-800 transition-colors hover:bg-cream-100 disabled:opacity-40 disabled:pointer-events-none"
+            >
+              Previous
+            </button>
+            <span className="px-2 font-body text-xs text-wood-800/60">
+              {page} of {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={page >= totalPages}
+              onClick={() => setPage(page + 1)}
+              className="rounded-lg px-3 py-1.5 font-body text-xs font-medium text-wood-800 transition-colors hover:bg-cream-100 disabled:opacity-40 disabled:pointer-events-none"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Icons ───────────────────────────────────────────────────────────
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="absolute left-3 top-1/2 -translate-y-1/2 text-wood-800/40"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="M21 21l-4.3-4.3" />
+    </svg>
+  )
+}
+
+function DownloadIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="7 10 12 15 17 10" />
+      <line x1="12" y1="15" x2="12" y2="3" />
+    </svg>
+  )
+}

--- a/src/lib/resend.ts
+++ b/src/lib/resend.ts
@@ -1,3 +1,38 @@
 import { Resend } from 'resend'
 
-export const resend = new Resend(process.env.RESEND_API_KEY)
+let _resend: Resend | null = null
+
+function getResend(): Resend {
+  if (!_resend) {
+    _resend = new Resend(process.env.RESEND_API_KEY)
+  }
+  return _resend
+}
+
+export const resend = new Proxy({} as Resend, {
+  get(_, prop) {
+    return getResend()[prop as keyof Resend]
+  },
+})
+
+export async function addContactToAudience(email: string): Promise<void> {
+  const audienceId = process.env.RESEND_AUDIENCE_ID
+  if (!audienceId) return
+
+  try {
+    await getResend().contacts.create({ email, audienceId })
+  } catch (error) {
+    console.error('Failed to add contact to Resend Audience:', error)
+  }
+}
+
+export async function removeContactFromAudience(email: string): Promise<void> {
+  const audienceId = process.env.RESEND_AUDIENCE_ID
+  if (!audienceId) return
+
+  try {
+    await getResend().contacts.remove({ audienceId, email })
+  } catch (error) {
+    console.error('Failed to remove contact from Resend Audience:', error)
+  }
+}


### PR DESCRIPTION
## Summary
- Sync subscribers to Resend Audience on email confirmation, remove on unsubscribe
- Add `/admin/subscribers` page with summary count cards (total, active, unconfirmed)
- Subscribers table with status indicators, email search, pagination, and CSV export
- Update dashboard feature cards to link to admin sections
- Make Resend client lazily initialized to avoid build-time errors

Implements georgenijo/St-Basils-Boston-Web#95

## Test plan
- [ ] Confirm a subscriber and verify they appear in Resend Audience
- [ ] Unsubscribe and verify contact is removed from Resend Audience
- [ ] Visit `/admin/subscribers` — verify summary cards show correct counts
- [ ] Search by email filters table correctly
- [ ] Status filter pills work (All, Active, Unconfirmed, Unsubscribed)
- [ ] Pagination displays when >20 subscribers
- [ ] CSV export downloads correct data
- [ ] Dashboard cards link to admin sections
- [ ] Page renders within admin layout with sidebar navigation