### PR TITLE
Add Users list page with summary cards, search, filters, and table

### DIFF
--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -203,14 +203,25 @@ export async function deactivateUser(
   } = await supabase.auth.getUser()
   if (!user) return { success: false, message: 'Unauthorized' }
 
-  // 3. Self-protection: cannot deactivate yourself
+  // 3. Admin check
+  const { data: actorProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (actorProfile?.role !== 'admin') {
+    return { success: false, message: 'Forbidden: admin access required' }
+  }
+
+  // 4. Self-protection: cannot deactivate yourself
   if (user.id === parsed.data.user_id) {
     return { success: false, message: 'You cannot deactivate your own account' }
   }
 
   const adminClient = createAdminClient()
 
-  // 4. Set is_active = false on the profile
+  // 5. Set is_active = false on the profile
   const { error: profileError } = await adminClient
     .from('profiles')
     .update({ is_active: false })
@@ -220,7 +231,7 @@ export async function deactivateUser(
     return { success: false, message: 'Failed to deactivate user profile' }
   }
 
-  // 5. Ban in Supabase auth (invalidates sessions)
+  // 6. Ban in Supabase auth (invalidates sessions)
   const { error: banError } = await adminClient.auth.admin.updateUserById(parsed.data.user_id, {
     ban_duration: '876000h',
   })
@@ -231,7 +242,7 @@ export async function deactivateUser(
     return { success: false, message: 'Failed to ban user in auth' }
   }
 
-  // 6. Audit log (non-fatal)
+  // 7. Audit log (non-fatal)
   const { error: auditError } = await supabase.from('admin_audit_log').insert({
     actor_id: user.id,
     action: 'user.deactivate',
@@ -242,7 +253,7 @@ export async function deactivateUser(
     console.error('Failed to write audit log for user.deactivate:', auditError)
   }
 
-  // 7. Revalidate and return
+  // 8. Revalidate and return
   revalidatePath('/admin/users')
   return { success: true, message: 'User deactivated successfully' }
 }
@@ -271,9 +282,20 @@ export async function reactivateUser(
   } = await supabase.auth.getUser()
   if (!user) return { success: false, message: 'Unauthorized' }
 
+  // 3. Admin check
+  const { data: actorProfile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (actorProfile?.role !== 'admin') {
+    return { success: false, message: 'Forbidden: admin access required' }
+  }
+
   const adminClient = createAdminClient()
 
-  // 3. Set is_active = true on the profile
+  // 4. Set is_active = true on the profile
   const { error: profileError } = await adminClient
     .from('profiles')
     .update({ is_active: true })
@@ -283,7 +305,7 @@ export async function reactivateUser(
     return { success: false, message: 'Failed to reactivate user profile' }
   }
 
-  // 4. Unban in Supabase auth
+  // 5. Unban in Supabase auth
   const { error: unbanError } = await adminClient.auth.admin.updateUserById(parsed.data.user_id, {
     ban_duration: 'none',
   })
@@ -294,7 +316,7 @@ export async function reactivateUser(
     return { success: false, message: 'Failed to unban user in auth' }
   }
 
-  // 5. Audit log (non-fatal)
+  // 6. Audit log (non-fatal)
   const { error: auditError } = await supabase.from('admin_audit_log').insert({
     actor_id: user.id,
     action: 'user.reactivate',
@@ -305,7 +327,7 @@ export async function reactivateUser(
     console.error('Failed to write audit log for user.reactivate:', auditError)
   }
 
-  // 6. Revalidate and return
+  // 7. Revalidate and return
   revalidatePath('/admin/users')
   return { success: true, message: 'User reactivated successfully' }
 }

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -15,10 +15,14 @@ export default async function UsersPage() {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const { data: profiles } = await supabase
+  const { data: profiles, error } = await supabase
     .from('profiles')
     .select('id, email, full_name, role, is_active, created_at, updated_at')
     .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Failed to fetch profiles:', error)
+  }
 
   const all = profiles ?? []
   const adminCount = all.filter((p) => p.role === 'admin').length

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { createClient } from '@/lib/supabase/server'
+import { UsersTable } from '@/components/features/UsersTable'
+
+export const metadata: Metadata = {
+  title: 'Users',
+}
+
+export default async function UsersPage() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const { data: profiles } = await supabase
+    .from('profiles')
+    .select('id, email, full_name, role, is_active, created_at, updated_at')
+    .order('created_at', { ascending: false })
+
+  const all = profiles ?? []
+  const adminCount = all.filter((p) => p.role === 'admin').length
+  const memberCount = all.filter((p) => p.role === 'member' && p.is_active).length
+  const deactivatedCount = all.filter((p) => !p.is_active).length
+
+  return (
+    <main className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="font-heading text-3xl font-semibold text-wood-900">Users</h1>
+          <p className="mt-1 font-body text-sm text-wood-800/60">
+            Manage admin accounts and church members.
+          </p>
+        </div>
+        <Link
+          href="/admin/users/invite"
+          className="inline-flex items-center gap-2 rounded-lg bg-burgundy-700 px-4 py-2 font-body text-sm font-medium text-cream-50 transition-colors hover:bg-burgundy-800"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Invite User
+        </Link>
+      </div>
+
+      {/* Summary cards */}
+      <div className="mb-8 grid gap-4 sm:grid-cols-4">
+        <SummaryCard label="Total" count={all.length} />
+        <SummaryCard label="Admins" count={adminCount} accent="blue" />
+        <SummaryCard label="Members" count={memberCount} accent="green" />
+        <SummaryCard label="Deactivated" count={deactivatedCount} accent="red" />
+      </div>
+
+      <UsersTable users={all} currentUserId={user?.id ?? ''} />
+    </main>
+  )
+}
+
+// ─── Summary Card ─────────────────────────────────────────────────
+
+function SummaryCard({
+  label,
+  count,
+  accent,
+}: {
+  label: string
+  count: number
+  accent?: 'blue' | 'green' | 'red'
+}) {
+  const dotColor =
+    accent === 'blue'
+      ? 'bg-blue-500'
+      : accent === 'green'
+        ? 'bg-emerald-500'
+        : accent === 'red'
+          ? 'bg-red-500'
+          : 'bg-burgundy-700'
+
+  return (
+    <div className="rounded-2xl border border-wood-800/10 bg-cream-50 p-5">
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${dotColor}`} aria-hidden="true" />
+        <span className="font-body text-sm font-medium text-wood-800/60">{label}</span>
+      </div>
+      <p className="mt-2 font-heading text-3xl font-semibold text-wood-900">{count}</p>
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -22,6 +22,14 @@ export default async function UsersPage() {
 
   if (error) {
     console.error('Failed to fetch profiles:', error)
+    return (
+      <main className="px-4 py-8 sm:px-6 lg:px-8">
+        <h1 className="font-heading text-3xl font-semibold text-wood-900">Users</h1>
+        <p className="mt-4 font-body text-sm text-red-600">
+          Failed to load users. Please try refreshing the page.
+        </p>
+      </main>
+    )
   }
 
   const all = profiles ?? []

--- a/src/components/features/UsersTable.tsx
+++ b/src/components/features/UsersTable.tsx
@@ -113,7 +113,10 @@ function ActionButton({
   disabled,
   title,
 }: {
-  action: (state: { success: boolean; message: string }, formData: FormData) => Promise<{ success: boolean; message: string }>
+  action: (
+    state: { success: boolean; message: string },
+    formData: FormData
+  ) => Promise<{ success: boolean; message: string }>
   userId: string
   hiddenFields?: Record<string, string>
   label: string
@@ -356,10 +359,7 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
                     </td>
 
                     {/* Actions */}
-                    <td
-                      className="px-4 py-3"
-                      onClick={(e) => e.stopPropagation()}
-                    >
+                    <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
                       <div className="flex items-center justify-end gap-1.5">
                         {user.is_active ? (
                           <>
@@ -372,9 +372,7 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
                               label="Change Role"
                               className="border-wood-800/15 bg-white text-wood-800 hover:bg-cream-100"
                               disabled={isSelf}
-                              title={
-                                isSelf ? 'You cannot change your own role' : undefined
-                              }
+                              title={isSelf ? 'You cannot change your own role' : undefined}
                             />
                             <ActionButton
                               action={deactivateUser}
@@ -382,11 +380,7 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
                               label="Deactivate"
                               className="border-red-200 bg-white text-red-600 hover:bg-red-50"
                               disabled={isSelf}
-                              title={
-                                isSelf
-                                  ? 'You cannot deactivate yourself'
-                                  : undefined
-                              }
+                              title={isSelf ? 'You cannot deactivate yourself' : undefined}
                             />
                           </>
                         ) : (

--- a/src/components/features/UsersTable.tsx
+++ b/src/components/features/UsersTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo, useActionState } from 'react'
+import { useState, useMemo, useEffect, useActionState } from 'react'
 
 import { cn } from '@/lib/utils'
 import { updateUserRole, deactivateUser, reactivateUser } from '@/actions/users'
@@ -124,10 +124,17 @@ function ActionButton({
   disabled?: boolean
   title?: string
 }) {
-  const [, formAction, isPending] = useActionState(action, {
+  const [state, formAction, isPending] = useActionState(action, {
     success: false,
     message: '',
   })
+
+  useEffect(() => {
+    if (state.message && !state.success) {
+      // Surface error to user via window alert (lightweight, no toast library needed)
+      window.alert(state.message)
+    }
+  }, [state])
 
   return (
     <form action={formAction}>
@@ -215,6 +222,24 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
   const thClass =
     'px-4 py-3 text-left font-body text-xs font-medium uppercase tracking-wider text-wood-800/60 cursor-pointer select-none hover:text-wood-900 transition-colors'
 
+  function sortableThProps(key: SortKey) {
+    return {
+      onClick: () => toggleSort(key),
+      onKeyDown: (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          toggleSort(key)
+        }
+      },
+      tabIndex: 0 as const,
+      role: 'button' as const,
+      'aria-sort': (sortKey === key ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none') as
+        | 'ascending'
+        | 'descending'
+        | 'none',
+    }
+  }
+
   return (
     <div>
       {/* Toolbar */}
@@ -262,27 +287,21 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
         <table className="w-full">
           <thead className="border-b border-wood-800/10 bg-cream-100/50">
             <tr>
-              <th className={thClass} onClick={() => toggleSort('name')}>
+              <th className={thClass} {...sortableThProps('name')}>
                 User
                 <SortIcon active={sortKey === 'name'} dir={sortDir} />
               </th>
-              <th
-                className={cn(thClass, 'hidden sm:table-cell')}
-                onClick={() => toggleSort('role')}
-              >
+              <th className={cn(thClass, 'hidden sm:table-cell')} {...sortableThProps('role')}>
                 Role
                 <SortIcon active={sortKey === 'role'} dir={sortDir} />
               </th>
-              <th
-                className={cn(thClass, 'hidden sm:table-cell')}
-                onClick={() => toggleSort('status')}
-              >
+              <th className={cn(thClass, 'hidden sm:table-cell')} {...sortableThProps('status')}>
                 Status
                 <SortIcon active={sortKey === 'status'} dir={sortDir} />
               </th>
               <th
                 className={cn(thClass, 'hidden sm:table-cell')}
-                onClick={() => toggleSort('created_at')}
+                {...sortableThProps('created_at')}
               >
                 Joined
                 <SortIcon active={sortKey === 'created_at'} dir={sortDir} />

--- a/src/components/features/UsersTable.tsx
+++ b/src/components/features/UsersTable.tsx
@@ -1,0 +1,463 @@
+'use client'
+
+import { useState, useMemo, useActionState } from 'react'
+
+import { cn } from '@/lib/utils'
+import { updateUserRole, deactivateUser, reactivateUser } from '@/actions/users'
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+interface User {
+  id: string
+  email: string | null
+  full_name: string | null
+  role: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+interface UsersTableProps {
+  users: User[]
+  currentUserId: string
+  onRowClick?: (user: User) => void
+}
+
+type SortKey = 'name' | 'role' | 'status' | 'created_at'
+type SortDir = 'asc' | 'desc'
+type FilterValue = '' | 'admin' | 'member' | 'deactivated'
+
+const PAGE_SIZE = 20
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: 'Admin',
+  member: 'Member',
+}
+
+const ROLE_COLORS: Record<string, string> = {
+  admin: 'bg-amber-50 text-amber-800',
+  member: 'bg-indigo-50 text-indigo-700',
+}
+
+const STATUS_COLORS = {
+  active: 'bg-emerald-50 text-emerald-700',
+  deactivated: 'bg-red-50 text-red-700',
+}
+
+const FILTER_OPTIONS: { value: FilterValue; label: string }[] = [
+  { value: '', label: 'All' },
+  { value: 'admin', label: 'Admins' },
+  { value: 'member', label: 'Members' },
+  { value: 'deactivated', label: 'Deactivated' },
+]
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+function getName(u: User): string {
+  return u.full_name || u.email || 'Unknown'
+}
+
+function matchesFilter(u: User, filter: FilterValue): boolean {
+  switch (filter) {
+    case 'admin':
+      return u.role === 'admin'
+    case 'member':
+      return u.role === 'member' && u.is_active
+    case 'deactivated':
+      return !u.is_active
+    default:
+      return true
+  }
+}
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      className={cn('ml-1 inline-block transition-transform', !active && 'opacity-30')}
+      aria-hidden="true"
+    >
+      <path
+        d="M6 2L9 5H3L6 2Z"
+        fill="currentColor"
+        className={cn(active && dir === 'asc' ? 'opacity-100' : 'opacity-30')}
+      />
+      <path
+        d="M6 10L3 7H9L6 10Z"
+        fill="currentColor"
+        className={cn(active && dir === 'desc' ? 'opacity-100' : 'opacity-30')}
+      />
+    </svg>
+  )
+}
+
+// ─── Action Button ───────────────────────────────────────────────────
+
+function ActionButton({
+  action,
+  userId,
+  hiddenFields,
+  label,
+  className,
+  disabled,
+  title,
+}: {
+  action: (state: { success: boolean; message: string }, formData: FormData) => Promise<{ success: boolean; message: string }>
+  userId: string
+  hiddenFields?: Record<string, string>
+  label: string
+  className?: string
+  disabled?: boolean
+  title?: string
+}) {
+  const [, formAction, isPending] = useActionState(action, {
+    success: false,
+    message: '',
+  })
+
+  return (
+    <form action={formAction}>
+      <input type="hidden" name="user_id" value={userId} />
+      {hiddenFields &&
+        Object.entries(hiddenFields).map(([name, value]) => (
+          <input key={name} type="hidden" name={name} value={value} />
+        ))}
+      <button
+        type="submit"
+        disabled={disabled || isPending}
+        title={title}
+        className={cn(
+          'rounded-md px-2.5 py-1.5 font-body text-xs font-medium border transition-colors whitespace-nowrap',
+          'disabled:opacity-35 disabled:cursor-not-allowed',
+          className
+        )}
+      >
+        {isPending ? '...' : label}
+      </button>
+    </form>
+  )
+}
+
+// ─── Component ───────────────────────────────────────────────────────
+
+export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps) {
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<FilterValue>('')
+  const [sortKey, setSortKey] = useState<SortKey>('created_at')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [page, setPage] = useState(1)
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortKey(key)
+      setSortDir('asc')
+    }
+    setPage(1)
+  }
+
+  const filtered = useMemo(() => {
+    let result = users
+
+    if (search) {
+      const q = search.toLowerCase()
+      result = result.filter(
+        (u) =>
+          (u.full_name && u.full_name.toLowerCase().includes(q)) ||
+          (u.email && u.email.toLowerCase().includes(q))
+      )
+    }
+
+    if (filter) {
+      result = result.filter((u) => matchesFilter(u, filter))
+    }
+
+    return result.sort((a, b) => {
+      let cmp: number
+      switch (sortKey) {
+        case 'name':
+          cmp = getName(a).localeCompare(getName(b))
+          break
+        case 'role':
+          cmp = a.role.localeCompare(b.role)
+          break
+        case 'status': {
+          const sa = a.is_active ? 'active' : 'deactivated'
+          const sb = b.is_active ? 'active' : 'deactivated'
+          cmp = sa.localeCompare(sb)
+          break
+        }
+        default:
+          cmp = String(a[sortKey]).localeCompare(String(b[sortKey]))
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  }, [users, search, filter, sortKey, sortDir])
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const paginated = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  const thClass =
+    'px-4 py-3 text-left font-body text-xs font-medium uppercase tracking-wider text-wood-800/60 cursor-pointer select-none hover:text-wood-900 transition-colors'
+
+  return (
+    <div>
+      {/* Toolbar */}
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        {/* Search */}
+        <div className="relative flex-1 sm:max-w-xs">
+          <SearchIcon />
+          <input
+            type="search"
+            placeholder="Search by name or email..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value)
+              setPage(1)
+            }}
+            className="w-full rounded-lg border border-wood-800/10 bg-cream-50 py-2 pl-9 pr-3 font-body text-sm text-wood-900 placeholder:text-wood-800/40 focus:border-burgundy-700 focus:outline-none focus:ring-1 focus:ring-burgundy-700"
+          />
+        </div>
+
+        {/* Filter pills */}
+        <div className="flex items-center gap-1.5">
+          {FILTER_OPTIONS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => {
+                setFilter(value)
+                setPage(1)
+              }}
+              className={cn(
+                'rounded-full px-3 py-1 font-body text-xs font-medium transition-colors',
+                filter === value
+                  ? 'bg-burgundy-700 text-cream-50'
+                  : 'bg-cream-100 text-wood-800 hover:bg-cream-100/80'
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-wood-800/10">
+        <table className="w-full">
+          <thead className="border-b border-wood-800/10 bg-cream-100/50">
+            <tr>
+              <th className={thClass} onClick={() => toggleSort('name')}>
+                User
+                <SortIcon active={sortKey === 'name'} dir={sortDir} />
+              </th>
+              <th
+                className={cn(thClass, 'hidden sm:table-cell')}
+                onClick={() => toggleSort('role')}
+              >
+                Role
+                <SortIcon active={sortKey === 'role'} dir={sortDir} />
+              </th>
+              <th
+                className={cn(thClass, 'hidden sm:table-cell')}
+                onClick={() => toggleSort('status')}
+              >
+                Status
+                <SortIcon active={sortKey === 'status'} dir={sortDir} />
+              </th>
+              <th
+                className={cn(thClass, 'hidden sm:table-cell')}
+                onClick={() => toggleSort('created_at')}
+              >
+                Joined
+                <SortIcon active={sortKey === 'created_at'} dir={sortDir} />
+              </th>
+              <th className="px-4 py-3 text-right font-body text-xs font-medium uppercase tracking-wider text-wood-800/60">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-wood-800/5">
+            {paginated.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-4 py-12 text-center font-body text-sm text-wood-800/60"
+                >
+                  {search || filter ? 'No users match your filters.' : 'No users yet.'}
+                </td>
+              </tr>
+            ) : (
+              paginated.map((user) => {
+                const isSelf = user.id === currentUserId
+                const status = user.is_active ? 'active' : 'deactivated'
+
+                return (
+                  <tr
+                    key={user.id}
+                    onClick={() => onRowClick?.(user)}
+                    className={cn(
+                      'transition-colors',
+                      onRowClick && 'cursor-pointer',
+                      !user.is_active ? 'opacity-60' : 'hover:bg-cream-100/30'
+                    )}
+                  >
+                    {/* User (name + email) */}
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="font-body text-sm font-medium text-burgundy-700">
+                          {user.full_name || '—'}
+                        </span>
+                        <span className="font-body text-xs text-wood-800/50">
+                          {user.email || '—'}
+                        </span>
+                      </div>
+                    </td>
+
+                    {/* Role badge */}
+                    <td className="hidden px-4 py-3 sm:table-cell">
+                      <span
+                        className={cn(
+                          'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+                          ROLE_COLORS[user.role] ?? 'bg-gray-50 text-gray-700'
+                        )}
+                      >
+                        {ROLE_LABELS[user.role] ?? user.role}
+                      </span>
+                    </td>
+
+                    {/* Status badge */}
+                    <td className="hidden px-4 py-3 sm:table-cell">
+                      <span
+                        className={cn(
+                          'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+                          STATUS_COLORS[status]
+                        )}
+                      >
+                        {status === 'active' ? 'Active' : 'Deactivated'}
+                      </span>
+                    </td>
+
+                    {/* Joined date */}
+                    <td className="hidden px-4 py-3 font-body text-sm text-wood-800/60 sm:table-cell">
+                      {formatDate(user.created_at)}
+                    </td>
+
+                    {/* Actions */}
+                    <td
+                      className="px-4 py-3"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center justify-end gap-1.5">
+                        {user.is_active ? (
+                          <>
+                            <ActionButton
+                              action={updateUserRole}
+                              userId={user.id}
+                              hiddenFields={{
+                                role: user.role === 'admin' ? 'member' : 'admin',
+                              }}
+                              label="Change Role"
+                              className="border-wood-800/15 bg-white text-wood-800 hover:bg-cream-100"
+                              disabled={isSelf}
+                              title={
+                                isSelf ? 'You cannot change your own role' : undefined
+                              }
+                            />
+                            <ActionButton
+                              action={deactivateUser}
+                              userId={user.id}
+                              label="Deactivate"
+                              className="border-red-200 bg-white text-red-600 hover:bg-red-50"
+                              disabled={isSelf}
+                              title={
+                                isSelf
+                                  ? 'You cannot deactivate yourself'
+                                  : undefined
+                              }
+                            />
+                          </>
+                        ) : (
+                          <ActionButton
+                            action={reactivateUser}
+                            userId={user.id}
+                            label="Reactivate"
+                            className="border-emerald-200 bg-white text-emerald-600 hover:bg-emerald-50"
+                          />
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between">
+          <p className="font-body text-sm text-wood-800/60">
+            {filtered.length} user{filtered.length !== 1 ? 's' : ''}
+          </p>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage(page - 1)}
+              className="rounded-lg px-3 py-1.5 font-body text-xs font-medium text-wood-800 transition-colors hover:bg-cream-100 disabled:opacity-40 disabled:pointer-events-none"
+            >
+              Previous
+            </button>
+            <span className="px-2 font-body text-xs text-wood-800/60">
+              {page} of {totalPages}
+            </span>
+            <button
+              type="button"
+              disabled={page >= totalPages}
+              onClick={() => setPage(page + 1)}
+              className="rounded-lg px-3 py-1.5 font-body text-xs font-medium text-wood-800 transition-colors hover:bg-cream-100 disabled:opacity-40 disabled:pointer-events-none"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Icons ───────────────────────────────────────────────────────────
+
+function SearchIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="absolute left-3 top-1/2 -translate-y-1/2 text-wood-800/40"
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="M21 21l-4.3-4.3" />
+    </svg>
+  )
+}

--- a/src/components/features/UsersTable.tsx
+++ b/src/components/features/UsersTable.tsx
@@ -55,6 +55,7 @@ const FILTER_OPTIONS: { value: FilterValue; label: string }[] = [
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', {
+    timeZone: 'UTC',
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -136,7 +137,8 @@ function ActionButton({
     }
   }, [state])
 
-  return (
+  const isDisabled = disabled || isPending
+  const button = (
     <form action={formAction}>
       <input type="hidden" name="user_id" value={userId} />
       {hiddenFields &&
@@ -145,11 +147,12 @@ function ActionButton({
         ))}
       <button
         type="submit"
-        disabled={disabled || isPending}
-        title={title}
+        disabled={isDisabled}
+        aria-disabled={isDisabled || undefined}
+        aria-label={isDisabled && title ? `${label} — ${title}` : undefined}
         className={cn(
           'rounded-md px-2.5 py-1.5 font-body text-xs font-medium border transition-colors whitespace-nowrap',
-          'disabled:opacity-35 disabled:cursor-not-allowed',
+          isDisabled && 'opacity-35 cursor-not-allowed',
           className
         )}
       >
@@ -157,6 +160,17 @@ function ActionButton({
       </button>
     </form>
   )
+
+  // Wrap disabled buttons so the tooltip is accessible via the focusable wrapper
+  if (isDisabled && title) {
+    return (
+      <span title={title} className="inline-block">
+        {button}
+      </span>
+    )
+  }
+
+  return button
 }
 
 // ─── Component ───────────────────────────────────────────────────────

--- a/src/components/features/UsersTable.tsx
+++ b/src/components/features/UsersTable.tsx
@@ -194,7 +194,7 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
       result = result.filter((u) => matchesFilter(u, filter))
     }
 
-    return result.sort((a, b) => {
+    return [...result].sort((a, b) => {
       let cmp: number
       switch (sortKey) {
         case 'name':


### PR DESCRIPTION
## Summary
- Adds `/admin/users` page with server-side data fetching from Supabase profiles table
- Summary cards showing Total, Admins, Members, and Deactivated counts with colored dot indicators
- Client-side `UsersTable` component with search (name/email), filter pills (All/Admins/Members/Deactivated), sortable columns, and pagination at 20/page
- Action buttons (Change Role, Deactivate, Reactivate) wired to existing server actions via `useActionState`
- Current user's action buttons disabled with tooltip for self-protection
- Deactivated rows rendered at reduced opacity
- "Invite User" button linking to `/admin/users/invite`
- `onRowClick` prop ready for #140 slide-out panel

Closes #139

## Test plan
- [ ] Navigate to `/admin/users` — page loads with correct data
- [ ] Summary cards show accurate counts
- [ ] Search filters by name and email
- [ ] Filter pills work (All, Admins, Members, Deactivated)
- [ ] Table is sortable by each column
- [ ] Pagination works at 20 per page
- [ ] Current user's action buttons are disabled
- [ ] Deactivated rows are visually dimmed
- [ ] Change Role / Deactivate / Reactivate actions work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin users page with summary cards and an Invite User link.
  * Searchable, filterable, sortable, paginated users table with row-click support and contextual empty states.
  * Per-user actions for changing role, deactivating, and reactivating users; deactivated users are visually de-emphasized and current-user actions are disabled.

* **Bug Fixes**
  * Enforced admin-only authorization for deactivate/reactivate actions to prevent unauthorized changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->