### PR TITLE
feat/P1-17-responsive-audit

### DIFF
--- a/src/app/(public)/giving/page.tsx
+++ b/src/app/(public)/giving/page.tsx
@@ -22,7 +22,7 @@ const ministries = [
     description:
       'Through God\u2019s provision and the generosity of our congregation, we have been blessed to contribute toward building homes for families in need throughout India. These modest dwellings provide shelter, dignity, and a foundation for families to build their lives upon, reflecting Christ\u2019s love through practical care.',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8" aria-hidden="true">
         <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
         <polyline points="9 22 9 12 15 12 15 22" />
       </svg>
@@ -33,7 +33,7 @@ const ministries = [
     description:
       'Our church family believes in supporting one another through life\u2019s most difficult moments. We are moved by Christian love to provide assistance during serious health challenges and times of loss, reflecting our understanding that we are called to bear one another\u2019s burdens and show compassion.',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8" aria-hidden="true">
         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
         <path d="M12 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" />
       </svg>
@@ -44,7 +44,7 @@ const ministries = [
     description:
       'Learning of a newly ordained deacon in India facing difficult living conditions, our congregation felt moved to help provide him with a proper home. This space enables him to prepare spiritually for the Divine Liturgy and serve his community with dignity.',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8" aria-hidden="true">
         <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
         <circle cx="8.5" cy="7" r="4" />
         <line x1="20" y1="8" x2="20" y2="14" />
@@ -57,7 +57,7 @@ const ministries = [
     description:
       'We have received heartfelt requests from individuals and families in India facing serious medical challenges\u2014kidney transplants, cancer treatments, and other urgent procedures. Through our congregation\u2019s compassionate giving, we provide financial assistance for life-saving treatments.',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8" aria-hidden="true">
         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
         <polyline points="8 13 11 16 16 10" />
       </svg>
@@ -68,7 +68,7 @@ const ministries = [
     description:
       'We are honored to support Solace Charity, an organization dedicated to caring for severely ill and underprivileged children in Kerala, India. Solace provides comprehensive support\u2014from funding critical medical procedures to offering emotional support for families.',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8" aria-hidden="true">
         <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67" />
         <path d="M13.73 21a2 2 0 0 1-3.46 0" />
@@ -80,7 +80,7 @@ const ministries = [
     description:
       'The Pelican Centre in Kerala, India, serves as \u201Can open door for the needy and mentally challenged people of our society,\u201D providing rehabilitation and care that enables individuals to lead fuller, more independent lives. Our support reflects our belief that every person deserves compassion and dignity.',
     icon: (
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="h-8 w-8" aria-hidden="true">
         <circle cx="12" cy="12" r="10" />
         <path d="M12 8a2 2 0 0 1 2 2v4a2 2 0 0 1-4 0v-4a2 2 0 0 1 2-2z" />
         <path d="M8 14s1.5 2 4 2 4-2 4-2" />
@@ -95,7 +95,6 @@ export default function GivingPage() {
   return (
     <>
       <JsonLd data={breadcrumbSchema([{ name: 'Giving', path: '/giving' }])} />
-      <main>
       <PageHero title="Giving" backgroundImage="/images/giving/hero.png" />
 
       {/* Introduction */}
@@ -115,7 +114,7 @@ export default function GivingPage() {
                 <p className="font-body text-base font-medium text-wood-900">
                   For your convenience, offerings may be sent to our Zelle account:
                 </p>
-                <p className="mt-2 font-heading text-xl font-semibold text-burgundy-700">
+                <p className="mt-2 break-all font-heading text-xl font-semibold text-burgundy-700">
                   stbasilsboston.trsr@gmail.com
                 </p>
               </div>
@@ -150,7 +149,7 @@ export default function GivingPage() {
           <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {ministries.map((ministry, i) => (
               <ScrollReveal key={ministry.title} delay={i * 0.12}>
-                <Card className="h-full transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
+                <Card className="h-full transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg motion-reduce:transition-none motion-reduce:hover:translate-y-0">
                   <Card.Body className="space-y-4">
                     <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-burgundy-700/10 text-burgundy-700">
                       {ministry.icon}
@@ -177,7 +176,6 @@ export default function GivingPage() {
           </ScrollReveal>
         </div>
       </section>
-    </main>
     </>
   )
 }

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -110,7 +110,7 @@ export default async function HomePage() {
           <div>
             <dt className="font-heading text-lg font-semibold text-cream-50">Contact</dt>
             <dd className="mt-1 text-sm text-cream-50/80">
-              <a href="tel:+16175270527" className="transition-colors hover:text-cream-50">
+              <a href="tel:+16175270527" className="inline-flex min-h-[44px] items-center transition-colors hover:text-cream-50">
                 (617) 527-0527
               </a>
             </dd>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,7 +101,8 @@ select:focus:not(:focus-visible),
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-drop-in {
+  .animate-drop-in,
+  .animate-flicker {
     animation: none;
   }
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -43,17 +43,17 @@ export function Footer() {
             <nav aria-label="Footer navigation" className="mt-4">
               <ul className="space-y-2 text-cream-50/80">
                 <li>
-                  <Link href="/contact" className="transition-colors hover:text-cream-50">
+                  <Link href="/contact" className="inline-flex min-h-[44px] items-center transition-colors hover:text-cream-50">
                     Contact Us
                   </Link>
                 </li>
                 <li>
-                  <Link href="/privacy-policy" className="transition-colors hover:text-cream-50">
+                  <Link href="/privacy-policy" className="inline-flex min-h-[44px] items-center transition-colors hover:text-cream-50">
                     Privacy Policy
                   </Link>
                 </li>
                 <li>
-                  <Link href="/terms-of-use" className="transition-colors hover:text-cream-50">
+                  <Link href="/terms-of-use" className="inline-flex min-h-[44px] items-center transition-colors hover:text-cream-50">
                     Terms of Use
                   </Link>
                 </li>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -182,7 +182,7 @@ export function Navbar({ className }: NavbarProps) {
                     <ul
                       id={`dropdown-${item.label}`}
                       className={cn(
-                        'absolute left-0 top-full mt-1 w-56 origin-top rounded-xl bg-cream-50 py-2 shadow-md transition-all duration-200',
+                        'absolute left-0 top-full mt-1 w-56 origin-top rounded-xl bg-cream-50 py-2 shadow-md transition-all duration-200 motion-reduce:transition-none',
                         activeDropdown === item.label
                           ? 'translate-y-0 scale-100 opacity-100'
                           : 'pointer-events-none -translate-y-2 scale-95 opacity-0'
@@ -254,7 +254,7 @@ export function Navbar({ className }: NavbarProps) {
         <div
           id="mobile-menu"
           className={cn(
-            'overflow-hidden bg-cream-50 transition-all duration-300 ease-in-out xl:hidden',
+            'overflow-hidden bg-cream-50 transition-all duration-300 ease-in-out motion-reduce:transition-none xl:hidden',
             mobileOpen ? 'max-h-[calc(100vh-4.25rem)]' : 'max-h-0'
           )}
         >
@@ -265,7 +265,7 @@ export function Navbar({ className }: NavbarProps) {
                   <button
                     type="button"
                     className={cn(
-                      'flex w-full items-center justify-between rounded-lg px-4 py-3 text-base font-medium transition-colors',
+                      'flex w-full items-center justify-between rounded-lg min-h-[44px] px-4 py-3 text-base font-medium transition-colors',
                       isActive(item) ? 'text-burgundy-700' : 'text-wood-800'
                     )}
                     aria-expanded={activeAccordion === item.label}
@@ -296,7 +296,7 @@ export function Navbar({ className }: NavbarProps) {
                         <Link
                           href={child.href}
                           className={cn(
-                            'block rounded-lg py-2.5 pl-8 pr-4 text-sm transition-colors',
+                            'flex items-center rounded-lg min-h-[44px] py-2.5 pl-8 pr-4 text-sm transition-colors',
                             isChildActive(child.href)
                               ? 'bg-burgundy-100 text-burgundy-700'
                               : 'text-wood-800 hover:text-burgundy-700'
@@ -316,7 +316,7 @@ export function Navbar({ className }: NavbarProps) {
                   <Link
                     href={item.href!}
                     className={cn(
-                      'block rounded-lg px-4 py-3 text-base font-medium transition-colors',
+                      'flex items-center rounded-lg min-h-[44px] px-4 py-3 text-base font-medium transition-colors',
                       isActive(item)
                         ? 'bg-burgundy-100 text-burgundy-700'
                         : 'text-wood-800 hover:text-burgundy-700'


### PR DESCRIPTION
Implements georgenijo/St-Basils-Boston-Web#48

## Summary

Responsive audit and polish pass across all Phase 1 pages (homepage, /about, /first-time, /giving) at breakpoints 375px, 768px, 1024px, 1280px, and 1920px.

### Touch targets (44px minimum)
- Mobile nav accordion buttons, child links, and parent links now enforce `min-h-[44px]`
- Footer quick links use `inline-flex min-h-[44px] items-center`
- Homepage phone link gets the same treatment

### `prefers-reduced-motion` compliance
- Navbar desktop dropdown and mobile menu panels: `motion-reduce:transition-none`
- Giving page card hover transforms: disabled under reduced motion
- CSS `animate-flicker` keyframe added to the existing reduced-motion media query (alongside `animate-drop-in`)

### Accessibility fixes
- Removed invalid nested `<main>` in giving page (public layout already provides `<main id="main-content">`)
- Added `aria-hidden="true"` to all 6 decorative ministry SVG icons in giving page

### Overflow prevention
- Email address on giving page (`stbasilsboston.trsr@gmail.com`) gets `break-all` to prevent horizontal overflow at 375px

## Already passing (no changes needed)
- No horizontal overflow at any breakpoint on homepage, about, first-time pages
- Font sizes readable at all breakpoints (SectionHeader scales h1/h2/h3 correctly)
- Navbar transitions cleanly at 1280px breakpoint (hamburger ↔ horizontal)
- ScrollReveal already respects `useReducedMotion()` via Framer Motion
- Homepage bounce chevron already has `motion-reduce:animate-none`
- PageHero `animate-drop-in` already disabled via CSS media query
- Heading hierarchy correct on all 4 pages
- Skip-to-content link present in public layout

## Test plan
- [ ] Resize browser to 375px, 768px, 1024px, 1280px, 1920px — verify no horizontal scrollbar on any page
- [ ] On mobile (375px), tap all nav links — verify each has adequate touch area
- [ ] On mobile, tap footer links — verify adequate touch area
- [ ] Enable `prefers-reduced-motion: reduce` in OS/browser — verify no animations play
- [ ] Run Lighthouse accessibility audit on homepage, /about, /first-time, /giving — verify >= 90
- [ ] Verify giving page email address doesn't overflow at 375px