### PR TITLE
Remove GoDaddy FTP workflows and add Supabase migration CI

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,33 @@
+name: Supabase Migrate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+
+concurrency:
+  group: supabase-migrate
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply Migrations
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - run: supabase link --project-ref $SUPABASE_PROJECT_ID
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
+      - run: supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ Static HTML website for St. Basil's Syriac Orthodox Church in Boston, Massachuse
 - **Frontend**: Static HTML5, CSS3, JavaScript (no build step)
 - **CSS Framework**: Bootstrap 5.3.3 (Squadfree template base)
 - **Backend**: PHP contact forms (currently non-functional)
-- **Hosting**: GoDaddy/Plesk (Windows/IIS)
-- **CI/CD**: GitHub Actions deploying via FTP
-- **Domain Management**: Vercel
+- **Hosting**: Vercel
+- **CI/CD**: GitHub Actions (Supabase migrations), Vercel (deployments)
+- **Database**: Supabase (Postgres)
 
 ## Project Structure
 
@@ -74,8 +74,11 @@ starter-page.html       # Squadfree template page
 └── newsletter.php          # Newsletter handler (BROKEN - see Known Issues)
 
 /.github/workflows/
-├── deploy-main.yml         # Production deploy: push to main → FTP to /new_website/root/
-└── deploy-staging.yml      # Staging deploy: PR to main → FTP to /preprod.stbasilsboston.org/
+├── ci.yml                  # Validate + unit tests + smoke tests on PRs/pushes to main
+├── migrate.yml             # Supabase migrations: push to main with changes in supabase/migrations/
+├── claude.yml              # Claude Code automation
+├── claude-code-review.yml  # Claude Code PR review
+└── lighthouse.yml          # Lighthouse performance checks
 ```
 
 ## Navigation Structure
@@ -136,10 +139,10 @@ Contact Us
 - PureCounter number animations
 
 ## Deployment
-- **Production**: Push to `main` triggers `.github/workflows/deploy-main.yml` → FTP to GoDaddy `/new_website/root/`
-- **Staging**: PR to `main` triggers `.github/workflows/deploy-staging.yml` → FTP to GoDaddy `/preprod.stbasilsboston.org/`
-- Both use `FTP_SERVER`, `FTP_USERNAME`, `FTP_PASSWORD` GitHub Secrets
-- Node.js build steps are commented out in both workflows (ready for future use)
+- **Production**: Vercel auto-deploys on push to `main`
+- **Preview**: Vercel deploys preview URLs on PRs
+- **Supabase Migrations**: Push to `main` with changes in `supabase/migrations/` triggers `.github/workflows/migrate.yml` → runs `supabase db push`
+- Migration workflow requires GitHub Secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD`
 
 ## Known Issues
 


### PR DESCRIPTION
## Summary
- Added `.github/workflows/migrate.yml` — auto-applies Supabase migrations on push to `main` when `supabase/migrations/**` changes
- Updated `CLAUDE.md` to remove GoDaddy/FTP references and document new CI/CD setup (Vercel deployments + Supabase migration workflow)
- Repaired remote migration history so existing migrations are tracked correctly

## Details
- Uses `supabase/setup-cli@v1` with `supabase link` + `supabase db push`
- `cancel-in-progress: false` to prevent interrupting running migrations
- Requires GitHub Secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_ID`, `SUPABASE_DB_PASSWORD` (already configured)

## Test plan
- [x] Verified YAML syntax is valid
- [x] Tested `supabase link` with credentials — connects successfully
- [x] Tested `supabase db push` — all 11 existing migrations recognized as applied
- [x] Confirmed workflow only triggers on `supabase/migrations/**` path changes

Closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure to Vercel with automated previews for pull requests.
  * Implemented automated database migration workflow that runs on updates to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->