### PR TITLE
feat/5-04-schema-org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "resend": "^6.9.4",
         "rrule": "^2.8.1",
         "sanity": "^4.22.0",
+        "schema-dts": "^2.0.0",
         "styled-components": "^6.3.12",
         "tailwind-merge": "^3.5.0",
         "zod": "^4.3.6"
@@ -18618,6 +18619,27 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/schema-dts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-2.0.0.tgz",
+      "integrity": "sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "schema-dts-lib": "^1.0.0"
+      }
+    },
+    "node_modules/schema-dts-lib": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-dts-lib/-/schema-dts-lib-1.0.0.tgz",
+      "integrity": "sha512-9MEO5vpQH9JdBioUupqluzxSYxPLjhmqRUudk15adUl/ypnRsM2/M1kN3AmVJQeG7nZqcL68H8JlGqQQT6vy9A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      }
+    },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
@@ -20055,7 +20077,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "resend": "^6.9.4",
     "rrule": "^2.8.1",
     "sanity": "^4.22.0",
+    "schema-dts": "^2.0.0",
     "styled-components": "^6.3.12",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 
-import { PageHero, SectionHeader, ScrollReveal, Card } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { PageHero, SectionHeader, ScrollReveal, Card, JsonLd } from '@/components/ui'
 
 export const metadata: Metadata = {
   title: 'About',
@@ -18,6 +19,8 @@ export const metadata: Metadata = {
 export default function AboutPage() {
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Our History', path: '/about' }])} />
+
       {/* Hero */}
       <PageHero title="Our Church History" backgroundImage="/images/about/church-exterior.jpg" />
 

--- a/src/app/(public)/acolytes-choir/page.tsx
+++ b/src/app/(public)/acolytes-choir/page.tsx
@@ -4,7 +4,8 @@ import { PortableText } from 'next-sanity'
 import { sanityFetch } from '@/lib/sanity/client'
 import { urlFor, SanityImage } from '@/lib/sanity/image'
 import { acolytesChoirPageQuery } from '@/lib/sanity/queries'
-import { GoldDivider, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { GoldDivider, JsonLd, ScrollReveal } from '@/components/ui'
 
 import type { AcolytesChoirPage } from '@/lib/sanity/types'
 
@@ -52,6 +53,8 @@ export default async function AcolytesChoirPage() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Our Acolytes & Choir', path: '/acolytes-choir' }])} />
+
       {/* Parallax Hero */}
       <section className="relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]">
         {page?.heroImage ? (

--- a/src/app/(public)/announcements/[slug]/page.tsx
+++ b/src/app/(public)/announcements/[slug]/page.tsx
@@ -4,7 +4,8 @@ import { notFound } from 'next/navigation'
 
 import { createClient } from '@/lib/supabase/server'
 import { renderTiptapHTML } from '@/lib/tiptap'
-import { Button, Card, GoldDivider, ScrollReveal } from '@/components/ui'
+import { articleSchema, breadcrumbSchema } from '@/lib/structured-data'
+import { Button, Card, GoldDivider, JsonLd, ScrollReveal } from '@/components/ui'
 
 interface AnnouncementRow {
   id: string
@@ -72,9 +73,25 @@ export default async function AnnouncementDetailPage({ params }: PageProps) {
   if (!announcement) notFound()
 
   const bodyHtml = renderTiptapHTML(announcement.body)
+  const bodyText = bodyHtml ? bodyHtml.replace(/<[^>]*>/g, '').trim() : null
+
+  const announcementJsonLd = articleSchema({
+    title: announcement.title,
+    slug: announcement.slug,
+    publishedAt: announcement.published_at,
+    bodyText,
+  })
+
+  const breadcrumbJsonLd = breadcrumbSchema([
+    { name: 'Announcements', path: '/announcements' },
+    { name: announcement.title, path: `/announcements/${announcement.slug}` },
+  ])
 
   return (
-    <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
+    <>
+      <JsonLd data={announcementJsonLd} />
+      <JsonLd data={breadcrumbJsonLd} />
+      <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
       <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
         <ScrollReveal>
           {/* Back link */}
@@ -195,6 +212,7 @@ export default async function AnnouncementDetailPage({ params }: PageProps) {
         </ScrollReveal>
       </div>
     </section>
+    </>
   )
 }
 

--- a/src/app/(public)/announcements/page.tsx
+++ b/src/app/(public)/announcements/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { createClient } from '@/lib/supabase/server'
-import { PageHero, SectionHeader, Card, ScrollReveal, Button } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { PageHero, SectionHeader, Card, ScrollReveal, Button, JsonLd } from '@/components/ui'
 
 export const metadata: Metadata = {
   title: 'Announcements',
@@ -68,6 +69,7 @@ export default async function AnnouncementsPage({ searchParams }: PageProps) {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Announcements', path: '/announcements' }])} />
       <PageHero title="Announcements" backgroundImage="/images/about/church-exterior.jpg" />
 
       <section className="py-16 md:py-22 lg:py-28">

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 
-import { PageHero, SectionHeader, Card } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { PageHero, SectionHeader, Card, JsonLd } from '@/components/ui'
 import { ScrollReveal } from '@/components/ui/ScrollReveal'
 import { ContactForm } from '@/components/features/ContactForm'
 
@@ -82,7 +83,9 @@ const contactInfo = [
 
 export default function ContactPage() {
   return (
-    <main>
+    <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Contact Us', path: '/contact' }])} />
+      <main>
       <PageHero title="Contact Us" backgroundImage="/images/about/church-exterior.jpg" />
 
       {/* Contact Info Cards */}
@@ -177,5 +180,6 @@ export default function ContactPage() {
         </div>
       </section>
     </main>
+    </>
   )
 }

--- a/src/app/(public)/events/[slug]/page.tsx
+++ b/src/app/(public)/events/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { renderTiptapHTML } from '@/lib/tiptap'
 import { describeRecurrence } from '@/lib/recurrence'
+import { eventSchema, breadcrumbSchema } from '@/lib/structured-data'
 import { Button, Card, GoldDivider, JsonLd, ScrollReveal } from '@/components/ui'
 import { AddToCalendar } from '@/components/features/AddToCalendar'
 
@@ -91,28 +92,26 @@ export default async function EventDetailPage({ params }: PageProps) {
     ? describeRecurrence(recurrenceRule.rrule_string)
     : null
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'Event',
-    name: event.title,
-    startDate: event.start_at,
-    ...(event.end_at && { endDate: event.end_at }),
-    ...(event.location && {
-      location: {
-        '@type': 'Place',
-        name: event.location,
-      },
-    }),
-    organizer: {
-      '@type': 'Organization',
-      name: "St. Basil's Syriac Orthodox Church",
-      url: 'https://stbasilsboston.org',
-    },
-  }
+  const plainText = descriptionHtml ? stripHtml(descriptionHtml) : null
+
+  const eventJsonLd = eventSchema({
+    title: event.title,
+    startAt: event.start_at,
+    endAt: event.end_at,
+    location: event.location,
+    description: plainText,
+    slug: event.slug,
+  })
+
+  const breadcrumbJsonLd = breadcrumbSchema([
+    { name: 'Events', path: '/events' },
+    { name: event.title, path: `/events/${event.slug}` },
+  ])
 
   return (
     <>
-      <JsonLd data={jsonLd} />
+      <JsonLd data={eventJsonLd} />
+      <JsonLd data={breadcrumbJsonLd} />
 
       <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
         <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
@@ -223,7 +222,7 @@ export default async function EventDetailPage({ params }: PageProps) {
             <div className="mb-10">
               <AddToCalendar
                 title={event.title}
-                description={descriptionHtml ? stripHtml(descriptionHtml) : undefined}
+                description={plainText ?? undefined}
                 location={event.location}
                 startAt={event.start_at}
                 endAt={event.end_at}

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next'
 
 import { createClient } from '@/lib/supabase/server'
-import { PageHero, SectionHeader, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { PageHero, SectionHeader, ScrollReveal, JsonLd } from '@/components/ui'
 import { EventCalendar } from '@/components/features/EventCalendar'
 
 import type { CalendarEvent } from '@/components/features/EventCalendar'
@@ -85,6 +86,7 @@ export default async function EventsPage() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Events Calendar', path: '/events' }])} />
       <PageHero title="Events Calendar" backgroundImage="/images/about/church-exterior.jpg" />
 
       <section className="py-16 md:py-22 lg:py-28">

--- a/src/app/(public)/first-time/page.tsx
+++ b/src/app/(public)/first-time/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 
-import { Card, PageHero, ScrollReveal, SectionHeader } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { Card, PageHero, ScrollReveal, SectionHeader, JsonLd } from '@/components/ui'
 
 export const metadata: Metadata = {
   title: 'First Time Visiting?',
@@ -90,6 +91,8 @@ const guidelines = [
 export default function FirstTimePage() {
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'First Time Visiting?', path: '/first-time' }])} />
+
       <PageHero
         title="A Guide to Our Sacred Worship"
         backgroundImage="/images/first-time-hero.jpg"

--- a/src/app/(public)/giving/page.tsx
+++ b/src/app/(public)/giving/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 
-import { PageHero, SectionHeader, Button, Card } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { PageHero, SectionHeader, Button, Card, JsonLd } from '@/components/ui'
 import { ScrollReveal } from '@/components/ui/ScrollReveal'
 
 export const metadata: Metadata = {
@@ -92,7 +93,9 @@ const ministries = [
 
 export default function GivingPage() {
   return (
-    <main>
+    <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Giving', path: '/giving' }])} />
+      <main>
       <PageHero title="Giving" backgroundImage="/images/giving/hero.png" />
 
       {/* Introduction */}
@@ -175,5 +178,6 @@ export default function GivingPage() {
         </div>
       </section>
     </main>
+    </>
   )
 }

--- a/src/app/(public)/office-bearers/page.tsx
+++ b/src/app/(public)/office-bearers/page.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from 'next'
 import { sanityFetch } from '@/lib/sanity/client'
 import { SanityImage } from '@/lib/sanity/image'
 import { allOfficeBearersQuery } from '@/lib/sanity/queries'
-import { SectionHeader, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { SectionHeader, ScrollReveal, JsonLd } from '@/components/ui'
 
 import type { OfficeBearer } from '@/lib/sanity/types'
 
@@ -46,6 +47,8 @@ export default async function OfficeBearersPage() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Our Office Bearers', path: '/office-bearers' }])} />
+
       {/* Maroon Hero */}
       <section className="relative flex h-[40vh] items-center justify-center bg-burgundy-700 md:h-[60vh]">
         <div className="absolute inset-0 bg-black/20" aria-hidden="true" />

--- a/src/app/(public)/our-clergy/page.tsx
+++ b/src/app/(public)/our-clergy/page.tsx
@@ -5,7 +5,8 @@ import { sanityFetch } from '@/lib/sanity/client'
 import { SanityImage } from '@/lib/sanity/image'
 import { allClergyQuery } from '@/lib/sanity/queries'
 import { cn } from '@/lib/utils'
-import { SectionHeader, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { SectionHeader, ScrollReveal, JsonLd } from '@/components/ui'
 import { CandleFlame } from '@/components/features/CandleFlame'
 
 import type { Clergy } from '@/lib/sanity/types'
@@ -51,6 +52,8 @@ export default async function OurClergyPage() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Our Clergy', path: '/our-clergy' }])} />
+
       {/* Fixed Background Hero */}
       <section className="relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]">
         <div

--- a/src/app/(public)/our-organizations/page.tsx
+++ b/src/app/(public)/our-organizations/page.tsx
@@ -6,7 +6,8 @@ import { sanityFetch } from '@/lib/sanity/client'
 import { SanityImage } from '@/lib/sanity/image'
 import { allOrganizationsQuery } from '@/lib/sanity/queries'
 import { cn } from '@/lib/utils'
-import { GoldDivider, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { GoldDivider, JsonLd, ScrollReveal } from '@/components/ui'
 
 import type { Organization } from '@/lib/sanity/types'
 
@@ -35,6 +36,8 @@ export default async function OurOrganizationsPage() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Our Organizations', path: '/our-organizations' }])} />
+
       {/* Parallax Hero */}
       <section className="relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]">
         <div

--- a/src/app/(public)/privacy-policy/page.tsx
+++ b/src/app/(public)/privacy-policy/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation'
 import { sanityFetch } from '@/lib/sanity/client'
 import { urlFor } from '@/lib/sanity/image'
 import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { JsonLd } from '@/components/ui'
 import { LegalPageLayout } from '@/components/features/LegalPageLayout'
 
 import type { PageContent } from '@/lib/sanity/types'
@@ -47,5 +49,10 @@ export default async function PrivacyPolicyPage() {
     notFound()
   }
 
-  return <LegalPageLayout page={page} />
+  return (
+    <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Privacy Policy', path: '/privacy-policy' }])} />
+      <LegalPageLayout page={page} />
+    </>
+  )
 }

--- a/src/app/(public)/spiritual-leaders/page.tsx
+++ b/src/app/(public)/spiritual-leaders/page.tsx
@@ -5,7 +5,8 @@ import { sanityFetch } from '@/lib/sanity/client'
 import { urlFor, SanityImage } from '@/lib/sanity/image'
 import { allSpiritualLeadersQuery } from '@/lib/sanity/queries'
 import { cn } from '@/lib/utils'
-import { GoldDivider, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { GoldDivider, JsonLd, ScrollReveal } from '@/components/ui'
 
 import type { SpiritualLeader } from '@/lib/sanity/types'
 
@@ -43,6 +44,8 @@ export default async function SpiritualLeadersPage() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Our Spiritual Fathers', path: '/spiritual-leaders' }])} />
+
       {/* Maroon Hero Banner */}
       <section className="flex h-[40vh] items-center justify-center bg-burgundy-700 md:h-[60vh]">
         <h1 className="animate-drop-in px-4 text-center font-heading text-[2.5rem] font-light leading-[1.1] text-cream-50 md:text-[4rem]">

--- a/src/app/(public)/terms-of-use/page.tsx
+++ b/src/app/(public)/terms-of-use/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation'
 import { sanityFetch } from '@/lib/sanity/client'
 import { urlFor } from '@/lib/sanity/image'
 import { pageContentBySlugQuery } from '@/lib/sanity/queries'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { JsonLd } from '@/components/ui'
 import { LegalPageLayout } from '@/components/features/LegalPageLayout'
 
 import type { PageContent } from '@/lib/sanity/types'
@@ -47,5 +49,10 @@ export default async function TermsOfUsePage() {
     notFound()
   }
 
-  return <LegalPageLayout page={page} />
+  return (
+    <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Terms of Use', path: '/terms-of-use' }])} />
+      <LegalPageLayout page={page} />
+    </>
+  )
 }

--- a/src/app/(public)/useful-links/page.tsx
+++ b/src/app/(public)/useful-links/page.tsx
@@ -3,7 +3,8 @@ import type { Metadata } from 'next'
 import { sanityFetch } from '@/lib/sanity/client'
 import { urlFor, SanityImage } from '@/lib/sanity/image'
 import { allUsefulLinksQuery, usefulLinksPageQuery } from '@/lib/sanity/queries'
-import { SectionHeader, ScrollReveal } from '@/components/ui'
+import { breadcrumbSchema } from '@/lib/structured-data'
+import { SectionHeader, ScrollReveal, JsonLd } from '@/components/ui'
 
 import type { UsefulLink, UsefulLinksPage } from '@/lib/sanity/types'
 
@@ -60,6 +61,8 @@ export default async function UsefulLinksPageRoute() {
 
   return (
     <>
+      <JsonLd data={breadcrumbSchema([{ name: 'Useful Links', path: '/useful-links' }])} />
+
       {/* Parallax Hero */}
       <section className="relative flex h-[40vh] items-center justify-center overflow-hidden md:h-[60vh]">
         {pageContent?.heroImage ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,44 +2,10 @@ import type { Metadata } from 'next'
 import { Cormorant_Garamond, DM_Sans, Poppins } from 'next/font/google'
 
 import { cn } from '@/lib/utils'
+import { churchSchema } from '@/lib/structured-data'
 import { JsonLd } from '@/components/ui'
 
 import './globals.css'
-
-const churchJsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'Church',
-  name: "St. Basil's Syriac Orthodox Church",
-  description:
-    "St. Basil's Syriac Orthodox Church in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.",
-  url: 'https://stbasilsboston.org',
-  telephone: '+1-617-527-0527',
-  logo: 'https://stbasilsboston.org/images/logo.png',
-  image: 'https://stbasilsboston.org/images/logo.png',
-  address: {
-    '@type': 'PostalAddress',
-    streetAddress: '73 Ellis Street',
-    addressLocality: 'Newton',
-    addressRegion: 'MA',
-    postalCode: '02464',
-    addressCountry: 'US',
-  },
-  geo: {
-    '@type': 'GeoCoordinates',
-    latitude: 42.3375,
-    longitude: -71.2093,
-  },
-  openingHoursSpecification: [
-    {
-      '@type': 'OpeningHoursSpecification',
-      dayOfWeek: 'Sunday',
-      opens: '08:30',
-      closes: '12:00',
-      description: 'Morning Prayer at 8:30 AM, Holy Qurbono at 9:15 AM',
-    },
-  ],
-  sameAs: ['https://www.facebook.com/stbasilsboston'],
-}
 
 const cormorantGaramond = Cormorant_Garamond({
   subsets: ['latin'],
@@ -102,7 +68,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={cn(cormorantGaramond.variable, dmSans.variable, poppins.variable)}>
       <body>
-        <JsonLd data={churchJsonLd} />
+        <JsonLd data={churchSchema} />
         {children}
       </body>
     </html>

--- a/src/components/ui/JsonLd.tsx
+++ b/src/components/ui/JsonLd.tsx
@@ -1,5 +1,7 @@
+import type { Thing, WithContext } from 'schema-dts'
+
 interface JsonLdProps {
-  data: Record<string, unknown>
+  data: WithContext<Thing> | Record<string, unknown>
 }
 
 export function JsonLd({ data }: JsonLdProps) {

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,136 @@
+import type { WithContext, Church, Event, Article, BreadcrumbList } from 'schema-dts'
+
+const SITE_URL = 'https://stbasilsboston.org'
+const ORG_NAME = "St. Basil's Syriac Orthodox Church"
+
+export const churchSchema: WithContext<Church> = {
+  '@context': 'https://schema.org',
+  '@type': 'Church',
+  name: ORG_NAME,
+  description: `${ORG_NAME} in Boston, Massachusetts. Serving the Jacobite Malayalee community in the New England region.`,
+  url: SITE_URL,
+  telephone: '+1-617-527-0527',
+  logo: `${SITE_URL}/images/logo.png`,
+  image: `${SITE_URL}/images/logo.png`,
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: '73 Ellis Street',
+    addressLocality: 'Newton',
+    addressRegion: 'MA',
+    postalCode: '02464',
+    addressCountry: 'US',
+  },
+  geo: {
+    '@type': 'GeoCoordinates',
+    latitude: 42.3375,
+    longitude: -71.2093,
+  },
+  openingHoursSpecification: [
+    {
+      '@type': 'OpeningHoursSpecification',
+      dayOfWeek: 'Sunday',
+      opens: '08:30',
+      closes: '12:00',
+      description: 'Morning Prayer at 8:30 AM, Holy Qurbono at 9:15 AM',
+    },
+  ],
+  sameAs: ['https://www.facebook.com/stbasilsboston'],
+}
+
+export function eventSchema(event: {
+  title: string
+  startAt: string
+  endAt: string | null
+  location: string | null
+  description: string | null
+  slug: string
+}): WithContext<Event> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: event.title,
+    startDate: event.startAt,
+    ...(event.endAt && { endDate: event.endAt }),
+    ...(event.description && { description: event.description }),
+    url: `${SITE_URL}/events/${event.slug}`,
+    ...(event.location && {
+      location: {
+        '@type': 'Place',
+        name: event.location,
+        address: {
+          '@type': 'PostalAddress',
+          streetAddress: '73 Ellis Street',
+          addressLocality: 'Newton',
+          addressRegion: 'MA',
+          postalCode: '02464',
+          addressCountry: 'US',
+        },
+      },
+    }),
+    organizer: {
+      '@type': 'Organization',
+      name: ORG_NAME,
+      url: SITE_URL,
+    },
+    eventStatus: 'https://schema.org/EventScheduled',
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+  }
+}
+
+export function articleSchema(announcement: {
+  title: string
+  slug: string
+  publishedAt: string
+  bodyText: string | null
+}): WithContext<Article> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: announcement.title,
+    url: `${SITE_URL}/announcements/${announcement.slug}`,
+    datePublished: announcement.publishedAt,
+    ...(announcement.bodyText && {
+      description: announcement.bodyText.slice(0, 200),
+    }),
+    author: {
+      '@type': 'Organization',
+      name: ORG_NAME,
+      url: SITE_URL,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: ORG_NAME,
+      url: SITE_URL,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${SITE_URL}/images/logo.png`,
+      },
+    },
+  }
+}
+
+interface BreadcrumbItem {
+  name: string
+  path: string
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]): WithContext<BreadcrumbList> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: SITE_URL,
+      },
+      ...items.map((item, index) => ({
+        '@type': 'ListItem' as const,
+        position: index + 2,
+        name: item.name,
+        item: `${SITE_URL}${item.path}`,
+      })),
+    ],
+  }
+}


### PR DESCRIPTION
## Summary
- Implements georgenijo/St-Basils-Boston-Web#99
- Adds `schema-dts` for type-safe Schema.org structured data
- **Event** JSON-LD on event detail pages (enhanced with `eventStatus`, `eventAttendanceMode`, description, URL)
- **Article** JSON-LD on announcement detail pages (headline, datePublished, author, publisher)
- **BreadcrumbList** JSON-LD on all 16 interior pages + 2 dynamic detail pages
- Refactors existing Church schema in root layout to use shared typed helper
- Updates `JsonLd` component to accept `schema-dts` `WithContext` types

## Test plan
- [ ] Verify Event JSON-LD renders on `/events/[slug]` pages via View Source
- [ ] Verify Article JSON-LD renders on `/announcements/[slug]` pages
- [ ] Verify BreadcrumbList JSON-LD renders on all interior pages
- [ ] Validate schemas with Google Rich Results Test
- [ ] Confirm no duplicate `@context` or conflicting structured data
- [ ] Run `npx tsc --noEmit` — passes cleanly