### PR TITLE
Show invite status (Pending/Active) on users list

### DIFF
--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -16,6 +16,8 @@ export default async function UsersPage() {
     data: { user },
   } = await supabase.auth.getUser()
 
+  // perPage: 1000 — single-page fetch is fine for a parish-sized user base.
+  // If the church ever exceeds 1000 users, paginate with the page param.
   const [profilesResult, authUsersResult] = await Promise.all([
     supabase
       .from('profiles')
@@ -38,9 +40,13 @@ export default async function UsersPage() {
     )
   }
 
-  // Build a map of user ID → email_confirmed_at from auth.users
+  // Build a map of user ID → email_confirmed_at from auth.users.
+  // If listUsers failed, the map stays empty and we fall back to showing
+  // all users as "Pending" rather than breaking the page entirely.
   const confirmedMap = new Map<string, string | null>()
-  if (authUsersResult.data?.users) {
+  if (authUsersResult.error) {
+    console.error('Failed to fetch auth users:', authUsersResult.error)
+  } else if (authUsersResult.data?.users) {
     for (const authUser of authUsersResult.data.users) {
       confirmedMap.set(authUser.id, authUser.email_confirmed_at ?? null)
     }

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { UsersTable } from '@/components/features/UsersTable'
 
 export const metadata: Metadata = {
@@ -15,10 +16,15 @@ export default async function UsersPage() {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const { data: profiles, error } = await supabase
-    .from('profiles')
-    .select('id, email, full_name, role, is_active, created_at, updated_at')
-    .order('created_at', { ascending: false })
+  const [profilesResult, authUsersResult] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('id, email, full_name, role, is_active, created_at, updated_at')
+      .order('created_at', { ascending: false }),
+    createAdminClient().auth.admin.listUsers({ perPage: 1000 }),
+  ])
+
+  const { data: profiles, error } = profilesResult
 
   if (error) {
     console.error('Failed to fetch profiles:', error)
@@ -32,10 +38,22 @@ export default async function UsersPage() {
     )
   }
 
-  const all = profiles ?? []
+  // Build a map of user ID → email_confirmed_at from auth.users
+  const confirmedMap = new Map<string, string | null>()
+  if (authUsersResult.data?.users) {
+    for (const authUser of authUsersResult.data.users) {
+      confirmedMap.set(authUser.id, authUser.email_confirmed_at ?? null)
+    }
+  }
+
+  const all = (profiles ?? []).map((p) => ({
+    ...p,
+    email_confirmed_at: confirmedMap.get(p.id) ?? null,
+  }))
   const adminCount = all.filter((p) => p.role === 'admin').length
   const memberCount = all.filter((p) => p.role === 'member' && p.is_active).length
   const deactivatedCount = all.filter((p) => !p.is_active).length
+  const pendingCount = all.filter((p) => p.is_active && !p.email_confirmed_at).length
 
   return (
     <main className="px-4 py-8 sm:px-6 lg:px-8">
@@ -69,10 +87,11 @@ export default async function UsersPage() {
       </div>
 
       {/* Summary cards */}
-      <div className="mb-8 grid gap-4 sm:grid-cols-4">
+      <div className="mb-8 grid gap-4 sm:grid-cols-5">
         <SummaryCard label="Total" count={all.length} />
         <SummaryCard label="Admins" count={adminCount} accent="blue" />
         <SummaryCard label="Members" count={memberCount} accent="green" />
+        <SummaryCard label="Pending" count={pendingCount} accent="amber" />
         <SummaryCard label="Deactivated" count={deactivatedCount} accent="red" />
       </div>
 
@@ -90,16 +109,18 @@ function SummaryCard({
 }: {
   label: string
   count: number
-  accent?: 'blue' | 'green' | 'red'
+  accent?: 'blue' | 'green' | 'amber' | 'red'
 }) {
   const dotColor =
     accent === 'blue'
       ? 'bg-blue-500'
       : accent === 'green'
         ? 'bg-emerald-500'
-        : accent === 'red'
-          ? 'bg-red-500'
-          : 'bg-burgundy-700'
+        : accent === 'amber'
+          ? 'bg-amber-500'
+          : accent === 'red'
+            ? 'bg-red-500'
+            : 'bg-burgundy-700'
 
   return (
     <div className="rounded-2xl border border-wood-800/10 bg-cream-50 p-5">

--- a/src/components/features/UsersTable.tsx
+++ b/src/components/features/UsersTable.tsx
@@ -15,6 +15,7 @@ interface User {
   is_active: boolean
   created_at: string
   updated_at: string
+  email_confirmed_at: string | null
 }
 
 interface UsersTableProps {
@@ -25,7 +26,7 @@ interface UsersTableProps {
 
 type SortKey = 'name' | 'role' | 'status' | 'created_at'
 type SortDir = 'asc' | 'desc'
-type FilterValue = '' | 'admin' | 'member' | 'deactivated'
+type FilterValue = '' | 'admin' | 'member' | 'pending' | 'deactivated'
 
 const PAGE_SIZE = 20
 
@@ -43,6 +44,7 @@ const ROLE_COLORS: Record<string, string> = {
 
 const STATUS_COLORS = {
   active: 'bg-emerald-50 text-emerald-700',
+  pending: 'bg-yellow-50 text-yellow-800',
   deactivated: 'bg-red-50 text-red-700',
 }
 
@@ -50,6 +52,7 @@ const FILTER_OPTIONS: { value: FilterValue; label: string }[] = [
   { value: '', label: 'All' },
   { value: 'admin', label: 'Admins' },
   { value: 'member', label: 'Members' },
+  { value: 'pending', label: 'Pending' },
   { value: 'deactivated', label: 'Deactivated' },
 ]
 
@@ -66,12 +69,20 @@ function getName(u: User): string {
   return u.full_name || u.email || 'Unknown'
 }
 
+function getStatus(u: User): 'active' | 'pending' | 'deactivated' {
+  if (!u.is_active) return 'deactivated'
+  if (!u.email_confirmed_at) return 'pending'
+  return 'active'
+}
+
 function matchesFilter(u: User, filter: FilterValue): boolean {
   switch (filter) {
     case 'admin':
       return u.role === 'admin'
     case 'member':
       return u.role === 'member' && u.is_active
+    case 'pending':
+      return u.is_active && !u.email_confirmed_at
     case 'deactivated':
       return !u.is_active
     default:
@@ -218,8 +229,8 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
           cmp = a.role.localeCompare(b.role)
           break
         case 'status': {
-          const sa = a.is_active ? 'active' : 'deactivated'
-          const sb = b.is_active ? 'active' : 'deactivated'
+          const sa = getStatus(a)
+          const sb = getStatus(b)
           cmp = sa.localeCompare(sb)
           break
         }
@@ -338,7 +349,7 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
             ) : (
               paginated.map((user) => {
                 const isSelf = user.id === currentUserId
-                const status = user.is_active ? 'active' : 'deactivated'
+                const status = getStatus(user)
 
                 return (
                   <tr
@@ -382,7 +393,11 @@ export function UsersTable({ users, currentUserId, onRowClick }: UsersTableProps
                           STATUS_COLORS[status]
                         )}
                       >
-                        {status === 'active' ? 'Active' : 'Deactivated'}
+                        {status === 'active'
+                          ? 'Active'
+                          : status === 'pending'
+                            ? 'Pending'
+                            : 'Deactivated'}
                       </span>
                     </td>
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -51,6 +51,7 @@ INSERT INTO auth.users (
   created_at,
   updated_at,
   confirmation_token,
+  email_change,
   email_change_token_new,
   recovery_token
 ) VALUES (
@@ -65,6 +66,7 @@ INSERT INTO auth.users (
   '{"full_name": "Parish Admin"}'::jsonb,
   now(),
   now(),
+  '',
   '',
   '',
   ''


### PR DESCRIPTION
## Summary
- Enrich users list with `email_confirmed_at` from `auth.users` via admin client to distinguish invited-but-unconfirmed users from active ones
- Add three-state status badge: **Active** (green), **Pending** (yellow), **Deactivated** (red)
- Add "Pending" summary card and filter pill to the users list toolbar

## Test plan
- [ ] Invite a new user and verify they appear with a "Pending" badge
- [ ] Confirm that existing confirmed users show as "Active"
- [ ] Test the "Pending" filter pill filters correctly
- [ ] Verify sorting on the Status column handles all three states
- [ ] Check the Pending summary card shows the correct count

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Pending" status to track users awaiting email confirmation.
  * New "Pending" filter option in the users table for easier management.
  * Added "Pending" summary card to the admin dashboard displaying the count of users with unconfirmed emails.

* **Improvements**
  * Enhanced admin dashboard layout to accommodate the new pending users metric.
  * Updated status badges with distinct styling for pending users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->