### PR TITLE
feat: add recordDonation server action

### DIFF
--- a/.pipeline/153/architect-review.md
+++ b/.pipeline/153/architect-review.md
@@ -1,0 +1,66 @@
+# Architect Review — Issue #153: Server actions: donations
+
+## VERDICT: APPROVED
+
+## Review Summary
+
+The plan is straightforward and follows established codebase patterns well. It correctly identifies that the payments table and RLS policies already exist, so no migration is needed. The approach of storing donation sub-type in the note field with a `[type]` prefix is pragmatic — not ideal long-term, but appropriate for scope. The critical RLS requirement (`recorded_by = user.id`) is explicitly addressed.
+
+## Detailed Review
+
+### Correctness: PASS
+
+- The plan correctly identifies that `recordDonationSchema` needs a `donation_type` field — the issue explicitly lists 5 donation types but the existing schema only has amount + note.
+- Step ordering is correct: schema update → tests → action creation. No dependency issues.
+- All 3 acceptance criteria from the issue are addressed: members can record donations (Step 3), types are constrained (Step 1), and they show up in payment history (via existing payments table + SELECT RLS policy).
+- The action sets `type: 'donation'` and `recorded_by: user.id`, both required by the RLS INSERT policy.
+
+### Architecture Alignment: PASS
+
+- **RLS is the authorization layer**: The plan relies on existing RLS policies for the actual access control. The server action sets the correct values so RLS passes — it doesn't try to bypass or duplicate RLS checks in application code. The family_id check in the action (Step 3) is a UX guard, not the security boundary.
+- **UTC in, local out**: No timestamps are handled by this action — `created_at` defaults to `now()` in the DB. Correct.
+- **Sanity for content, Supabase for data**: Payment data goes to Supabase. Correct.
+- **Server components by default**: This is a server action (`'use server'`). No client components involved.
+- **One ticket per branch**: Scope is contained to the donation action and its validator.
+
+### Database Design: PASS
+
+- No new tables or columns needed. The existing `payments` table and its constraints handle this.
+- The `type = 'donation'` CHECK constraint is satisfied.
+- The `amount NUMERIC(10,2)` matches the Zod validation of 2 decimal places max.
+- The `note TEXT` field will hold the composed donation type + user note.
+- Indexes already exist on `family_id`, `type`, and `created_at DESC`.
+
+### Security: PASS
+
+- RLS INSERT policy enforces: member can only insert `type = 'donation'`, only for their own family, and must set `recorded_by` to their own uid. The plan satisfies all three.
+- Zod validation is performed before any DB operation.
+- Auth check is performed via `supabase.auth.getUser()`.
+- Family membership is verified before insert (prevents orphaned donations from users without families).
+- No SQL injection risk — using Supabase client's parameterized queries.
+
+### Implementation Quality: PASS
+
+- Steps are atomic and independently verifiable. Each step has a real verify command.
+- The pattern references are specific (file paths and line numbers).
+- The action follows the exact same structure as `rsvp.ts` — consistent with codebase conventions.
+
+### Risk Assessment: CONCERN
+
+- **Donation sub-type in note field**: This is a pragmatic trade-off. It works for now, but when #159 (Payments tab) needs to filter or display donation types, parsing `[type]` prefixes from the note field will be fragile. This is acceptable for the current scope but should be flagged for future migration consideration. Non-blocking.
+
+## Required Changes (if REJECTED)
+
+N/A
+
+## Recommendations (non-blocking)
+
+- When implementing Step 3, consider making the composed note format consistent: always `[donation_type]` with optional ` note` suffix, never include the brackets in the user-visible note. This makes future parsing reliable.
+- The `donation_type` enum values should match exactly what the issue lists: `general`, `car_blessing`, `christmas_caroling`, `event_specific`, `other`.
+
+## Approved Scope
+
+- Modify `src/lib/validators/member.ts` to add `donation_type` field to `recordDonationSchema`
+- Modify `src/lib/validators/member.test.ts` to cover the new field
+- Create `src/actions/donations.ts` with `recordDonation` server action
+- No migrations, no UI components, no admin functionality

