### PR TITLE
Add Users nav item to admin sidebar and dashboard

### DIFF
--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -29,6 +29,12 @@ const placeholderCards = [
     icon: <UsersIcon />,
     href: '/admin/subscribers',
   },
+  {
+    title: 'Users',
+    description: 'Manage admin accounts, roles, and user access.',
+    icon: <ShieldIcon />,
+    href: '/admin/users',
+  },
 ]
 
 // ─── Page ───────────────────────────────────────────────────────────
@@ -121,6 +127,26 @@ function MegaphoneIcon() {
     >
       <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
       <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  )
+}
+
+function ShieldIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      <circle cx="12" cy="10" r="3" />
+      <path d="M7 20.662V18a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v.662" />
     </svg>
   )
 }

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -37,6 +37,11 @@ const navigation: NavItem[] = [
     href: '/admin/subscribers',
     icon: <UsersIcon />,
   },
+  {
+    label: 'Users',
+    href: '/admin/users',
+    icon: <ShieldUserIcon />,
+  },
 ]
 
 // ─── Component ───────────────────────────────────────────────────────
@@ -255,6 +260,26 @@ function UsersIcon() {
       <circle cx="9" cy="7" r="4" />
       <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
       <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  )
+}
+
+function ShieldUserIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      <circle cx="12" cy="10" r="3" />
+      <path d="M7 20.662V18a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v.662" />
     </svg>
   )
 }


### PR DESCRIPTION
## Summary
- Adds "Users" nav item to admin sidebar (below "Subscribers") with a shield+person icon
- Adds "Users" card to admin dashboard with description "Manage admin accounts, roles, and user access."
- Both link to `/admin/users` (will 404 until the Users page is built)

Closes #138

## Test plan
- [ ] Sidebar shows "Users" below "Subscribers" with a distinct shield icon
- [ ] Dashboard shows "Users" card with shield icon and correct description
- [ ] Both link to `/admin/users`
- [ ] Active state highlights correctly when on `/admin/users` or `/admin/users/*`
- [ ] Build passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Users management section to the admin panel, accessible from both the dashboard and sidebar navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->