### PR TITLE
feat: add Playwright smoke test suite (#104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/e2e/.auth/

--- a/e2e/smoke/admin.spec.ts
+++ b/e2e/smoke/admin.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: Admin pages.
+ *
+ * Without valid credentials we can only verify:
+ * - The login page renders correctly
+ * - Protected admin routes redirect to login (auth guard works)
+ */
+
+test.describe('Admin login @smoke', () => {
+  test('login page renders email and password fields', async ({ page }) => {
+    await page.goto('/login', { waitUntil: 'domcontentloaded' })
+
+    await expect(page.locator('input#email')).toBeVisible()
+    await expect(page.locator('input#password')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible()
+  })
+})
+
+test.describe('Admin auth guard @smoke', () => {
+  const PROTECTED_ROUTES = [
+    '/admin',
+    '/admin/dashboard',
+    '/admin/events',
+    '/admin/announcements',
+  ]
+
+  for (const route of PROTECTED_ROUTES) {
+    test(`${route} redirects unauthenticated users`, async ({ page }) => {
+      const response = await page.goto(route, { waitUntil: 'domcontentloaded' })
+      const url = page.url()
+
+      // Should either redirect to /login or show 401/403
+      // Next.js middleware typically redirects to login
+      const isRedirected = url.includes('/login')
+      const isBlocked = response?.status() === 401 || response?.status() === 403
+      const isOk = response?.status() === 200 && url.includes('/login')
+
+      expect(isRedirected || isBlocked || isOk).toBeTruthy()
+    })
+  }
+})

--- a/e2e/smoke/calendar-announcements.spec.ts
+++ b/e2e/smoke/calendar-announcements.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: Calendar and announcements render.
+ *
+ * Calendar: the filter buttons and FullCalendar container render.
+ * Announcements: the listing page loads and either shows items or
+ * an empty state.
+ */
+
+test.describe('Events calendar @smoke', () => {
+  test('renders category filter buttons', async ({ page }) => {
+    await page.goto('/events', { waitUntil: 'domcontentloaded' })
+
+    const filterGroup = page.locator('[role="group"][aria-label="Filter events by category"]')
+    await expect(filterGroup).toBeVisible()
+
+    // All four filter buttons present
+    await expect(filterGroup.getByRole('button', { name: 'All Events' })).toBeVisible()
+    await expect(filterGroup.getByRole('button', { name: 'Liturgical' })).toBeVisible()
+    await expect(filterGroup.getByRole('button', { name: 'Community' })).toBeVisible()
+    await expect(filterGroup.getByRole('button', { name: 'Special' })).toBeVisible()
+
+    // "All Events" is active by default
+    await expect(filterGroup.getByRole('button', { name: 'All Events' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  test('renders FullCalendar container', async ({ page }) => {
+    await page.goto('/events', { waitUntil: 'networkidle' })
+
+    // FullCalendar renders inside the rounded container
+    // The dynamically imported CalendarView creates the fc container
+    const calendarContainer = page.locator('.fc')
+    await expect(calendarContainer).toBeVisible({ timeout: 15_000 })
+  })
+})
+
+test.describe('Announcements @smoke', () => {
+  test('listing page loads', async ({ page }) => {
+    const response = await page.goto('/announcements', { waitUntil: 'domcontentloaded' })
+    expect(response?.status()).toBe(200)
+
+    // Page should have a heading
+    await expect(page.locator('h1, h2').first()).toBeVisible()
+  })
+})

--- a/e2e/smoke/forms.spec.ts
+++ b/e2e/smoke/forms.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: Contact form + newsletter signup form render correctly.
+ *
+ * Does not submit (requires Turnstile + server), but verifies
+ * all fields and the submit button are present.
+ */
+
+test.describe('Contact form @smoke', () => {
+  test('renders all fields and submit button', async ({ page }) => {
+    await page.goto('/contact', { waitUntil: 'domcontentloaded' })
+
+    // All form fields present
+    await expect(page.locator('input#name')).toBeVisible()
+    await expect(page.locator('input#email')).toBeVisible()
+    await expect(page.locator('input#subject')).toBeVisible()
+    await expect(page.locator('textarea#message')).toBeVisible()
+
+    // Labels present
+    await expect(page.locator('label[for="name"]')).toContainText('Name')
+    await expect(page.locator('label[for="email"]')).toContainText('Email')
+    await expect(page.locator('label[for="subject"]')).toContainText('Subject')
+    await expect(page.locator('label[for="message"]')).toContainText('Message')
+
+    // Submit button
+    await expect(page.getByRole('button', { name: 'Send Message' })).toBeVisible()
+
+    // Honeypot field is hidden
+    const honeypot = page.locator('input#website')
+    await expect(honeypot).toBeHidden()
+  })
+
+  test('fields have required attribute', async ({ page }) => {
+    await page.goto('/contact', { waitUntil: 'domcontentloaded' })
+
+    for (const id of ['name', 'email', 'subject', 'message']) {
+      const field = id === 'message' ? page.locator(`textarea#${id}`) : page.locator(`input#${id}`)
+      await expect(field).toHaveAttribute('required', '')
+    }
+  })
+})
+
+test.describe('Newsletter signup form @smoke', () => {
+  test('renders email input and subscribe button in footer', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    const footer = page.locator('footer')
+
+    // Email input for newsletter
+    const emailInput = footer.locator('input#newsletter-email')
+    await expect(emailInput).toBeVisible()
+    await expect(emailInput).toHaveAttribute('type', 'email')
+    await expect(emailInput).toHaveAttribute('required', '')
+
+    // Subscribe button
+    await expect(footer.getByRole('button', { name: 'Subscribe' })).toBeVisible()
+
+    // Honeypot hidden
+    await expect(footer.locator('input#newsletter-website')).toBeHidden()
+  })
+})

--- a/e2e/smoke/images.spec.ts
+++ b/e2e/smoke/images.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: All images load without errors.
+ *
+ * Navigates to key pages and checks for broken images
+ * (images that fail to load or have naturalWidth of 0).
+ */
+
+const PAGES_WITH_IMAGES = ['/', '/about', '/contact', '/giving', '/first-time']
+
+test.describe('Image loading @smoke', () => {
+  for (const path of PAGES_WITH_IMAGES) {
+    test(`all images load on ${path}`, async ({ page }) => {
+      const failedImages: string[] = []
+
+      // Track failed image requests
+      page.on('response', (response) => {
+        const url = response.url()
+        const isImage =
+          url.match(/\.(png|jpe?g|gif|webp|avif|svg|ico)(\?|$)/i) ||
+          response.request().resourceType() === 'image'
+
+        if (isImage && response.status() >= 400) {
+          failedImages.push(`${response.status()} ${url}`)
+        }
+      })
+
+      await page.goto(path, { waitUntil: 'networkidle' })
+
+      // Check for broken images in the DOM
+      const brokenImages = await page.evaluate(() => {
+        const images = document.querySelectorAll('img')
+        const broken: string[] = []
+        images.forEach((img) => {
+          // Skip lazy images that haven't loaded yet
+          if (img.loading === 'lazy' && !img.complete) return
+          // Skip tiny tracking pixels
+          if (img.width <= 1 && img.height <= 1) return
+
+          if (img.complete && img.naturalWidth === 0) {
+            broken.push(img.src || img.dataset.src || 'unknown')
+          }
+        })
+        return broken
+      })
+
+      expect(failedImages).toEqual([])
+      expect(brokenImages).toEqual([])
+    })
+  }
+
+  test('logo image loads in navbar', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    const logo = page.locator('nav img[alt="St. Basil\'s Syriac Orthodox Church"]')
+    await expect(logo).toBeVisible()
+
+    // Verify natural dimensions (not broken)
+    const naturalWidth = await logo.evaluate((img: HTMLImageElement) => img.naturalWidth)
+    expect(naturalWidth).toBeGreaterThan(0)
+  })
+})

--- a/e2e/smoke/mobile-nav.spec.ts
+++ b/e2e/smoke/mobile-nav.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: Mobile navigation.
+ *
+ * Uses the mobile-chrome project (Pixel 5 viewport)
+ * to verify hamburger menu opens/closes and all nav links are reachable.
+ */
+
+test.describe('Mobile navigation @smoke', () => {
+  test.use({ viewport: { width: 393, height: 851 } })
+
+  test('hamburger menu opens and shows all nav items', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    // Desktop nav should be hidden, hamburger visible
+    const hamburger = page.locator('button[aria-controls="mobile-menu"]')
+    await expect(hamburger).toBeVisible()
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false')
+
+    // Open the menu
+    await hamburger.click()
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'true')
+
+    const mobileMenu = page.locator('#mobile-menu')
+
+    // Top-level nav items visible
+    await expect(mobileMenu.getByText('Home')).toBeVisible()
+    await expect(mobileMenu.getByText('About')).toBeVisible()
+    await expect(mobileMenu.getByText('Resources')).toBeVisible()
+    await expect(mobileMenu.getByText('Giving')).toBeVisible()
+    await expect(mobileMenu.getByText('Contact Us')).toBeVisible()
+  })
+
+  test('accordion dropdowns expand on tap', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    // Open menu
+    await page.locator('button[aria-controls="mobile-menu"]').click()
+
+    // Tap "About" accordion
+    const aboutButton = page.locator('#mobile-menu button', { hasText: 'About' })
+    await aboutButton.click()
+    await expect(aboutButton).toHaveAttribute('aria-expanded', 'true')
+
+    // Sub-items should be visible
+    await expect(page.locator('#mobile-menu').getByText('Our History')).toBeVisible()
+    await expect(page.locator('#mobile-menu').getByText('Our Clergy')).toBeVisible()
+    await expect(page.locator('#mobile-menu').getByText('Our Organizations')).toBeVisible()
+  })
+
+  test('menu closes after clicking a link', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    const hamburger = page.locator('button[aria-controls="mobile-menu"]')
+    await hamburger.click()
+
+    // Click a direct link
+    await page.locator('#mobile-menu').getByText('Giving').click()
+
+    // Should navigate and close menu
+    await page.waitForURL('**/giving')
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false')
+  })
+})

--- a/e2e/smoke/public-pages.spec.ts
+++ b/e2e/smoke/public-pages.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: Every public page loads without errors.
+ *
+ * Verifies each route returns 200, renders the <nav> and <footer>,
+ * and produces no console errors.
+ */
+
+const PUBLIC_PAGES: { path: string; label: string }[] = [
+  { path: '/', label: 'Homepage' },
+  { path: '/about', label: 'About / Our History' },
+  { path: '/spiritual-leaders', label: 'Our Spiritual Fathers' },
+  { path: '/our-clergy', label: 'Our Clergy' },
+  { path: '/office-bearers', label: 'Office Bearers' },
+  { path: '/acolytes-choir', label: 'Acolytes & Choir' },
+  { path: '/our-organizations', label: 'Our Organizations' },
+  { path: '/events', label: 'Events Calendar' },
+  { path: '/useful-links', label: 'Useful Links' },
+  { path: '/first-time', label: 'First Time Visiting' },
+  { path: '/giving', label: 'Giving' },
+  { path: '/contact', label: 'Contact Us' },
+  { path: '/privacy-policy', label: 'Privacy Policy' },
+  { path: '/terms-of-use', label: 'Terms of Use' },
+  { path: '/announcements', label: 'Announcements' },
+]
+
+test.describe('Public pages @smoke', () => {
+  for (const { path, label } of PUBLIC_PAGES) {
+    test(`${label} (${path}) loads successfully`, async ({ page }) => {
+      const consoleErrors: string[] = []
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          // Ignore known benign errors
+          const text = msg.text()
+          if (text.includes('Turnstile') || text.includes('cf-turnstile')) return
+          if (text.includes('NEXT_PUBLIC_')) return
+          consoleErrors.push(text)
+        }
+      })
+
+      const response = await page.goto(path, { waitUntil: 'domcontentloaded' })
+
+      // Page returns 200
+      expect(response?.status()).toBe(200)
+
+      // Nav and footer render (layout is intact)
+      await expect(page.locator('nav[aria-label="Main navigation"]')).toBeVisible()
+      await expect(page.locator('footer')).toBeVisible()
+
+      // No console errors
+      expect(consoleErrors).toEqual([])
+    })
+  }
+})