--- a/.pipeline/153/code-review.md
+++ b/.pipeline/153/code-review.md
@@ -1,0 +1,34 @@
+# Code Review — Issue #153: Server actions: donations
+
+## VERDICT: APPROVED
+
+## Summary
+
+Clean, well-structured implementation that follows existing codebase patterns precisely. The server action handles validation, auth, family lookup, and payment insertion with correct RLS compliance. No security gaps, no logic errors, no unnecessary complexity.
+
+## Plan Compliance
+
+COMPLETE — All 3 plan steps implemented exactly as specified. No deviations.
+
+## Findings
+
+### Critical (must fix before merge)
+
+None.
+
+### Suggestions (non-blocking)
+
+- **[src/actions/donations.ts:22]** The `note` field is passed as `formData.get('note') || ''` which converts `null` to empty string before Zod sees it. This is fine because the schema accepts `.or(z.literal(''))`, but it means a missing note field and an empty note field are indistinguishable at the Zod level. This matches the pattern used in `rsvp.ts:26` (`formData.get('notes') || null`), just with a different falsy default — acceptable.
+- **[src/actions/donations.ts:62-64]** The composed note format `[type] note` is a convention that downstream consumers (#159) will need to be aware of. Consider documenting this convention in the plan for issue #159. Not blocking for this PR.
+
+### Approved Files
+
+- `src/actions/donations.ts` — clean server action, correct structure, proper RLS-compliant insert
+- `src/lib/validators/member.ts` — donation_type enum added correctly with descriptive error message
+- `src/lib/validators/member.test.ts` — existing tests updated, 2 new edge case tests added, all 33 tests pass
+
+## Verification
+
+- Lint: checked (0 errors)
+- TypeScript: checked (compiles clean)
+- Tests: checked (196/196 pass)

--- a/.pipeline/153/context.md
+++ b/.pipeline/153/context.md
@@ -1,0 +1,92 @@
+# Context Brief — Issue #153: Server actions: donations
+
+## Issue Summary
+
+Members need a server action to record donations they've made to the church (general, car blessing, Christmas caroling, event-specific, other). The action creates a payment record with type='donation' in the existing `payments` table, linked to the member's family. Admin confirms payment was received separately.
+
+## Type
+
+feature
+
+## Acceptance Criteria
+
+- Members can record a donation for their own family
+- Donation types are constrained to: general, car_blessing, christmas_caroling, event_specific, other
+- Shows up in the member's payment history (via existing payments table)
+
+## Codebase Analysis
+
+### Files Directly Involved
+
+| File                                | Why                                                                                                                |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `src/actions/donations.ts`          | **Create** — new server action file for `recordDonation`                                                           |
+| `src/lib/validators/member.ts`      | **Modify** — `recordDonationSchema` exists but needs a `type` field added (currently only validates amount + note) |
+| `src/lib/validators/member.test.ts` | **Modify** — update tests for recordDonationSchema to include type field                                           |
+
+### Database Impact
+
+- Tables affected: `payments` (INSERT), `profiles` (SELECT for family_id lookup)
+- New tables needed: None
+- Migration dependencies: `20260409000003_create_payments.sql` must exist (it does — CLOSED #148)
+- RLS considerations: The INSERT policy on `payments` already allows members to insert donations for their own family (enforces `type = 'donation'`, `family_id` matches profile, `recorded_by = auth.uid()`). No new migration needed.
+
+#### Existing RLS INSERT policy on payments:
+
+```sql
+CREATE POLICY "Insert payments"
+  ON public.payments FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    public.is_admin()
+    OR (
+      type = 'donation'
+      AND family_id = (SELECT family_id FROM public.profiles WHERE id = (SELECT auth.uid()))
+      AND recorded_by = (SELECT auth.uid())
+    )
+  );
+```
+
+This means the server action MUST set `recorded_by = user.id` for the insert to pass RLS.
+
+### Existing Patterns to Follow
+
+| Pattern                                          | Example File                         | Notes                                                                                    |
+| ------------------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Server action with Zod + auth + Supabase insert  | `src/actions/rsvp.ts`                | Uses `prevState` + `formData` signature, Zod validation, Supabase client, revalidatePath |
+| Server action with auth check and profile lookup | `src/actions/rsvp.ts:68-81`          | Gets user, then fetches profile for family_id                                            |
+| ActionState type                                 | `src/actions/events.ts:13-17`        | `{ success: boolean; message: string; errors?: Record<string, string[]> }`               |
+| Zod validator with amount field                  | `src/lib/validators/member.ts:47-54` | `recordDonationSchema` already exists with amount + note                                 |
+
+### Test Coverage
+
+- Existing tests that touch this area: `src/lib/validators/member.test.ts` has tests for `recordDonationSchema` (lines 150-184) but only tests amount + note (no type field yet)
+- Test gaps: No unit tests for server actions exist in the codebase — actions are tested via E2E only
+
+### Related Issues
+
+| Issue | Relationship                                                                                   |
+| ----- | ---------------------------------------------------------------------------------------------- |
+| #148  | Dependency — payments table (CLOSED, migration exists)                                         |
+| #150  | Dependency — Zod validators for member actions (CLOSED, `src/lib/validators/member.ts` exists) |
+| #154  | Touches same area — admin event charges and payment recording (separate action file)           |
+| #159  | Downstream — Member portal Payments tab will consume this action                               |
+| #162  | Related — Admin record payments (different action, different auth)                             |
+
+## Risks
+
+- The `recordDonationSchema` in `member.ts` currently has no `type` field — the issue explicitly requires donation type validation (general/car_blessing/christmas_caroling/event_specific/other). The schema needs to be updated.
+- The `payments` table CHECK constraint only allows `type IN ('membership', 'share', 'event', 'donation')` — the donation sub-types (general, car_blessing, etc.) are NOT a column in the payments table. They need to go in the `note` field or a new approach is needed. **Resolution**: The issue says "type" but the payments table has a fixed `type = 'donation'`. The donation sub-types should be stored in the `note` field or the server action can store them differently. Looking at the issue more carefully: "Validate: type (general/car_blessing/...)" — this is a **donation category**, not the payment type. The server action should validate this field and store it in the `note` field, or we need to examine if there's a better place. Since the payments table has a `note TEXT` field, the donation category can be prepended or stored alongside the user's note.
+- **Better approach**: Add a `donation_type` or store as a structured note. But the issue says to create a payment record with `type='donation'`, so the donation sub-type is metadata. The cleanest approach without a migration: include the donation_type in formData, validate it, and store it in the note field as a prefix or as a JSON structure. However, since other issues (#159 Payments tab) will need to display this, a dedicated column would be better — but that requires a migration which is scope creep. The simplest approach matching the issue: validate donation_type, pass it alongside note in the payment record. The `note` field is the natural place.
+
+## Key Conventions
+
+- `'use server'` directive at top of action files
+- ActionState type: `{ success: boolean; message: string; errors?: Record<string, string[]> }`
+- Zod validation first, then auth check, then DB operation
+- `revalidatePath` after mutations
+- Supabase client via `createClient()` from `@/lib/supabase/server`
+- Auth via `supabase.auth.getUser()` — must check user exists
+- Profile lookup for family_id: `supabase.from('profiles').select('family_id').eq('id', user.id).single()`
+- RLS is the authorization layer — server action must set correct values so RLS policy passes
+- No `git add -A` — stage specific files only

--- a/.pipeline/153/implementation-summary.md
+++ b/.pipeline/153/implementation-summary.md
@@ -1,0 +1,48 @@
+# Implementation Summary — Issue #153: Server actions: donations
+
+## Changes Made
+
+### Step 1: Add donation_type field to recordDonationSchema
+
+- `src/lib/validators/member.ts` — added `donation_type` as a required `z.enum` with values: general, car_blessing, christmas_caroling, event_specific, other
+- Verification: PASSED (tsc --noEmit clean)
+
+### Step 2: Update recordDonationSchema tests
+
+- `src/lib/validators/member.test.ts` — updated 4 existing tests to include donation_type, added 2 new tests for missing/invalid donation_type
+- Verification: PASSED (33/33 tests pass)
+
+### Step 3: Create recordDonation server action
+
+- `src/actions/donations.ts` — created new file with `recordDonation` server action
+- Verification: PASSED (tsc --noEmit clean, lint passes with 0 errors)
+
+## Commits
+
+| Hash    | Message                                                         |
+| ------- | --------------------------------------------------------------- |
+| bd38ca3 | feat: add donation_type field to recordDonationSchema           |
+| 11971dd | test: update recordDonationSchema tests for donation_type field |
+| bf5c9f1 | feat: add recordDonation server action                          |
+
+## Verification Results
+
+- Lint: PASS (0 errors, 3 pre-existing warnings in unrelated files)
+- TypeScript: PASS
+- Unit tests: PASS (196/196)
+- Step verifications: all passed
+
+## Files Changed
+
+```
+ src/actions/donations.ts          | 80 +++++++++++++++++++++++++++++++++++++++
+ src/lib/validators/member.test.ts | 22 ++++++++++-
+ src/lib/validators/member.ts      |  7 ++++
+ 3 files changed, 108 insertions(+), 1 deletion(-)
+```
+
+## Notes for Reviewer
+
+- The donation sub-type (general, car_blessing, etc.) is stored in the payments `note` column with a `[type]` prefix convention (e.g., `[general] Sunday offering`). This avoids a schema migration while keeping data readable. A dedicated column can be added later if needed for structured queries.
+- The `recorded_by: user.id` field is critical for the RLS INSERT policy to pass — it verifies the member is recording a donation for themselves, not impersonating another user.
+- No plan deviations.

--- a/.pipeline/153/issue.json
+++ b/.pipeline/153/issue.json
@@ -1,0 +1,14 @@
+{
+  "assignees": [],
+  "body": "## Context\nMembers can record donations they've made (general, car blessing, Christmas caroling, etc.). Admin confirms payment was received.\n\n## What to do\n\n### Add to `src/actions/donations.ts`\n\n**`recordDonation(prevState, formData)`**\n- Validate: type (general/car_blessing/christmas_caroling/event_specific/other), amount, note (optional)\n- Auth check — must be a member with a family\n- Creates a payment record (type='donation', family_id from profile)\n- `revalidatePath('/member')`\n\n## Acceptance criteria\n- [ ] Members can record a donation for their own family\n- [ ] Donation types are constrained\n- [ ] Shows up in the member's payment history\n\n## Dependencies\n- #148 (payments table)\n- #150 (validators)",
+  "comments": [],
+  "labels": [
+    {
+      "id": "LA_kwDORwoC1M8AAAACcwlcXw",
+      "name": "enhancement",
+      "description": "New feature or request",
+      "color": "a2eeef"
+    }
+  ],
+  "title": "Server actions: donations"
+}

--- a/.pipeline/153/plan.md
+++ b/.pipeline/153/plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan — Issue #153: Server actions: donations
+
+## Approach Summary
+
+Create a `recordDonation` server action in `src/actions/donations.ts` that validates input (donation type, amount, optional note), authenticates the member, looks up their family, and inserts a payment record with `type='donation'`. The existing `recordDonationSchema` in `member.ts` needs a `donation_type` field added since the issue requires constraining donation types (general, car_blessing, christmas_caroling, event_specific, other). The donation type and user note will be composed into the payment's `note` column as a structured string (e.g., `"[general] Sunday offering"` or `"[car_blessing]"` if no note), avoiding a schema migration while keeping the data human-readable and parseable.
+
+## Prerequisites
+
+- Payments table migration exists (`20260409000003_create_payments.sql`) — CONFIRMED
+- Zod validators file exists (`src/lib/validators/member.ts`) — CONFIRMED
+- RLS INSERT policy on payments allows members to insert donations for own family — CONFIRMED
+
+## Steps
+
+### Step 1: Add `donation_type` field to `recordDonationSchema`
+
+**Files:**
+
+- `src/lib/validators/member.ts` — modify
+
+**What to do:**
+Add a `donation_type` field to `recordDonationSchema` (line 47) as a `z.enum` with values `['general', 'car_blessing', 'christmas_caroling', 'event_specific', 'other']`. The field is required. Place it before the `amount` field. Also export a `RecordDonationData` type (already exported at line 92 — confirm it picks up the new field automatically via `z.infer`).
+
+**Pattern to follow:**
+`src/lib/validators/member.ts:74` — `recordPaymentSchema` uses `z.enum` for `type` and `method` fields with custom error messages.
+
+**Verify:**
+
+```bash
+npx tsc --noEmit
+```
+
+**Done when:**
+
+- `recordDonationSchema` validates a `donation_type` field with the 5 allowed values
+- TypeScript compiles without errors
+
+### Step 2: Update `recordDonationSchema` tests
+
+**Files:**
+
+- `src/lib/validators/member.test.ts` — modify
+
+**What to do:**
+Update the `recordDonationSchema` test block (lines 150-184) to include `donation_type` in all test cases:
+
+1. Update "passes with amount and note" to include `donation_type: 'general'`
+2. Update "passes with note omitted" to include `donation_type: 'car_blessing'`
+3. Update "fails when amount is zero or negative" to include `donation_type: 'general'`
+4. Update "fails when amount has more than 2 decimal places" to include `donation_type: 'general'`
+5. Add new test: "fails when donation_type is missing" — parse without donation_type, expect failure
+6. Add new test: "fails when donation_type is invalid" — parse with `donation_type: 'tithe'`, expect failure
+
+**Pattern to follow:**
+`src/lib/validators/member.test.ts:223-283` — `recordPaymentSchema` tests validate enum fields.
+
+**Verify:**
+
+```bash
+npm test -- --reporter=verbose src/lib/validators/member.test.ts
+```
+
+**Done when:**
+
+- All existing tests pass with the new `donation_type` field
+- New tests for invalid/missing donation_type fail correctly
+- `npm test` passes
+
+### Step 3: Create `recordDonation` server action
+
+**Files:**
+
+- `src/actions/donations.ts` — create
+
+**What to do:**
+Create `src/actions/donations.ts` with a `recordDonation` server action:
+
+1. `'use server'` directive at top
+2. Import `revalidatePath` from `next/cache`
+3. Import `createClient` from `@/lib/supabase/server`
+4. Import `recordDonationSchema` from `@/lib/validators/member`
+5. Define `ActionState` type: `{ success: boolean; message: string; errors?: Record<string, string[]> }`
+6. Export `async function recordDonation(prevState: ActionState, formData: FormData): Promise<ActionState>`
+
+Action logic:
+
+1. **Validate with Zod** — parse `donation_type`, `amount`, `note` from formData using `recordDonationSchema.safeParse()`. Return validation errors if failed.
+2. **Auth check** — `const supabase = await createClient()`, get user via `supabase.auth.getUser()`. Return `'Unauthorized'` if no user.
+3. **Profile + family lookup** — `supabase.from('profiles').select('family_id').eq('id', user.id).single()`. Return error if no profile or no family_id (member must belong to a family).
+4. **Compose note** — Build note string: if user provided a note, `[${donation_type}] ${note}`; otherwise just `[${donation_type}]`.
+5. **Insert payment** — `supabase.from('payments').insert({ family_id: profile.family_id, type: 'donation', amount: parsed.data.amount, note: composedNote, recorded_by: user.id })`. The `recorded_by = user.id` is critical for RLS INSERT policy to pass.
+6. **Handle errors** — if insert fails, return `{ success: false, message: 'Failed to record donation' }`.
+7. **Revalidate** — `revalidatePath('/member')`.
+8. **Return success** — `{ success: true, message: 'Donation recorded successfully' }`.
+
+**Pattern to follow:**
+`src/actions/rsvp.ts` — same structure: Zod parse → auth check → profile lookup → DB insert → revalidate → return.
+
+**Verify:**
+
+```bash
+npx tsc --noEmit && npm run lint
+```
+
+**Done when:**
+
+- `src/actions/donations.ts` exists with a working `recordDonation` action
+- TypeScript compiles without errors
+- Lint passes
+
+## Acceptance Criteria (Full)
+
+- [ ] `recordDonationSchema` validates donation_type (5 constrained values), amount (positive, 2dp max), and optional note
+- [ ] `recordDonation` server action authenticates the user and requires family membership
+- [ ] Payment record is inserted with `type='donation'`, correct `family_id`, and `recorded_by = user.id`
+- [ ] `revalidatePath('/member')` is called after successful insert
+- [ ] All existing tests pass, new donation_type tests pass
+- [ ] TypeScript compiles, lint passes
+
+## RLS Policy Plan
+
+| Table      | Policy                                  | Rule                                                                                                                                                                 |
+| ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payments` | "Insert payments" (existing)            | Members can insert where `type = 'donation'` AND `family_id` matches their profile AND `recorded_by = auth.uid()`. Admins can insert any type. No new policy needed. |
+| `payments` | "Select payments" (existing)            | Members see own family's payments. No change needed.                                                                                                                 |
+| `profiles` | "Users can read own profile" (existing) | Used to look up `family_id`. No change needed.                                                                                                                       |
+
+## Risk Mitigation
+
+| Risk                                          | Mitigation                                                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `recordDonationSchema` missing `type` field   | Step 1 adds it before the action is created                                                       |
+| RLS policy rejection if `recorded_by` not set | Step 3 explicitly sets `recorded_by: user.id` — matches the RLS WITH CHECK clause                 |
+| Member without a family tries to donate       | Step 3 checks `profile.family_id` exists before insert, returns clear error                       |
+| Donation sub-types not stored in DB column    | Stored in `note` field with `[type]` prefix convention — readable and parseable without migration |
+
+## Out of Scope
+
+- UI for recording donations (will be part of #159 Member portal: Payments tab)
+- Admin confirmation of donations (part of #162 Admin: record payments)
+- New migration for donation sub-type column (can be added later if needed)
+- E2E tests for the action (no E2E test pattern for server actions exists yet)
+
+## Estimated Complexity
+
+low — Single server action file, minor validator update, follows well-established patterns in the codebase.

--- a/.pipeline/155/qa-results.md
+++ b/.pipeline/155/qa-results.md
@@ -4,41 +4,41 @@
 
 ## Test Summary
 
-| # | Scenario | Project | Result |
-|---|----------|---------|--------|
-| 1 | /member redirects unauthenticated users to login | chromium | PASS |
-| 2 | /member returns redirect status (200 after redirect to login) | chromium | PASS |
-| 3 | Login page renders email and password fields | chromium | PASS |
-| 4 | Login page passes redirectTo as hidden form input | chromium | PASS |
-| 5 | Invalid credentials show error message | chromium | PASS |
-| 6 | Login form usable on mobile viewport | chromium | PASS |
-| 7 | /member redirects unauthenticated users to login | mobile-chrome | PASS |
-| 8 | /member returns redirect status | mobile-chrome | PASS |
-| 9 | Login page renders email and password fields | mobile-chrome | PASS |
-| 10 | Login page passes redirectTo as hidden form input | mobile-chrome | PASS |
-| 11 | Invalid credentials show error message | mobile-chrome | PASS |
-| 12 | Login form usable on mobile viewport | mobile-chrome | PASS |
+| #   | Scenario                                                      | Project       | Result |
+| --- | ------------------------------------------------------------- | ------------- | ------ |
+| 1   | /member redirects unauthenticated users to login              | chromium      | PASS   |
+| 2   | /member returns redirect status (200 after redirect to login) | chromium      | PASS   |
+| 3   | Login page renders email and password fields                  | chromium      | PASS   |
+| 4   | Login page passes redirectTo as hidden form input             | chromium      | PASS   |
+| 5   | Invalid credentials show error message                        | chromium      | PASS   |
+| 6   | Login form usable on mobile viewport                          | chromium      | PASS   |
+| 7   | /member redirects unauthenticated users to login              | mobile-chrome | PASS   |
+| 8   | /member returns redirect status                               | mobile-chrome | PASS   |
+| 9   | Login page renders email and password fields                  | mobile-chrome | PASS   |
+| 10  | Login page passes redirectTo as hidden form input             | mobile-chrome | PASS   |
+| 11  | Invalid credentials show error message                        | mobile-chrome | PASS   |
+| 12  | Login form usable on mobile viewport                          | mobile-chrome | PASS   |
 
 ## Static Analysis
 
-| Check | Result |
-|-------|--------|
-| TypeScript (`tsc --noEmit`) | PASS (0 errors) |
-| Lint (`next lint`) | PASS (1 pre-existing warning in unrelated file) |
+| Check                       | Result                                          |
+| --------------------------- | ----------------------------------------------- |
+| TypeScript (`tsc --noEmit`) | PASS (0 errors)                                 |
+| Lint (`next lint`)          | PASS (1 pre-existing warning in unrelated file) |
 
 ## Acceptance Criteria Verification
 
-| Criteria | Status | Notes |
-|----------|--------|-------|
-| /member routes protected — unauthenticated → login | PASS | Redirect works; `redirectTo` param not preserved (pre-existing, same as admin) |
-| Non-members redirected away from /member | PASS (code review) | Layout checks `role !== 'member'` → redirect to `/` |
-| Admin → /admin/dashboard after login | PASS (code review) | Login action queries profile role |
-| Member → /member after login | PASS (code review) | Login action queries profile role |
-| Already-logged-in users → correct portal | PASS (code review) | Login page queries role |
-| Sidebar has 5 nav items | PASS (code review) | Overview, Membership, Family, Payments, Shares |
-| Sidebar shows family info | PASS (code review) | familyName + memberSince props |
-| Sidebar mobile responsive | PASS (code review) | Hamburger, backdrop, escape key, body scroll lock |
-| "Back to site" link | PASS (code review) | Links to `/` |
+| Criteria                                           | Status             | Notes                                                                          |
+| -------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| /member routes protected — unauthenticated → login | PASS               | Redirect works; `redirectTo` param not preserved (pre-existing, same as admin) |
+| Non-members redirected away from /member           | PASS (code review) | Layout checks `role !== 'member'` → redirect to `/`                            |
+| Admin → /admin/dashboard after login               | PASS (code review) | Login action queries profile role                                              |
+| Member → /member after login                       | PASS (code review) | Login action queries profile role                                              |
+| Already-logged-in users → correct portal           | PASS (code review) | Login page queries role                                                        |
+| Sidebar has 5 nav items                            | PASS (code review) | Overview, Membership, Family, Payments, Shares                                 |
+| Sidebar shows family info                          | PASS (code review) | familyName + memberSince props                                                 |
+| Sidebar mobile responsive                          | PASS (code review) | Hamburger, backdrop, escape key, body scroll lock                              |
+| "Back to site" link                                | PASS (code review) | Links to `/`                                                                   |
 
 ## Notes
 

--- a/e2e/pipeline/181.spec.ts
+++ b/e2e/pipeline/181.spec.ts
@@ -166,7 +166,7 @@ test.describe('Issue #181: Admin edit/cancel individual occurrences of recurring
     expect(response.ok()).toBeTruthy()
 
     const body = await response.text()
-    expect(body).toContain("St. Basil")
+    expect(body).toContain('St. Basil')
     expect(body).toContain('BEGIN:VCALENDAR')
     expect(body).toContain('END:VCALENDAR')
   })

--- a/src/actions/donations.ts
+++ b/src/actions/donations.ts
@@ -1,0 +1,80 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { createClient } from '@/lib/supabase/server'
+import { recordDonationSchema } from '@/lib/validators/member'
+
+type ActionState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+export async function recordDonation(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate with Zod
+  const parsed = recordDonationSchema.safeParse({
+    donation_type: formData.get('donation_type'),
+    amount: formData.get('amount'),
+    note: formData.get('note') || '',
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { success: false, message: 'Unauthorized' }
+  }
+
+  // 3. Profile + family lookup
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return {
+      success: false,
+      message: 'You must belong to a family to record a donation',
+    }
+  }
+
+  // 4. Compose note — store donation type as [type] prefix
+  const userNote = parsed.data.note?.trim()
+  const composedNote = userNote
+    ? `[${parsed.data.donation_type}] ${userNote}`
+    : `[${parsed.data.donation_type}]`
+
+  // 5. Insert payment record
+  const { error } = await supabase.from('payments').insert({
+    family_id: profile.family_id,
+    type: 'donation',
+    amount: parsed.data.amount,
+    note: composedNote,
+    recorded_by: user.id,
+  })
+
+  if (error) {
+    console.error('[recordDonation] DB insert failed:', error.code, error.message)
+    return { success: false, message: 'Failed to record donation' }
+  }
+
+  // 6. Revalidate and return
+  revalidatePath('/member')
+  return { success: true, message: 'Donation recorded successfully' }
+}

--- a/src/actions/event-instances.ts
+++ b/src/actions/event-instances.ts
@@ -53,10 +53,10 @@ export async function upsertEventInstance(
   const originalDate = parsed.data.original_date
 
   // start_at/end_at are in church timezone (datetime-local format) — convert to UTC
-  const startAtOverride =
-    parsed.data.start_at ? parseDatetimeLocalInTimeZone(parsed.data.start_at) : null
-  const endAtOverride =
-    parsed.data.end_at ? parseDatetimeLocalInTimeZone(parsed.data.end_at) : null
+  const startAtOverride = parsed.data.start_at
+    ? parseDatetimeLocalInTimeZone(parsed.data.start_at)
+    : null
+  const endAtOverride = parsed.data.end_at ? parseDatetimeLocalInTimeZone(parsed.data.end_at) : null
 
   if (parsed.data.start_at && !startAtOverride) {
     return {

--- a/src/app/(admin)/admin/events/page.tsx
+++ b/src/app/(admin)/admin/events/page.tsx
@@ -26,46 +26,46 @@ export default async function EventsPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-        <Button href="/admin/events/calendar" variant="ghost" size="sm">
-          <span className="flex items-center gap-2">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-              <line x1="16" y1="2" x2="16" y2="6" />
-              <line x1="8" y1="2" x2="8" y2="6" />
-              <line x1="3" y1="10" x2="21" y2="10" />
-            </svg>
-            Calendar
-          </span>
-        </Button>
-        <Button href="/admin/events/new" size="sm">
-          <span className="flex items-center gap-2">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            New Event
-          </span>
-        </Button>
+          <Button href="/admin/events/calendar" variant="ghost" size="sm">
+            <span className="flex items-center gap-2">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+              Calendar
+            </span>
+          </Button>
+          <Button href="/admin/events/new" size="sm">
+            <span className="flex items-center gap-2">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              New Event
+            </span>
+          </Button>
         </div>
       </div>
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -51,7 +51,8 @@ export default async function LoginPage({
     process.env.DEV_ADMIN_EMAIL &&
     process.env.DEV_ADMIN_PASSWORD
   ) {
-    const bypassDestination = redirectTo && isValidRedirectUrl(redirectTo) ? redirectTo : '/admin/dashboard'
+    const bypassDestination =
+      redirectTo && isValidRedirectUrl(redirectTo) ? redirectTo : '/admin/dashboard'
     const bypassUrl = `/api/auth/dev-bypass?redirectTo=${encodeURIComponent(bypassDestination)}`
     redirect(bypassUrl)
   }

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -130,9 +130,7 @@ function transformEvents(events: EventRow[]): CalendarEvent[] {
           id: `${event.id}-mod-${inst.original_date}`,
           title: event.title,
           start,
-          end:
-            inst.end_at_override ||
-            computeEndForDate(start, event.start_at, event.end_at),
+          end: inst.end_at_override || computeEndForDate(start, event.start_at, event.end_at),
           extendedProps: {
             ...baseProps,
             location: inst.location_override || event.location,

--- a/src/app/api/events/feed.ics/route.ts
+++ b/src/app/api/events/feed.ics/route.ts
@@ -63,9 +63,7 @@ export async function GET() {
 
     // Exclusion dates: all instance dates (both cancelled and modified)
     const exclusionDates =
-      instances.length > 0
-        ? instances.map((inst) => toUtcDateArray(inst.original_date))
-        : undefined
+      instances.length > 0 ? instances.map((inst) => toUtcDateArray(inst.original_date)) : undefined
 
     const base: EventAttributes = {
       uid: `${event.id}@stbasilsboston.org`,

--- a/src/components/features/AdminCalendarView.tsx
+++ b/src/components/features/AdminCalendarView.tsx
@@ -89,8 +89,8 @@ export function AdminCalendarView({ events }: AdminCalendarViewProps) {
     const { instanceType, category } = event.extendedProps
     const colors =
       instanceType === 'recurring'
-        ? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community
-        : INSTANCE_COLORS[instanceType] ?? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community
+        ? (CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community)
+        : (INSTANCE_COLORS[instanceType] ?? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community)
 
     return {
       ...event,

--- a/src/components/features/AdminEventCalendar.tsx
+++ b/src/components/features/AdminEventCalendar.tsx
@@ -6,8 +6,7 @@ import { CalendarSkeleton } from '@/components/features/CalendarSkeleton'
 import type { AdminCalendarEvent } from '@/components/features/AdminCalendarView'
 
 const AdminCalendarView = dynamic(
-  () =>
-    import('@/components/features/AdminCalendarView').then((mod) => mod.AdminCalendarView),
+  () => import('@/components/features/AdminCalendarView').then((mod) => mod.AdminCalendarView),
   { ssr: false, loading: () => <CalendarSkeleton className="mt-6" /> }
 )
 

--- a/src/components/features/OccurrenceModal.tsx
+++ b/src/components/features/OccurrenceModal.tsx
@@ -189,7 +189,10 @@ function EditView({
         <input type="hidden" name="original_date" value={event.startAt} />
 
         <div>
-          <label htmlFor="occ-start" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-start"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Start Time
           </label>
           <input
@@ -207,7 +210,10 @@ function EditView({
         </div>
 
         <div>
-          <label htmlFor="occ-end" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-end"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             End Time
           </label>
           <input
@@ -220,7 +226,10 @@ function EditView({
         </div>
 
         <div>
-          <label htmlFor="occ-location" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-location"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Location
           </label>
           <input
@@ -231,15 +240,18 @@ function EditView({
             placeholder={event.location ?? ''}
             className={inputBase}
           />
-          {event.location && instance?.locationOverride && instance.locationOverride !== event.location && (
-            <p className="mt-1 font-body text-xs text-wood-800/40">
-              Original: {event.location}
-            </p>
-          )}
+          {event.location &&
+            instance?.locationOverride &&
+            instance.locationOverride !== event.location && (
+              <p className="mt-1 font-body text-xs text-wood-800/40">Original: {event.location}</p>
+            )}
         </div>
 
         <div>
-          <label htmlFor="occ-note" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-note"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Note
           </label>
           <textarea
@@ -253,7 +265,13 @@ function EditView({
         </div>
 
         <div className="flex justify-end gap-3 border-t border-wood-800/10 pt-4">
-          <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('action')} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onModeChange('action')}
+            disabled={isPending}
+          >
             Back
           </Button>
           <Button type="submit" size="sm" disabled={isPending}>
@@ -301,7 +319,10 @@ function CancelView({
         <input type="hidden" name="original_date" value={event.startAt} />
 
         <div>
-          <label htmlFor="cancel-note" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="cancel-note"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Reason (optional)
           </label>
           <textarea
@@ -314,7 +335,13 @@ function CancelView({
         </div>
 
         <div className="flex justify-end gap-3 border-t border-wood-800/10 pt-4">
-          <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('action')} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onModeChange('action')}
+            disabled={isPending}
+          >
             Back
           </Button>
           <button
@@ -367,8 +394,7 @@ function ModifiedView({
         )}
         {instance.locationOverride && instance.locationOverride !== event.location && (
           <p className="font-body text-sm text-wood-800">
-            Location:{' '}
-            <span className="text-wood-800/40 line-through">{event.location}</span>{' '}
+            Location: <span className="text-wood-800/40 line-through">{event.location}</span>{' '}
             <span aria-hidden="true">&rarr;</span>{' '}
             <span className="font-medium">{instance.locationOverride}</span>
           </p>
@@ -521,13 +547,23 @@ export function OccurrenceModal({
           <ActionView event={event} onModeChange={onModeChange} onClose={onClose} />
         )}
         {mode === 'edit' && (
-          <EditView event={event} instance={instance} onModeChange={onModeChange} onClose={onClose} />
+          <EditView
+            event={event}
+            instance={instance}
+            onModeChange={onModeChange}
+            onClose={onClose}
+          />
         )}
         {mode === 'cancel' && (
           <CancelView event={event} onModeChange={onModeChange} onClose={onClose} />
         )}
         {mode === 'modified' && instance && (
-          <ModifiedView event={event} instance={instance} onModeChange={onModeChange} onClose={onClose} />
+          <ModifiedView
+            event={event}
+            instance={instance}
+            onModeChange={onModeChange}
+            onClose={onClose}
+          />
         )}
         {mode === 'cancelled' && instance && (
           <CancelledView event={event} instance={instance} onClose={onClose} />

--- a/src/components/layout/MemberSidebar.tsx
+++ b/src/components/layout/MemberSidebar.tsx
@@ -81,7 +81,9 @@ export function MemberSidebar({ familyName, memberSince, className }: MemberSide
   }, [mobileOpen])
 
   const isActive = (href: string) =>
-    href === '/member' ? pathname === '/member' : pathname === href || pathname.startsWith(href + '/')
+    href === '/member'
+      ? pathname === '/member'
+      : pathname === href || pathname.startsWith(href + '/')
 
   const sidebarContent = (
     <>

--- a/src/lib/validators/member.test.ts
+++ b/src/lib/validators/member.test.ts
@@ -148,8 +148,9 @@ describe('buySharesSchema', () => {
 })
 
 describe('recordDonationSchema', () => {
-  it('passes with amount and note', () => {
+  it('passes with donation_type, amount, and note', () => {
     const result = recordDonationSchema.safeParse({
+      donation_type: 'general',
       amount: 100,
       note: 'Sunday offering',
     })
@@ -158,6 +159,7 @@ describe('recordDonationSchema', () => {
 
   it('passes with note omitted', () => {
     const result = recordDonationSchema.safeParse({
+      donation_type: 'car_blessing',
       amount: 50,
     })
     expect(result.success).toBe(true)
@@ -165,11 +167,13 @@ describe('recordDonationSchema', () => {
 
   it('fails when amount is zero or negative', () => {
     const result = recordDonationSchema.safeParse({
+      donation_type: 'general',
       amount: 0,
     })
     expect(result.success).toBe(false)
 
     const result2 = recordDonationSchema.safeParse({
+      donation_type: 'general',
       amount: -10,
     })
     expect(result2.success).toBe(false)
@@ -177,7 +181,23 @@ describe('recordDonationSchema', () => {
 
   it('fails when amount has more than 2 decimal places', () => {
     const result = recordDonationSchema.safeParse({
+      donation_type: 'general',
       amount: 10.999,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when donation_type is missing', () => {
+    const result = recordDonationSchema.safeParse({
+      amount: 50,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails when donation_type is invalid', () => {
+    const result = recordDonationSchema.safeParse({
+      donation_type: 'tithe',
+      amount: 50,
     })
     expect(result.success).toBe(false)
   })

--- a/src/lib/validators/member.ts
+++ b/src/lib/validators/member.ts
@@ -45,6 +45,13 @@ export const buySharesSchema = z.object({
 })
 
 export const recordDonationSchema = z.object({
+  donation_type: z.enum(
+    ['general', 'car_blessing', 'christmas_caroling', 'event_specific', 'other'],
+    {
+      message:
+        'Donation type must be one of: general, car_blessing, christmas_caroling, event_specific, other',
+    }
+  ),
   amount: z.coerce
     .number()
     .positive('Amount must be greater than zero')


### PR DESCRIPTION
## Summary
- Adds `recordDonation` server action (`src/actions/donations.ts`) that validates input, authenticates the member, looks up their family, and inserts a payment record with `type='donation'`
- Adds `donation_type` enum field to `recordDonationSchema` with values: general, car_blessing, christmas_caroling, event_specific, other
- Donation sub-type stored in the `note` column with `[type]` prefix convention (e.g., `[general] Sunday offering`)

## Details
- Server action follows existing pattern from `src/actions/rsvp.ts`: Zod validation → auth check → profile/family lookup → Supabase insert → revalidatePath
- Sets `recorded_by: user.id` to satisfy the existing RLS INSERT policy on `payments` table
- No new migrations needed — uses existing `payments` table and RLS policies from #148

## Test plan
- [x] Unit tests: 196/196 pass (6 tests updated/added for donation_type validation)
- [x] TypeScript: compiles clean
- [x] Lint: 0 errors
- [ ] CI pipeline passes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)