### PR TITLE
Add Zod validators for user management actions

### DIFF
--- a/src/lib/validators/user.test.ts
+++ b/src/lib/validators/user.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { inviteUserSchema, updateRoleSchema, userActionSchema } from '@/lib/validators/user'
+
+describe('inviteUserSchema', () => {
+  it('passes with valid data', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'john@example.com',
+      full_name: 'John Doe',
+      role: 'member',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('passes with admin role', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'admin@example.com',
+      full_name: 'Admin User',
+      role: 'admin',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('fails when email is missing', () => {
+    const result = inviteUserSchema.safeParse({
+      email: '',
+      full_name: 'John Doe',
+      role: 'member',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when email is invalid', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'not-an-email',
+      full_name: 'John Doe',
+      role: 'member',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when full_name is missing', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'john@example.com',
+      full_name: '',
+      role: 'member',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when full_name exceeds 200 characters', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'john@example.com',
+      full_name: 'A'.repeat(201),
+      role: 'member',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when role is invalid', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'john@example.com',
+      full_name: 'John Doe',
+      role: 'superadmin',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when role is missing', () => {
+    const result = inviteUserSchema.safeParse({
+      email: 'john@example.com',
+      full_name: 'John Doe',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('updateRoleSchema', () => {
+  it('passes with valid data', () => {
+    const result = updateRoleSchema.safeParse({
+      user_id: '550e8400-e29b-41d4-a716-446655440000',
+      role: 'admin',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('fails when user_id is not a valid UUID', () => {
+    const result = updateRoleSchema.safeParse({
+      user_id: 'not-a-uuid',
+      role: 'admin',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when user_id is missing', () => {
+    const result = updateRoleSchema.safeParse({
+      role: 'admin',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when role is invalid', () => {
+    const result = updateRoleSchema.safeParse({
+      user_id: '550e8400-e29b-41d4-a716-446655440000',
+      role: 'editor',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('userActionSchema', () => {
+  it('passes with valid UUID', () => {
+    const result = userActionSchema.safeParse({
+      user_id: '550e8400-e29b-41d4-a716-446655440000',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('fails when user_id is not a valid UUID', () => {
+    const result = userActionSchema.safeParse({
+      user_id: 'invalid',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when user_id is missing', () => {
+    const result = userActionSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/lib/validators/user.ts
+++ b/src/lib/validators/user.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const inviteUserSchema = z.object({
+  email: z.string().min(1, 'Email is required').email('Invalid email address'),
+  full_name: z
+    .string()
+    .min(1, 'Full name is required')
+    .max(200, 'Full name must be 200 characters or less'),
+  role: z.enum(['admin', 'member'], { message: 'Role must be "admin" or "member"' }),
+})
+
+export const updateRoleSchema = z.object({
+  user_id: z.string().uuid('Invalid user ID'),
+  role: z.enum(['admin', 'member'], { message: 'Role must be "admin" or "member"' }),
+})
+
+export const userActionSchema = z.object({
+  user_id: z.string().uuid('Invalid user ID'),
+})
+
+export type InviteUserData = z.infer<typeof inviteUserSchema>
+export type UpdateRoleData = z.infer<typeof updateRoleSchema>
+export type UserActionData = z.infer<typeof userActionSchema>


### PR DESCRIPTION
## Summary
- Adds `inviteUserSchema`, `updateRoleSchema`, and `userActionSchema` to `src/lib/validators/user.ts`
- Validates email format, UUID format, role enum (`admin`/`member`), and field length constraints
- 15 unit tests covering valid inputs, missing fields, invalid formats, and boundary conditions

Closes #135

## Test plan
- [x] `npx vitest run src/lib/validators/user.test.ts` — 15/15 passing
- [x] `npx tsc --noEmit` — clean