### PR TITLE
feat: member experience database schema (#145-#149)

### DIFF
--- a/supabase/migrations/20260409000000_create_families.sql
+++ b/supabase/migrations/20260409000000_create_families.sql
@@ -55,7 +55,7 @@ CREATE POLICY "Users can update own profile"
   WITH CHECK (
     id = (SELECT auth.uid())
     AND role = (SELECT p.role FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
-    AND is_active IS NOT DISTINCT FROM (SELECT p.is_active FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
+    AND is_active = (SELECT p.is_active FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
     AND family_id IS NOT DISTINCT FROM (SELECT p.family_id FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
   );
 

--- a/supabase/migrations/20260409000000_create_families.sql
+++ b/supabase/migrations/20260409000000_create_families.sql
@@ -1,0 +1,83 @@
+-- Migration: Create families table and link to profiles
+-- Issues: #145
+
+-- ─── Families Table ────────────────────────────────────────────────────
+
+CREATE TABLE public.families (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  head_of_household UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  family_name TEXT NOT NULL,
+  phone TEXT,
+  address TEXT,
+  membership_status TEXT NOT NULL DEFAULT 'pending' CHECK (membership_status IN ('active', 'expired', 'pending')),
+  membership_type TEXT CHECK (membership_type IN ('monthly', 'annual')),
+  membership_expires_at DATE,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_families_head_of_household ON public.families(head_of_household);
+CREATE INDEX idx_families_membership_status ON public.families(membership_status);
+
+-- Enable RLS
+ALTER TABLE public.families ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: members can read their own family
+CREATE POLICY "Members can read own family"
+  ON public.families FOR SELECT
+  TO authenticated
+  USING (
+    id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- SELECT: admins can read all families
+CREATE POLICY "Admins can read all families"
+  ON public.families FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- UPDATE: members can update their own family
+CREATE POLICY "Members can update own family"
+  ON public.families FOR UPDATE
+  TO authenticated
+  USING (
+    id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  )
+  WITH CHECK (
+    id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- UPDATE: admins can update all families
+CREATE POLICY "Admins can update all families"
+  ON public.families FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- INSERT: admins only
+CREATE POLICY "Admins can insert families"
+  ON public.families FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+-- DELETE: admins only
+CREATE POLICY "Admins can delete families"
+  ON public.families FOR DELETE
+  TO authenticated
+  USING (public.is_admin());
+
+-- Auto-update updated_at
+CREATE TRIGGER set_families_updated_at
+  BEFORE UPDATE ON public.families
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ─── Link profiles to families ──────────────────────────────────────────
+
+ALTER TABLE public.profiles
+  ADD COLUMN family_id UUID REFERENCES public.families(id) ON DELETE SET NULL,
+  ADD COLUMN phone TEXT;
+
+CREATE INDEX idx_profiles_family_id ON public.profiles(family_id);

--- a/supabase/migrations/20260409000000_create_families.sql
+++ b/supabase/migrations/20260409000000_create_families.sql
@@ -20,48 +20,50 @@ CREATE TABLE public.families (
 CREATE INDEX idx_families_head_of_household ON public.families(head_of_household);
 CREATE INDEX idx_families_membership_status ON public.families(membership_status);
 
+-- ─── Link profiles to families ──────────────────────────────────────────
+-- Must happen before RLS policies that reference profiles.family_id
+
+ALTER TABLE public.profiles
+  ADD COLUMN family_id UUID REFERENCES public.families(id) ON DELETE SET NULL,
+  ADD COLUMN phone TEXT;
+
+CREATE INDEX idx_profiles_family_id ON public.profiles(family_id);
+
 -- Enable RLS
 ALTER TABLE public.families ENABLE ROW LEVEL SECURITY;
 
--- RLS Policies
+-- ─── RLS Policies ──────────────────────────────────────────────────────
+-- Member + admin merged into single policies per action to avoid multiple
+-- permissive policy overhead. auth.uid() wrapped in (select ...) so it
+-- evaluates once per query, not per row.
 
--- SELECT: members can read their own family
-CREATE POLICY "Members can read own family"
+-- SELECT: members see their own family, admins see all
+CREATE POLICY "Select families"
   ON public.families FOR SELECT
   TO authenticated
   USING (
-    id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
-
--- SELECT: admins can read all families
-CREATE POLICY "Admins can read all families"
-  ON public.families FOR SELECT
-  TO authenticated
-  USING (public.is_admin());
-
--- UPDATE: members can update their own family
-CREATE POLICY "Members can update own family"
-  ON public.families FOR UPDATE
-  TO authenticated
-  USING (
-    id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
-  )
-  WITH CHECK (
-    id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
-  );
-
--- UPDATE: admins can update all families
-CREATE POLICY "Admins can update all families"
-  ON public.families FOR UPDATE
-  TO authenticated
-  USING (public.is_admin())
-  WITH CHECK (public.is_admin());
 
 -- INSERT: admins only
 CREATE POLICY "Admins can insert families"
   ON public.families FOR INSERT
   TO authenticated
   WITH CHECK (public.is_admin());
+
+-- UPDATE: members update their own family, admins update all
+CREATE POLICY "Update families"
+  ON public.families FOR UPDATE
+  TO authenticated
+  USING (
+    public.is_admin()
+    OR id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+  )
+  WITH CHECK (
+    public.is_admin()
+    OR id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+  );
 
 -- DELETE: admins only
 CREATE POLICY "Admins can delete families"
@@ -73,11 +75,3 @@ CREATE POLICY "Admins can delete families"
 CREATE TRIGGER set_families_updated_at
   BEFORE UPDATE ON public.families
   FOR EACH ROW EXECUTE FUNCTION update_updated_at();
-
--- ─── Link profiles to families ──────────────────────────────────────────
-
-ALTER TABLE public.profiles
-  ADD COLUMN family_id UUID REFERENCES public.families(id) ON DELETE SET NULL,
-  ADD COLUMN phone TEXT;
-
-CREATE INDEX idx_profiles_family_id ON public.profiles(family_id);

--- a/supabase/migrations/20260409000000_create_families.sql
+++ b/supabase/migrations/20260409000000_create_families.sql
@@ -33,6 +33,15 @@ CREATE INDEX idx_profiles_family_id ON public.profiles(family_id);
 -- that enforces a linked profile belongs to the same family.
 CREATE UNIQUE INDEX idx_profiles_id_family_unique ON public.profiles(id, family_id);
 
+-- Composite FK: ensures head_of_household profile belongs to THIS family.
+-- Requires idx_profiles_id_family_unique above to exist first.
+-- MATCH SIMPLE (default): skipped when head_of_household IS NULL, so families
+-- can be created before a head is assigned.
+ALTER TABLE public.families
+  ADD CONSTRAINT fk_families_head_of_household_family
+  FOREIGN KEY (head_of_household, id)
+  REFERENCES public.profiles(id, family_id);
+
 -- ─── Protect profiles.family_id from self-assignment ────────────────────
 -- Drop and recreate the user self-update policy to also prevent users from
 -- reassigning their own family_id, which would bypass family-scoped RLS.
@@ -42,10 +51,11 @@ DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
 CREATE POLICY "Users can update own profile"
   ON public.profiles FOR UPDATE
   TO authenticated
-  USING (id = (SELECT auth.uid()))
+  USING (id = (SELECT auth.uid()) AND is_active = true)
   WITH CHECK (
     id = (SELECT auth.uid())
     AND role = (SELECT p.role FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
+    AND is_active IS NOT DISTINCT FROM (SELECT p.is_active FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
     AND family_id IS NOT DISTINCT FROM (SELECT p.family_id FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
   );
 
@@ -86,11 +96,13 @@ CREATE POLICY "Update families"
     public.is_admin()
     OR (
       id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
-      -- Prevent non-admins from changing admin-controlled columns
-      AND membership_status = (SELECT f.membership_status FROM public.families f WHERE f.id = id)
-      AND membership_type IS NOT DISTINCT FROM (SELECT f.membership_type FROM public.families f WHERE f.id = id)
-      AND membership_expires_at IS NOT DISTINCT FROM (SELECT f.membership_expires_at FROM public.families f WHERE f.id = id)
-      AND head_of_household IS NOT DISTINCT FROM (SELECT f.head_of_household FROM public.families f WHERE f.id = id)
+      -- Prevent non-admins from changing admin-controlled columns.
+      -- Use families.id (outer row reference) so the subquery filters to THIS
+      -- family, not f.id = f.id (always-true self-match via the inner alias).
+      AND membership_status = (SELECT f.membership_status FROM public.families f WHERE f.id = families.id)
+      AND membership_type IS NOT DISTINCT FROM (SELECT f.membership_type FROM public.families f WHERE f.id = families.id)
+      AND membership_expires_at IS NOT DISTINCT FROM (SELECT f.membership_expires_at FROM public.families f WHERE f.id = families.id)
+      AND head_of_household IS NOT DISTINCT FROM (SELECT f.head_of_household FROM public.families f WHERE f.id = families.id)
     )
   );
 

--- a/supabase/migrations/20260409000000_create_families.sql
+++ b/supabase/migrations/20260409000000_create_families.sql
@@ -29,6 +29,26 @@ ALTER TABLE public.profiles
 
 CREATE INDEX idx_profiles_family_id ON public.profiles(family_id);
 
+-- Unique index on (id, family_id) to support composite FK in family_members
+-- that enforces a linked profile belongs to the same family.
+CREATE UNIQUE INDEX idx_profiles_id_family_unique ON public.profiles(id, family_id);
+
+-- ─── Protect profiles.family_id from self-assignment ────────────────────
+-- Drop and recreate the user self-update policy to also prevent users from
+-- reassigning their own family_id, which would bypass family-scoped RLS.
+
+DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
+
+CREATE POLICY "Users can update own profile"
+  ON public.profiles FOR UPDATE
+  TO authenticated
+  USING (id = (SELECT auth.uid()))
+  WITH CHECK (
+    id = (SELECT auth.uid())
+    AND role = (SELECT p.role FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
+    AND family_id IS NOT DISTINCT FROM (SELECT p.family_id FROM public.profiles p WHERE p.id = (SELECT auth.uid()))
+  );
+
 -- Enable RLS
 ALTER TABLE public.families ENABLE ROW LEVEL SECURITY;
 
@@ -52,7 +72,9 @@ CREATE POLICY "Admins can insert families"
   TO authenticated
   WITH CHECK (public.is_admin());
 
--- UPDATE: members update their own family, admins update all
+-- UPDATE: members can update non-admin fields; admins can update everything.
+-- Non-admins are blocked from changing membership_status, membership_type,
+-- membership_expires_at, and head_of_household (admin-controlled columns).
 CREATE POLICY "Update families"
   ON public.families FOR UPDATE
   TO authenticated
@@ -62,7 +84,14 @@ CREATE POLICY "Update families"
   )
   WITH CHECK (
     public.is_admin()
-    OR id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+    OR (
+      id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+      -- Prevent non-admins from changing admin-controlled columns
+      AND membership_status = (SELECT f.membership_status FROM public.families f WHERE f.id = id)
+      AND membership_type IS NOT DISTINCT FROM (SELECT f.membership_type FROM public.families f WHERE f.id = id)
+      AND membership_expires_at IS NOT DISTINCT FROM (SELECT f.membership_expires_at FROM public.families f WHERE f.id = id)
+      AND head_of_household IS NOT DISTINCT FROM (SELECT f.head_of_household FROM public.families f WHERE f.id = id)
+    )
   );
 
 -- DELETE: admins only

--- a/supabase/migrations/20260409000001_create_family_members.sql
+++ b/supabase/migrations/20260409000001_create_family_members.sql
@@ -1,0 +1,80 @@
+-- Migration: Create family_members table
+-- Issue: #146
+
+CREATE TABLE public.family_members (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  full_name TEXT NOT NULL,
+  relationship TEXT NOT NULL CHECK (relationship IN ('self', 'spouse', 'child', 'parent', 'sibling', 'other')),
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_family_members_family_id ON public.family_members(family_id);
+CREATE INDEX idx_family_members_profile_id ON public.family_members(profile_id);
+
+-- Enable RLS
+ALTER TABLE public.family_members ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: members can read their own family's members
+CREATE POLICY "Members can read own family members"
+  ON public.family_members FOR SELECT
+  TO authenticated
+  USING (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- SELECT: admins can read all
+CREATE POLICY "Admins can read all family members"
+  ON public.family_members FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: members can add to their own family
+CREATE POLICY "Members can insert own family members"
+  ON public.family_members FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- INSERT: admins can insert any
+CREATE POLICY "Admins can insert family members"
+  ON public.family_members FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+-- UPDATE: members can update their own family's members
+CREATE POLICY "Members can update own family members"
+  ON public.family_members FOR UPDATE
+  TO authenticated
+  USING (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  )
+  WITH CHECK (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- UPDATE: admins can update all
+CREATE POLICY "Admins can update all family members"
+  ON public.family_members FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- DELETE: members can remove from their own family
+CREATE POLICY "Members can delete own family members"
+  ON public.family_members FOR DELETE
+  TO authenticated
+  USING (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- DELETE: admins can delete all
+CREATE POLICY "Admins can delete all family members"
+  ON public.family_members FOR DELETE
+  TO authenticated
+  USING (public.is_admin());

--- a/supabase/migrations/20260409000001_create_family_members.sql
+++ b/supabase/migrations/20260409000001_create_family_members.sql
@@ -17,64 +17,47 @@ CREATE INDEX idx_family_members_profile_id ON public.family_members(profile_id);
 -- Enable RLS
 ALTER TABLE public.family_members ENABLE ROW LEVEL SECURITY;
 
--- RLS Policies
+-- ─── RLS Policies ──────────────────────────────────────────────────────
+-- Member + admin merged into single policies per action to avoid multiple
+-- permissive policy overhead. auth.uid() wrapped in (select ...) so it
+-- evaluates once per query, not per row.
 
--- SELECT: members can read their own family's members
-CREATE POLICY "Members can read own family members"
+-- SELECT: members see their own family's members, admins see all
+CREATE POLICY "Select family members"
   ON public.family_members FOR SELECT
   TO authenticated
   USING (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- SELECT: admins can read all
-CREATE POLICY "Admins can read all family members"
-  ON public.family_members FOR SELECT
-  TO authenticated
-  USING (public.is_admin());
-
--- INSERT: members can add to their own family
-CREATE POLICY "Members can insert own family members"
+-- INSERT: members add to their own family, admins add to any
+CREATE POLICY "Insert family members"
   ON public.family_members FOR INSERT
   TO authenticated
   WITH CHECK (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- INSERT: admins can insert any
-CREATE POLICY "Admins can insert family members"
-  ON public.family_members FOR INSERT
-  TO authenticated
-  WITH CHECK (public.is_admin());
-
--- UPDATE: members can update their own family's members
-CREATE POLICY "Members can update own family members"
+-- UPDATE: members update their own family's members, admins update all
+CREATE POLICY "Update family members"
   ON public.family_members FOR UPDATE
   TO authenticated
   USING (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   )
   WITH CHECK (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- UPDATE: admins can update all
-CREATE POLICY "Admins can update all family members"
-  ON public.family_members FOR UPDATE
-  TO authenticated
-  USING (public.is_admin())
-  WITH CHECK (public.is_admin());
-
--- DELETE: members can remove from their own family
-CREATE POLICY "Members can delete own family members"
+-- DELETE: members remove from their own family, admins remove any
+CREATE POLICY "Delete family members"
   ON public.family_members FOR DELETE
   TO authenticated
   USING (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
-
--- DELETE: admins can delete all
-CREATE POLICY "Admins can delete all family members"
-  ON public.family_members FOR DELETE
-  TO authenticated
-  USING (public.is_admin());

--- a/supabase/migrations/20260409000001_create_family_members.sql
+++ b/supabase/migrations/20260409000001_create_family_members.sql
@@ -10,6 +10,7 @@ CREATE TABLE public.family_members (
   full_name TEXT NOT NULL,
   relationship TEXT NOT NULL CHECK (relationship IN ('self', 'spouse', 'child', 'parent', 'sibling', 'other')),
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
   -- Composite FK: ensures the linked profile belongs to the same family.
   -- MATCH SIMPLE (default): skipped when profile_id IS NULL, so optional members work fine.
   -- ON DELETE SET NULL (profile_id): when a profile is deleted, profile_id is nulled
@@ -22,6 +23,11 @@ CREATE TABLE public.family_members (
 -- Indexes
 CREATE INDEX idx_family_members_family_id ON public.family_members(family_id);
 CREATE INDEX idx_family_members_profile_id ON public.family_members(profile_id);
+
+-- Auto-update updated_at
+CREATE TRIGGER set_family_members_updated_at
+  BEFORE UPDATE ON public.family_members
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 -- Enable RLS
 ALTER TABLE public.family_members ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260409000001_create_family_members.sql
+++ b/supabase/migrations/20260409000001_create_family_members.sql
@@ -23,6 +23,10 @@ CREATE TABLE public.family_members (
 -- Indexes
 CREATE INDEX idx_family_members_family_id ON public.family_members(family_id);
 CREATE INDEX idx_family_members_profile_id ON public.family_members(profile_id);
+-- One auth account can only be linked to one family_members row (partial: NULLs are unconstrained)
+CREATE UNIQUE INDEX uq_family_members_profile_id
+  ON public.family_members(profile_id)
+  WHERE profile_id IS NOT NULL;
 
 -- Auto-update updated_at
 CREATE TRIGGER set_family_members_updated_at

--- a/supabase/migrations/20260409000001_create_family_members.sql
+++ b/supabase/migrations/20260409000001_create_family_members.sql
@@ -4,10 +4,19 @@
 CREATE TABLE public.family_members (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
-  profile_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  -- No single-column FK on profile_id; composite FK below enforces same-family integrity.
+  -- profile_id is nullable — not all household members have a login account.
+  profile_id UUID,
   full_name TEXT NOT NULL,
   relationship TEXT NOT NULL CHECK (relationship IN ('self', 'spouse', 'child', 'parent', 'sibling', 'other')),
-  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  -- Composite FK: ensures the linked profile belongs to the same family.
+  -- MATCH SIMPLE (default): skipped when profile_id IS NULL, so optional members work fine.
+  -- ON DELETE SET NULL (profile_id): when a profile is deleted, profile_id is nulled
+  -- while family_id remains intact.
+  FOREIGN KEY (profile_id, family_id)
+    REFERENCES public.profiles(id, family_id)
+    ON DELETE SET NULL (profile_id)
 );
 
 -- Indexes

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -1,0 +1,63 @@
+-- Migration: Create shares table
+-- Issue: #147
+
+CREATE TABLE public.shares (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  person_name TEXT NOT NULL,
+  year INT NOT NULL,
+  amount NUMERIC NOT NULL DEFAULT 50,
+  paid BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_shares_family_id ON public.shares(family_id);
+CREATE INDEX idx_shares_year ON public.shares(year);
+CREATE INDEX idx_shares_year_paid ON public.shares(year, paid);
+
+-- Enable RLS
+ALTER TABLE public.shares ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: members can read their own family's shares
+CREATE POLICY "Members can read own family shares"
+  ON public.shares FOR SELECT
+  TO authenticated
+  USING (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- SELECT: admins can read all shares
+CREATE POLICY "Admins can read all shares"
+  ON public.shares FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: members can buy shares for their own family
+CREATE POLICY "Members can insert own family shares"
+  ON public.shares FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- INSERT: admins can insert any shares
+CREATE POLICY "Admins can insert shares"
+  ON public.shares FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+-- UPDATE: admins only (paid status, corrections)
+CREATE POLICY "Admins can update shares"
+  ON public.shares FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- DELETE: admins only
+CREATE POLICY "Admins can delete shares"
+  ON public.shares FOR DELETE
+  TO authenticated
+  USING (public.is_admin());

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -7,9 +7,12 @@ CREATE TABLE public.shares (
   person_name TEXT NOT NULL,
   year INT NOT NULL,
   -- amount must be non-negative; paid status is always false on insert (see trigger)
-  amount NUMERIC NOT NULL DEFAULT 50 CHECK (amount >= 0),
+  amount NUMERIC(10,2) NOT NULL DEFAULT 50 CHECK (amount >= 0),
   paid BOOLEAN NOT NULL DEFAULT false,
-  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  -- Prevent duplicate remembrance shares for the same person in the same year
+  CONSTRAINT uq_shares_family_person_year UNIQUE (family_id, person_name, year)
 );
 
 -- Unique key on (id, family_id) to support composite FK from payments,
@@ -20,6 +23,11 @@ ALTER TABLE public.shares ADD CONSTRAINT uq_shares_id_family UNIQUE (id, family_
 CREATE INDEX idx_shares_family_id ON public.shares(family_id);
 CREATE INDEX idx_shares_year ON public.shares(year);
 CREATE INDEX idx_shares_year_paid ON public.shares(year, paid);
+
+-- Auto-update updated_at
+CREATE TRIGGER set_shares_updated_at
+  BEFORE UPDATE ON public.shares
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 -- ─── Trigger: block paid=true on INSERT ──────────────────────────────────
 -- Members should not be able to mark a share as paid at insert time.

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -19,35 +19,28 @@ CREATE INDEX idx_shares_year_paid ON public.shares(year, paid);
 -- Enable RLS
 ALTER TABLE public.shares ENABLE ROW LEVEL SECURITY;
 
--- RLS Policies
+-- ─── RLS Policies ──────────────────────────────────────────────────────
+-- Member + admin merged into single policies per action to avoid multiple
+-- permissive policy overhead. auth.uid() wrapped in (select ...) so it
+-- evaluates once per query, not per row.
 
--- SELECT: members can read their own family's shares
-CREATE POLICY "Members can read own family shares"
+-- SELECT: members see their own family's shares, admins see all
+CREATE POLICY "Select shares"
   ON public.shares FOR SELECT
   TO authenticated
   USING (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- SELECT: admins can read all shares
-CREATE POLICY "Admins can read all shares"
-  ON public.shares FOR SELECT
-  TO authenticated
-  USING (public.is_admin());
-
--- INSERT: members can buy shares for their own family
-CREATE POLICY "Members can insert own family shares"
+-- INSERT: members buy shares for their own family, admins insert any
+CREATE POLICY "Insert shares"
   ON public.shares FOR INSERT
   TO authenticated
   WITH CHECK (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
-
--- INSERT: admins can insert any shares
-CREATE POLICY "Admins can insert shares"
-  ON public.shares FOR INSERT
-  TO authenticated
-  WITH CHECK (public.is_admin());
 
 -- UPDATE: admins only (paid status, corrections)
 CREATE POLICY "Admins can update shares"

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -12,6 +12,10 @@ CREATE TABLE public.shares (
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL
 );
 
+-- Unique key on (id, family_id) to support composite FK from payments,
+-- ensuring a payment cannot reference a share owned by a different family.
+ALTER TABLE public.shares ADD CONSTRAINT uq_shares_id_family UNIQUE (id, family_id);
+
 -- Indexes
 CREATE INDEX idx_shares_family_id ON public.shares(family_id);
 CREATE INDEX idx_shares_year ON public.shares(year);

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -6,8 +6,8 @@ CREATE TABLE public.shares (
   family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
   person_name TEXT NOT NULL,
   year INT NOT NULL,
-  -- amount must be non-negative; paid status is always false on insert (see trigger)
-  amount NUMERIC(10,2) NOT NULL DEFAULT 50 CHECK (amount >= 0),
+  -- amount is fixed at $50/year (ticket #147); paid status is always false on insert (see trigger)
+  amount NUMERIC(10,2) NOT NULL DEFAULT 50 CHECK (amount = 50),
   paid BOOLEAN NOT NULL DEFAULT false,
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
   updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -6,7 +6,8 @@ CREATE TABLE public.shares (
   family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
   person_name TEXT NOT NULL,
   year INT NOT NULL,
-  amount NUMERIC NOT NULL DEFAULT 50,
+  -- amount must be non-negative; paid status is always false on insert (see trigger)
+  amount NUMERIC NOT NULL DEFAULT 50 CHECK (amount >= 0),
   paid BOOLEAN NOT NULL DEFAULT false,
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL
 );
@@ -15,6 +16,23 @@ CREATE TABLE public.shares (
 CREATE INDEX idx_shares_family_id ON public.shares(family_id);
 CREATE INDEX idx_shares_year ON public.shares(year);
 CREATE INDEX idx_shares_year_paid ON public.shares(year, paid);
+
+-- ─── Trigger: block paid=true on INSERT ──────────────────────────────────
+-- Members should not be able to mark a share as paid at insert time.
+-- Paid status is admin-only via UPDATE. This trigger enforces it at the DB
+-- level regardless of the RLS path used.
+
+CREATE OR REPLACE FUNCTION fn_shares_block_paid_on_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.paid := false;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_shares_block_paid_on_insert
+  BEFORE INSERT ON public.shares
+  FOR EACH ROW EXECUTE FUNCTION fn_shares_block_paid_on_insert();
 
 -- Enable RLS
 ALTER TABLE public.shares ENABLE ROW LEVEL SECURITY;
@@ -34,6 +52,7 @@ CREATE POLICY "Select shares"
   );
 
 -- INSERT: members buy shares for their own family, admins insert any
+-- paid=true is always forced to false by the trigger regardless.
 CREATE POLICY "Insert shares"
   ON public.shares FOR INSERT
   TO authenticated

--- a/supabase/migrations/20260409000002_create_shares.sql
+++ b/supabase/migrations/20260409000002_create_shares.sql
@@ -51,14 +51,19 @@ CREATE POLICY "Select shares"
     OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- INSERT: members buy shares for their own family, admins insert any
--- paid=true is always forced to false by the trigger regardless.
+-- INSERT: members buy shares for their own family at the fixed $50 rate.
+-- Non-admins are restricted to paid=false and amount=50 at the policy level.
+-- The trigger also forces paid=false as a DB-level safety net for all paths.
 CREATE POLICY "Insert shares"
   ON public.shares FOR INSERT
   TO authenticated
   WITH CHECK (
     public.is_admin()
-    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+    OR (
+      family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+      AND paid = false
+      AND amount = 50
+    )
   );
 
 -- UPDATE: admins only (paid status, corrections)

--- a/supabase/migrations/20260409000003_create_payments.sql
+++ b/supabase/migrations/20260409000003_create_payments.sql
@@ -22,36 +22,31 @@ CREATE INDEX idx_payments_created_at ON public.payments(created_at DESC);
 -- Enable RLS
 ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY;
 
--- RLS Policies
+-- ─── RLS Policies ──────────────────────────────────────────────────────
+-- Member + admin merged into single policies per action to avoid multiple
+-- permissive policy overhead. auth.uid() wrapped in (select ...) so it
+-- evaluates once per query, not per row.
 
--- SELECT: members can read their own family's payments
-CREATE POLICY "Members can read own family payments"
+-- SELECT: members see their own family's payments, admins see all
+CREATE POLICY "Select payments"
   ON public.payments FOR SELECT
   TO authenticated
   USING (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- SELECT: admins can read all payments
-CREATE POLICY "Admins can read all payments"
-  ON public.payments FOR SELECT
-  TO authenticated
-  USING (public.is_admin());
-
--- INSERT: members can record donations for their own family
-CREATE POLICY "Members can insert own family donations"
+-- INSERT: members can record donations for their own family; admins record any type
+CREATE POLICY "Insert payments"
   ON public.payments FOR INSERT
   TO authenticated
   WITH CHECK (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
-    AND type = 'donation'
+    public.is_admin()
+    OR (
+      type = 'donation'
+      AND family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+    )
   );
-
--- INSERT: admins can record any payment type
-CREATE POLICY "Admins can insert payments"
-  ON public.payments FOR INSERT
-  TO authenticated
-  WITH CHECK (public.is_admin());
 
 -- UPDATE: admins only
 CREATE POLICY "Admins can update payments"

--- a/supabase/migrations/20260409000003_create_payments.sql
+++ b/supabase/migrations/20260409000003_create_payments.sql
@@ -1,0 +1,67 @@
+-- Migration: Create payments table
+-- Issue: #148
+
+CREATE TABLE public.payments (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN ('membership', 'share', 'event', 'donation')),
+  amount NUMERIC NOT NULL,
+  method TEXT CHECK (method IN ('cash', 'check', 'zelle', 'online')),
+  note TEXT,
+  recorded_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  related_event_id UUID REFERENCES public.events(id) ON DELETE SET NULL,
+  related_share_id UUID REFERENCES public.shares(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_payments_family_id ON public.payments(family_id);
+CREATE INDEX idx_payments_type ON public.payments(type);
+CREATE INDEX idx_payments_created_at ON public.payments(created_at DESC);
+
+-- Enable RLS
+ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: members can read their own family's payments
+CREATE POLICY "Members can read own family payments"
+  ON public.payments FOR SELECT
+  TO authenticated
+  USING (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- SELECT: admins can read all payments
+CREATE POLICY "Admins can read all payments"
+  ON public.payments FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: members can record donations for their own family
+CREATE POLICY "Members can insert own family donations"
+  ON public.payments FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    AND type = 'donation'
+  );
+
+-- INSERT: admins can record any payment type
+CREATE POLICY "Admins can insert payments"
+  ON public.payments FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+-- UPDATE: admins only
+CREATE POLICY "Admins can update payments"
+  ON public.payments FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- DELETE: admins only
+CREATE POLICY "Admins can delete payments"
+  ON public.payments FOR DELETE
+  TO authenticated
+  USING (public.is_admin());

--- a/supabase/migrations/20260409000003_create_payments.sql
+++ b/supabase/migrations/20260409000003_create_payments.sql
@@ -5,7 +5,7 @@ CREATE TABLE public.payments (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
   type TEXT NOT NULL CHECK (type IN ('membership', 'share', 'event', 'donation')),
-  amount NUMERIC NOT NULL,
+  amount NUMERIC(10,2) NOT NULL,
   method TEXT CHECK (method IN ('cash', 'check', 'zelle', 'online')),
   note TEXT,
   recorded_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
@@ -16,6 +16,7 @@ CREATE TABLE public.payments (
   related_share_id UUID,
   FOREIGN KEY (related_share_id, family_id) REFERENCES public.shares(id, family_id) ON DELETE SET NULL,
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
 
   -- Enforce consistency between type and relation columns to prevent impossible combos
   CONSTRAINT chk_payments_share_relation
@@ -25,6 +26,11 @@ CREATE TABLE public.payments (
   CONSTRAINT chk_payments_no_relation
     CHECK (type NOT IN ('membership', 'donation') OR (related_share_id IS NULL AND related_event_id IS NULL))
 );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_payments_updated_at
+  BEFORE UPDATE ON public.payments
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 -- Indexes
 CREATE INDEX idx_payments_family_id ON public.payments(family_id);

--- a/supabase/migrations/20260409000003_create_payments.sql
+++ b/supabase/migrations/20260409000003_create_payments.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE public.payments (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE RESTRICT,
   type TEXT NOT NULL CHECK (type IN ('membership', 'share', 'event', 'donation')),
   amount NUMERIC(10,2) NOT NULL,
   method TEXT CHECK (method IN ('cash', 'check', 'zelle', 'online')),
@@ -14,7 +14,9 @@ CREATE TABLE public.payments (
   -- this payment. Requires uq_shares_id_family on shares(id, family_id).
   -- MATCH SIMPLE (default): skipped when related_share_id IS NULL.
   related_share_id UUID,
-  FOREIGN KEY (related_share_id, family_id) REFERENCES public.shares(id, family_id) ON DELETE SET NULL,
+  FOREIGN KEY (related_share_id, family_id)
+    REFERENCES public.shares(id, family_id)
+    ON DELETE SET NULL (related_share_id),
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
   updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
 

--- a/supabase/migrations/20260409000003_create_payments.sql
+++ b/supabase/migrations/20260409000003_create_payments.sql
@@ -10,7 +10,11 @@ CREATE TABLE public.payments (
   note TEXT,
   recorded_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
   related_event_id UUID REFERENCES public.events(id) ON DELETE SET NULL,
-  related_share_id UUID REFERENCES public.shares(id) ON DELETE SET NULL,
+  -- Composite FK: ensures the referenced share belongs to the same family as
+  -- this payment. Requires uq_shares_id_family on shares(id, family_id).
+  -- MATCH SIMPLE (default): skipped when related_share_id IS NULL.
+  related_share_id UUID,
+  FOREIGN KEY (related_share_id, family_id) REFERENCES public.shares(id, family_id) ON DELETE SET NULL,
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
 
   -- Enforce consistency between type and relation columns to prevent impossible combos

--- a/supabase/migrations/20260409000003_create_payments.sql
+++ b/supabase/migrations/20260409000003_create_payments.sql
@@ -11,7 +11,15 @@ CREATE TABLE public.payments (
   recorded_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
   related_event_id UUID REFERENCES public.events(id) ON DELETE SET NULL,
   related_share_id UUID REFERENCES public.shares(id) ON DELETE SET NULL,
-  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+
+  -- Enforce consistency between type and relation columns to prevent impossible combos
+  CONSTRAINT chk_payments_share_relation
+    CHECK (type != 'share' OR (related_share_id IS NOT NULL AND related_event_id IS NULL)),
+  CONSTRAINT chk_payments_event_relation
+    CHECK (type != 'event' OR (related_event_id IS NOT NULL AND related_share_id IS NULL)),
+  CONSTRAINT chk_payments_no_relation
+    CHECK (type NOT IN ('membership', 'donation') OR (related_share_id IS NULL AND related_event_id IS NULL))
 );
 
 -- Indexes
@@ -36,7 +44,9 @@ CREATE POLICY "Select payments"
     OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- INSERT: members can record donations for their own family; admins record any type
+-- INSERT: members can record donations for their own family only.
+-- Requires recorded_by = their own auth.uid() to prevent impersonation.
+-- Admins can record any payment type.
 CREATE POLICY "Insert payments"
   ON public.payments FOR INSERT
   TO authenticated
@@ -45,6 +55,7 @@ CREATE POLICY "Insert payments"
     OR (
       type = 'donation'
       AND family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+      AND recorded_by = (SELECT auth.uid())
     )
   );
 

--- a/supabase/migrations/20260409000004_create_event_charges.sql
+++ b/supabase/migrations/20260409000004_create_event_charges.sql
@@ -1,0 +1,54 @@
+-- Migration: Create event_charges table
+-- Issue: #149
+
+CREATE TABLE public.event_charges (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
+  family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
+  amount NUMERIC NOT NULL,
+  paid BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Indexes
+CREATE INDEX idx_event_charges_event_id ON public.event_charges(event_id);
+CREATE INDEX idx_event_charges_family_id ON public.event_charges(family_id);
+CREATE INDEX idx_event_charges_family_paid ON public.event_charges(family_id, paid);
+
+-- Enable RLS
+ALTER TABLE public.event_charges ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+
+-- SELECT: members can read their own family's charges
+CREATE POLICY "Members can read own family event charges"
+  ON public.event_charges FOR SELECT
+  TO authenticated
+  USING (
+    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+  );
+
+-- SELECT: admins can read all charges
+CREATE POLICY "Admins can read all event charges"
+  ON public.event_charges FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: admins only (admin assigns charges to families)
+CREATE POLICY "Admins can insert event charges"
+  ON public.event_charges FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+-- UPDATE: admins only (mark paid, adjust amount)
+CREATE POLICY "Admins can update event charges"
+  ON public.event_charges FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- DELETE: admins only
+CREATE POLICY "Admins can delete event charges"
+  ON public.event_charges FOR DELETE
+  TO authenticated
+  USING (public.is_admin());

--- a/supabase/migrations/20260409000004_create_event_charges.sql
+++ b/supabase/migrations/20260409000004_create_event_charges.sql
@@ -18,23 +18,21 @@ CREATE INDEX idx_event_charges_family_paid ON public.event_charges(family_id, pa
 -- Enable RLS
 ALTER TABLE public.event_charges ENABLE ROW LEVEL SECURITY;
 
--- RLS Policies
+-- ─── RLS Policies ──────────────────────────────────────────────────────
+-- Member + admin merged into single policies per action to avoid multiple
+-- permissive policy overhead. auth.uid() wrapped in (select ...) so it
+-- evaluates once per query, not per row.
 
--- SELECT: members can read their own family's charges
-CREATE POLICY "Members can read own family event charges"
+-- SELECT: members see their own family's charges, admins see all
+CREATE POLICY "Select event charges"
   ON public.event_charges FOR SELECT
   TO authenticated
   USING (
-    family_id = (SELECT family_id FROM public.profiles WHERE id = auth.uid())
+    public.is_admin()
+    OR family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
   );
 
--- SELECT: admins can read all charges
-CREATE POLICY "Admins can read all event charges"
-  ON public.event_charges FOR SELECT
-  TO authenticated
-  USING (public.is_admin());
-
--- INSERT: admins only (admin assigns charges to families)
+-- INSERT: admins only (admin assigns charges to families after events)
 CREATE POLICY "Admins can insert event charges"
   ON public.event_charges FOR INSERT
   TO authenticated

--- a/supabase/migrations/20260409000004_create_event_charges.sql
+++ b/supabase/migrations/20260409000004_create_event_charges.sql
@@ -5,13 +5,19 @@ CREATE TABLE public.event_charges (
   id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   event_id UUID NOT NULL REFERENCES public.events(id) ON DELETE CASCADE,
   family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
-  amount NUMERIC NOT NULL,
+  amount NUMERIC(10,2) NOT NULL,
   paid BOOLEAN NOT NULL DEFAULT false,
   created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL,
 
   -- Prevent duplicate charges for the same family per event
   CONSTRAINT uq_event_charges_event_family UNIQUE (event_id, family_id)
 );
+
+-- Auto-update updated_at
+CREATE TRIGGER set_event_charges_updated_at
+  BEFORE UPDATE ON public.event_charges
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 -- Indexes
 CREATE INDEX idx_event_charges_event_id ON public.event_charges(event_id);

--- a/supabase/migrations/20260409000004_create_event_charges.sql
+++ b/supabase/migrations/20260409000004_create_event_charges.sql
@@ -7,7 +7,10 @@ CREATE TABLE public.event_charges (
   family_id UUID NOT NULL REFERENCES public.families(id) ON DELETE CASCADE,
   amount NUMERIC NOT NULL,
   paid BOOLEAN NOT NULL DEFAULT false,
-  created_at TIMESTAMPTZ DEFAULT now() NOT NULL
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+
+  -- Prevent duplicate charges for the same family per event
+  CONSTRAINT uq_event_charges_event_family UNIQUE (event_id, family_id)
 );
 
 -- Indexes


### PR DESCRIPTION
## Summary

Creates the foundational database tables for the member portal and admin financial features.

- **#145** — `families` table + `profiles.family_id` / `profiles.phone` columns
- **#146** — `family_members` table (household members, not all need logins)
- **#147** — `shares` table ($50/year name remembrance purchases)
- **#148** — `payments` table (unified ledger: membership, shares, events, donations)
- **#149** — `event_charges` table (per-family cost splits after events)

## RLS Design

All tables follow the same pattern:
- Members can only read/write their own family's data (scoped via `profiles.family_id`)
- Admins can read and manage all rows
- Member + admin policies merged into single `OR` policies per action to avoid multiple permissive policy overhead
- `auth.uid()` wrapped as `(select auth.uid())` to prevent per-row re-evaluation

## Test plan

- [x] All 5 migrations apply cleanly via `supabase db reset`
- [x] No new Supabase performance/security lint warnings introduced
- [ ] Verify in Supabase Studio: tables exist with correct columns and constraints
- [ ] Verify RLS: member can only read their own family, admin can read all

## Dependencies

These tables are the foundation for:
- Server actions #150–#154
- Member portal UI #155–#160
- Admin financial views #161–#163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Family/household management with head-of-household, contact info, membership status/type/expiry, and member records with relationships
  * Profiles can be linked to families; per-family shares, payments, and event charges with amounts and paid state

* **Chores**
  * Row-level access controls, data integrity rules, uniqueness safeguards, cascades, and automated updated_at timestamp maintenance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->