### PR TITLE
feat/5-06-core-web-vitals

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,17 @@
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: [
+      '@fullcalendar/core',
+      '@fullcalendar/react',
+      '@fullcalendar/daygrid',
+      '@fullcalendar/timegrid',
+      '@fullcalendar/list',
+      '@fullcalendar/interaction',
+      '@fullcalendar/rrule',
+    ],
+  },
   images: {
     remotePatterns: [
       {

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import { PageHero, SectionHeader, Card } from '@/components/ui'
 import { ScrollReveal } from '@/components/ui/ScrollReveal'
 import { ContactForm } from '@/components/features/ContactForm'
+import { LazyMap } from '@/components/features/LazyMap'
 
 export const metadata: Metadata = {
   title: 'Contact Us',
@@ -126,8 +127,25 @@ export default function ContactPage() {
         </div>
       </section>
 
-      {/* Contact Form */}
+      {/* Google Maps Embed */}
       <section className="bg-cream-50 py-16 md:py-22 lg:py-28">
+        <div className="mx-auto max-w-[1200px] px-4 sm:px-6 lg:px-8">
+          <ScrollReveal>
+            <SectionHeader title="Find Us" as="h2" />
+          </ScrollReveal>
+
+          <ScrollReveal className="mt-10">
+            <LazyMap
+              src="https://maps.google.com/maps?q=73+Ellis+Street,+Newton,+MA+02464&z=15&output=embed"
+              title="St. Basil's Syriac Orthodox Church location at 73 Ellis Street, Newton, MA"
+              className="aspect-video shadow-md"
+            />
+          </ScrollReveal>
+        </div>
+      </section>
+
+      {/* Contact Form */}
+      <section className="bg-sand py-16 md:py-22 lg:py-28">
         <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
           <ScrollReveal>
             <SectionHeader

--- a/src/components/features/LazyMap.tsx
+++ b/src/components/features/LazyMap.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
+interface LazyMapProps {
+  src: string
+  title: string
+  className?: string
+}
+
+export function LazyMap({ src, title, className }: LazyMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '200px' }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('relative overflow-hidden rounded-2xl bg-sand', className)}
+    >
+      {isVisible ? (
+        <iframe
+          src={src}
+          title={title}
+          width="100%"
+          height="100%"
+          style={{ border: 0 }}
+          allowFullScreen
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          className="absolute inset-0 h-full w-full"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center" aria-hidden="true">
+          <p className="text-sm text-wood-800/60">Loading map…</p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements georgenijo/St-Basils-Boston-Web#101

- **FullCalendar bundle optimization**: Added `experimental.optimizePackageImports` for all 7 FullCalendar packages in `next.config.ts` to enable tree-shaking and reduce JS bundle size
- **Lazy-loaded Google Maps embed**: New `LazyMap` component uses `IntersectionObserver` (200px rootMargin) to defer iframe creation until near viewport, preventing the heavy embed from blocking initial page load. Added to contact page with `aspect-video` for CLS prevention
- **Contact page layout**: Inserted "Find Us" map section between contact info cards and contact form, adjusted section backgrounds for proper alternation (sand → cream → sand → charcoal)

### Already optimized (verified, no changes needed)
- Hero images: `priority` prop on `next/image` in PageHero (LCP)
- Fonts: `display: 'swap'` via `next/font/google` with build-time download (CLS)
- FullCalendar: `next/dynamic` with `ssr: false` + skeleton loader (INP)
- Reduced motion: CSS `@media (prefers-reduced-motion)` + `useReducedMotion` in ScrollReveal
- Non-hero images: default `loading="lazy"` via `next/image`

### Dependency note
Tickets 5-01 (Vercel Speed Insights) and 5-02 (Lighthouse CI) are not yet merged. "Verified via Vercel Speed Insights" acceptance criterion is deferred until those land.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Contact page renders map section with proper lazy loading
- [ ] Map iframe only appears in DOM after scrolling near the section
- [ ] Contact page section backgrounds alternate correctly
- [ ] FullCalendar still loads and functions on /events page
- [ ] No regressions on other pages using PageHero