### PR TITLE
Add invite user page and form

### DIFF
--- a/src/app/(admin)/admin/users/invite/page.tsx
+++ b/src/app/(admin)/admin/users/invite/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+import { InviteUserForm } from '@/components/features/InviteUserForm'
+
+export const metadata: Metadata = {
+  title: 'Invite User',
+}
+
+export default function InviteUserPage() {
+  return (
+    <main className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-6">
+        <Link
+          href="/admin/users"
+          className="inline-flex items-center gap-1 font-body text-sm text-wood-800/60 transition-colors hover:text-burgundy-700"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M19 12H5" />
+            <path d="M12 19l-7-7 7-7" />
+          </svg>
+          Back to Users
+        </Link>
+        <h1 className="mt-2 font-heading text-3xl font-semibold text-wood-900">Invite User</h1>
+      </div>
+
+      <div className="max-w-2xl">
+        <InviteUserForm />
+      </div>
+    </main>
+  )
+}

--- a/src/components/features/InviteUserForm.tsx
+++ b/src/components/features/InviteUserForm.tsx
@@ -20,10 +20,10 @@ const initialState = {
   errors: undefined as Record<string, string[]> | undefined,
 }
 
-function FieldError({ errors }: { errors?: string[] }) {
+function FieldError({ id, errors }: { id: string; errors?: string[] }) {
   if (!errors?.length) return null
   return (
-    <p className="mt-1.5 font-body text-sm text-red-600" role="alert">
+    <p id={id} className="mt-1.5 font-body text-sm text-red-600" role="alert">
       {errors[0]}
     </p>
   )
@@ -59,9 +59,11 @@ export function InviteUserForm() {
           name="email"
           required
           placeholder="e.g. john@example.com"
+          aria-invalid={Boolean(state.errors?.email)}
+          aria-describedby={state.errors?.email ? 'email-error' : undefined}
           className={cn(inputBase, state.errors?.email && 'border-red-400')}
         />
-        <FieldError errors={state.errors?.email} />
+        <FieldError id="email-error" errors={state.errors?.email} />
       </div>
 
       {/* Full Name */}
@@ -79,9 +81,11 @@ export function InviteUserForm() {
           required
           maxLength={200}
           placeholder="e.g. John Thomas"
+          aria-invalid={Boolean(state.errors?.full_name)}
+          aria-describedby={state.errors?.full_name ? 'full-name-error' : undefined}
           className={cn(inputBase, state.errors?.full_name && 'border-red-400')}
         />
-        <FieldError errors={state.errors?.full_name} />
+        <FieldError id="full-name-error" errors={state.errors?.full_name} />
       </div>
 
       {/* Role */}
@@ -93,6 +97,8 @@ export function InviteUserForm() {
           id="role"
           name="role"
           defaultValue="member"
+          aria-invalid={Boolean(state.errors?.role)}
+          aria-describedby={state.errors?.role ? 'role-error' : undefined}
           className={cn(inputBase, state.errors?.role && 'border-red-400')}
         >
           {ROLES.map((r) => (
@@ -101,7 +107,7 @@ export function InviteUserForm() {
             </option>
           ))}
         </select>
-        <FieldError errors={state.errors?.role} />
+        <FieldError id="role-error" errors={state.errors?.role} />
       </div>
 
       {/* Submit / Cancel */}
@@ -130,7 +136,7 @@ export function InviteUserForm() {
             'Send Invite'
           )}
         </Button>
-        <Button type="button" variant="ghost" href="/admin/users">
+        <Button variant="ghost" href="/admin/users">
           Cancel
         </Button>
       </div>

--- a/src/components/features/InviteUserForm.tsx
+++ b/src/components/features/InviteUserForm.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useActionState, useEffect } from 'react'
+
+import { inviteUser } from '@/actions/users'
+import { Button } from '@/components/ui'
+import { cn } from '@/lib/utils'
+
+const ROLES = [
+  { value: 'member', label: 'Member' },
+  { value: 'admin', label: 'Admin' },
+] as const
+
+const inputBase =
+  'w-full rounded-lg border bg-cream-50 px-4 py-3 font-body text-base text-wood-800 placeholder:text-wood-800/40 transition-colors focus:border-burgundy-700 focus:outline-none focus:ring-2 focus:ring-burgundy-700/20'
+
+const initialState = {
+  success: false,
+  message: '',
+  errors: undefined as Record<string, string[]> | undefined,
+}
+
+function FieldError({ errors }: { errors?: string[] }) {
+  if (!errors?.length) return null
+  return (
+    <p className="mt-1.5 font-body text-sm text-red-600" role="alert">
+      {errors[0]}
+    </p>
+  )
+}
+
+export function InviteUserForm() {
+  const [state, formAction, isPending] = useActionState(inviteUser, initialState)
+
+  // Redirect on success
+  useEffect(() => {
+    if (state.success) {
+      window.location.href = '/admin/users'
+    }
+  }, [state.success])
+
+  return (
+    <form action={formAction} className="space-y-6">
+      {/* Server error message */}
+      {!state.success && state.message && !state.errors && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3" role="alert">
+          <p className="font-body text-sm text-red-600">{state.message}</p>
+        </div>
+      )}
+
+      {/* Email */}
+      <div>
+        <label htmlFor="email" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          Email <span className="text-burgundy-700">*</span>
+        </label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          required
+          placeholder="e.g. john@example.com"
+          className={cn(inputBase, state.errors?.email && 'border-red-400')}
+        />
+        <FieldError errors={state.errors?.email} />
+      </div>
+
+      {/* Full Name */}
+      <div>
+        <label
+          htmlFor="full_name"
+          className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+        >
+          Full Name <span className="text-burgundy-700">*</span>
+        </label>
+        <input
+          type="text"
+          id="full_name"
+          name="full_name"
+          required
+          maxLength={200}
+          placeholder="e.g. John Thomas"
+          className={cn(inputBase, state.errors?.full_name && 'border-red-400')}
+        />
+        <FieldError errors={state.errors?.full_name} />
+      </div>
+
+      {/* Role */}
+      <div>
+        <label htmlFor="role" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          Role
+        </label>
+        <select
+          id="role"
+          name="role"
+          defaultValue="member"
+          className={cn(inputBase, state.errors?.role && 'border-red-400')}
+        >
+          {ROLES.map((r) => (
+            <option key={r.value} value={r.value}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+        <FieldError errors={state.errors?.role} />
+      </div>
+
+      {/* Submit / Cancel */}
+      <div className="flex items-center gap-4 border-t border-wood-800/10 pt-6">
+        <Button type="submit" disabled={isPending}>
+          {isPending ? (
+            <span className="flex items-center gap-2">
+              <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Sending Invite...
+            </span>
+          ) : (
+            'Send Invite'
+          )}
+        </Button>
+        <Button type="button" variant="ghost" href="/admin/users">
+          Cancel
+        </Button>
+      </div>
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds server component page at `/admin/users/invite` with back link, heading, and `max-w-2xl` container
- Adds `InviteUserForm` client component with email, full name, and role fields
- Wired to existing `inviteUser` server action via `useActionState` with field-level Zod validation, error banner, loading spinner, and success redirect

## Dependencies
- #135 (Zod validators)
- #136 (inviteUser server action)
- #138 (nav — "Invite User" button on users page links here)

## Test plan
- [ ] Page loads at `/admin/users/invite`
- [ ] Form validates required fields with clear errors
- [ ] Invalid email shows validation error
- [ ] Submitting calls the `inviteUser` server action
- [ ] Loading state shows spinner on submit button
- [ ] Success redirects to `/admin/users`
- [ ] Duplicate email shows a clear error message
- [ ] Cancel navigates back to `/admin/users`
- [ ] Back link navigates to `/admin/users`

Closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin "Invite User" page with a dedicated invite form.
  * Form includes email, full name, and role selection fields.
  * Built-in validation with clear, field-level error messages and accessibility attributes.
  * Submit shows a loading state ("Sending Invite...") and disables while pending.
  * Successful invites automatically redirect to the users list; a Cancel button returns to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->