--- a/e2e/smoke/redirects.spec.ts
+++ b/e2e/smoke/redirects.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke: Legacy .html redirects
+ *
+ * All old .html URLs must return a 308 permanent redirect
+ * to their modern equivalents. Covers active pages, orphaned
+ * pages (consolidated to /our-organizations), and unused
+ * template pages (redirected to /).
+ */
+
+const REDIRECTS: { source: string; destination: string }[] = [
+  // Active pages
+  { source: '/index.html', destination: '/' },
+  { source: '/about.html', destination: '/about' },
+  { source: '/spiritual-leader.html', destination: '/spiritual-leaders' },
+  { source: '/our-clergy.html', destination: '/our-clergy' },
+  { source: '/office-bearers.html', destination: '/office-bearers' },
+  { source: '/acolytes-choir.html', destination: '/acolytes-choir' },
+  { source: '/our-organizations.html', destination: '/our-organizations' },
+  { source: '/events-calendar.html', destination: '/events' },
+  { source: '/events-calendar', destination: '/events' },
+  { source: '/useful-links.html', destination: '/useful-links' },
+  { source: '/first-time.html', destination: '/first-time' },
+  { source: '/giving.html', destination: '/giving' },
+  { source: '/contact-us.html', destination: '/contact' },
+  { source: '/privacy-policy.html', destination: '/privacy-policy' },
+  { source: '/terms-of-use.html', destination: '/terms-of-use' },
+
+  // Orphaned pages → /our-organizations
+  { source: '/sunday-school.html', destination: '/our-organizations' },
+  { source: '/stpauls-mensfellow.html', destination: '/our-organizations' },
+  { source: '/stmarys-womens.html', destination: '/our-organizations' },
+  { source: '/youth.html', destination: '/our-organizations' },
+
+  // Template pages → /
+  { source: '/portfolio-details.html', destination: '/' },
+  { source: '/starter-page.html', destination: '/' },
+]
+
+test.describe('Legacy .html redirects @smoke', () => {
+  for (const { source, destination } of REDIRECTS) {
+    test(`${source} → ${destination} (308)`, async ({ request, baseURL }) => {
+      const response = await request.get(`${baseURL}${source}`, {
+        maxRedirects: 0,
+      })
+
+      expect(response.status()).toBe(308)
+
+      const location = response.headers()['location']
+      // Next.js may return absolute or relative Location headers
+      const resolved = location?.startsWith('http')
+        ? new URL(location).pathname
+        : location
+
+      expect(resolved).toBe(destination)
+    })
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.1.4",
         "@types/node": "^22.14.1",
         "@types/react": "^19.1.2",
@@ -4645,6 +4646,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -16861,6 +16878,53 @@
       "dependencies": {
         "@vercel/edge": "^1.2.1",
         "ce-la-react": "^0.3.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize-esm": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test:e2e": "playwright test",
+    "test:smoke": "playwright test --grep @smoke"
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.20",
@@ -44,6 +46,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.4",
     "@types/node": "^22.14.1",
     "@types/react": "^19.1.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+})


### PR DESCRIPTION
## Summary
- Adds Playwright e2e smoke test suite covering all acceptance criteria from georgenijo/St-Basils-Boston-Web#104
- 7 test files across redirects, public pages, forms, calendar/announcements, admin, mobile nav, and image loading
- Playwright configured with chromium + mobile-chrome projects, auto-starts dev server for local runs
- npm scripts: `test:e2e` (all tests) and `test:smoke` (smoke-tagged only)

## Test Coverage
| Suite | Tests | What it verifies |
|-------|-------|------------------|
| redirects | 21 | All legacy .html URLs return 308 to correct destination |
| public-pages | 15 | Every public route returns 200, renders nav/footer, 0 console errors |
| forms | 3 | Contact form fields/labels/required attrs, newsletter signup in footer |
| calendar-announcements | 3 | Category filters, FullCalendar render, announcements listing |
| admin | 5 | Login page renders, protected routes redirect unauthenticated users |
| mobile-nav | 3 | Hamburger menu, accordion dropdowns, link navigation closes menu |
| images | 6 | No broken images on key pages, logo loads in navbar |

## Test plan
- [ ] `npx playwright test` passes locally with dev server running
- [ ] Verify against staging after domain cutover (set `BASE_URL` env var)
- [ ] Run on CI with `npm run test:smoke`