### PR TITLE
feat: add shares server actions (buyShares, markSharesPaid)

### DIFF
--- a/src/actions/shares.test.ts
+++ b/src/actions/shares.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Mocks ---
+
+const mockGetUser = vi.fn()
+const mockFrom = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+      from: mockFrom,
+    })
+  ),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}))
+
+import { buyShares, markSharesPaid } from '@/actions/shares'
+
+// --- Helpers ---
+
+const MEMBER_ID = '550e8400-e29b-41d4-a716-446655440001'
+const ADMIN_ID = '550e8400-e29b-41d4-a716-446655440002'
+const FAMILY_ID = '550e8400-e29b-41d4-a716-446655440003'
+const SHARE_ID_1 = '550e8400-e29b-41d4-a716-446655440010'
+const SHARE_ID_2 = '550e8400-e29b-41d4-a716-446655440011'
+const INITIAL_STATE = { success: false, message: '' }
+
+function makeFormData(entries: Record<string, string | string[]>): FormData {
+  const fd = new FormData()
+  for (const [k, v] of Object.entries(entries)) {
+    if (Array.isArray(v)) {
+      for (const item of v) fd.append(k, item)
+    } else {
+      fd.append(k, v)
+    }
+  }
+  return fd
+}
+
+// --- buyShares ---
+
+describe('buyShares', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns validation errors for empty names', async () => {
+    const fd = makeFormData({ names: '[]', year: '2026' })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Validation failed')
+    expect(result.errors).toBeDefined()
+  })
+
+  it('returns validation errors for missing year', async () => {
+    const fd = makeFormData({ names: '["George Thomas"]' })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Validation failed')
+  })
+
+  it('returns Unauthorized when no user session', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const fd = makeFormData({ names: '["George Thomas"]', year: '2026' })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Unauthorized')
+  })
+
+  it('returns error when user has no family', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MEMBER_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { family_id: null }, error: null }),
+            }),
+          }),
+        }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({ names: '["George Thomas"]', year: '2026' })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('You must belong to a family to purchase shares')
+  })
+
+  it('inserts shares successfully for multiple names', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MEMBER_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { family_id: FAMILY_ID }, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'shares') {
+        return {
+          insert: (rows: unknown[]) => {
+            expect(rows).toHaveLength(2)
+            return Promise.resolve({ error: null })
+          },
+        }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({
+      names: '["George Thomas", "Mary Thomas"]',
+      year: '2026',
+    })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toBe('2 share(s) purchased successfully')
+  })
+
+  it('handles duplicate constraint violation', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MEMBER_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { family_id: FAMILY_ID }, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'shares') {
+        return {
+          insert: () =>
+            Promise.resolve({ error: { code: '23505', message: 'duplicate key' } }),
+        }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({ names: '["George Thomas"]', year: '2026' })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('One or more names already have shares for this year')
+  })
+
+  it('accepts names via repeated form fields', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MEMBER_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { family_id: FAMILY_ID }, error: null }),
+            }),
+          }),
+        }
+      }
+      if (table === 'shares') {
+        return {
+          insert: (rows: unknown[]) => {
+            expect(rows).toHaveLength(2)
+            return Promise.resolve({ error: null })
+          },
+        }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({
+      names: ['George Thomas', 'Mary Thomas'],
+      year: '2026',
+    })
+    const result = await buyShares(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(true)
+  })
+})
+
+// --- markSharesPaid ---
+
+describe('markSharesPaid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns validation errors for missing share_ids', async () => {
+    const fd = makeFormData({ share_ids: '[]', method: 'cash' })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Validation failed')
+  })
+
+  it('returns validation errors for invalid method', async () => {
+    const fd = makeFormData({ share_ids: `["${SHARE_ID_1}"]`, method: 'bitcoin' })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Validation failed')
+  })
+
+  it('returns Unauthorized when no user session', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const fd = makeFormData({ share_ids: `["${SHARE_ID_1}"]`, method: 'cash' })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Unauthorized')
+  })
+
+  it('returns Forbidden when caller is not admin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MEMBER_ID } } })
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: { role: 'member' }, error: null }),
+        }),
+      }),
+    })
+
+    const fd = makeFormData({ share_ids: `["${SHARE_ID_1}"]`, method: 'cash' })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Forbidden: admin access required')
+  })
+
+  it('returns error when shares not found', async () => {
+    let profileCallCount = 0
+    mockGetUser.mockResolvedValue({ data: { user: { id: ADMIN_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profileCallCount++
+        if (profileCallCount === 1) {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { role: 'admin' }, error: null }),
+              }),
+            }),
+          }
+        }
+      }
+      if (table === 'shares') {
+        return {
+          select: () => ({
+            in: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({ share_ids: `["${SHARE_ID_1}"]`, method: 'cash' })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Failed to find the specified shares')
+  })
+
+  it('returns error when shares already paid', async () => {
+    let profileCallCount = 0
+    mockGetUser.mockResolvedValue({ data: { user: { id: ADMIN_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profileCallCount++
+        if (profileCallCount === 1) {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { role: 'admin' }, error: null }),
+              }),
+            }),
+          }
+        }
+      }
+      if (table === 'shares') {
+        return {
+          select: () => ({
+            in: () =>
+              Promise.resolve({
+                data: [{ id: SHARE_ID_1, family_id: FAMILY_ID, amount: 50, paid: true }],
+                error: null,
+              }),
+          }),
+        }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({ share_ids: `["${SHARE_ID_1}"]`, method: 'cash' })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('1 share(s) are already marked as paid')
+  })
+
+  it('marks shares as paid and creates payment records', async () => {
+    let profileCallCount = 0
+    const mockInsert = vi.fn().mockResolvedValue({ error: null })
+    const mockUpdate = vi.fn().mockReturnValue({
+      in: () => Promise.resolve({ error: null }),
+    })
+
+    mockGetUser.mockResolvedValue({ data: { user: { id: ADMIN_ID } } })
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        profileCallCount++
+        if (profileCallCount === 1) {
+          return {
+            select: () => ({
+              eq: () => ({
+                single: () => Promise.resolve({ data: { role: 'admin' }, error: null }),
+              }),
+            }),
+          }
+        }
+      }
+      if (table === 'shares') {
+        return {
+          select: () => ({
+            in: () =>
+              Promise.resolve({
+                data: [
+                  { id: SHARE_ID_1, family_id: FAMILY_ID, amount: 50, paid: false },
+                  { id: SHARE_ID_2, family_id: FAMILY_ID, amount: 50, paid: false },
+                ],
+                error: null,
+              }),
+          }),
+          update: mockUpdate,
+        }
+      }
+      if (table === 'payments') {
+        return { insert: mockInsert }
+      }
+      return {}
+    })
+
+    const fd = makeFormData({
+      share_ids: `["${SHARE_ID_1}", "${SHARE_ID_2}"]`,
+      method: 'check',
+      note: 'Paid by check #1234',
+    })
+    const result = await markSharesPaid(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toBe('2 share(s) marked as paid')
+    expect(mockUpdate).toHaveBeenCalledWith({ paid: true })
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          family_id: FAMILY_ID,
+          type: 'share',
+          amount: 50,
+          method: 'check',
+          related_share_id: SHARE_ID_1,
+          recorded_by: ADMIN_ID,
+        }),
+      ])
+    )
+  })
+})

--- a/src/actions/shares.test.ts
+++ b/src/actions/shares.test.ts
@@ -144,8 +144,7 @@ describe('buyShares', () => {
       }
       if (table === 'shares') {
         return {
-          insert: () =>
-            Promise.resolve({ error: { code: '23505', message: 'duplicate key' } }),
+          insert: () => Promise.resolve({ error: { code: '23505', message: 'duplicate key' } }),
         }
       }
       return {}

--- a/src/actions/shares.ts
+++ b/src/actions/shares.ts
@@ -1,0 +1,196 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { createClient } from '@/lib/supabase/server'
+import { buySharesSchema, markSharesPaidSchema } from '@/lib/validators/member'
+
+type ActionState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+/** Parse a form field that may be repeated (getAll) or a JSON array string. */
+function parseStringArray(formData: FormData, key: string): string[] {
+  const all = formData.getAll(key) as string[]
+  // Multiple repeated fields — use directly
+  if (all.length > 1) return all
+  // Single value — could be a JSON array string
+  if (all.length === 1) {
+    try {
+      const parsed = JSON.parse(all[0])
+      if (Array.isArray(parsed)) return parsed
+    } catch {
+      // Not JSON — treat as a single-element array
+    }
+    return all
+  }
+  return []
+}
+
+export async function buyShares(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate with Zod
+  const parsed = buySharesSchema.safeParse({
+    names: parseStringArray(formData, 'names'),
+    year: formData.get('year'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, message: 'Unauthorized' }
+
+  // 3. Get user's family
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return {
+      success: false,
+      message: 'You must belong to a family to purchase shares',
+    }
+  }
+
+  // 4. Insert one share row per name
+  const rows = parsed.data.names.map((name) => ({
+    family_id: profile.family_id,
+    person_name: name,
+    year: parsed.data.year,
+    amount: 50,
+    paid: false,
+  }))
+
+  const { error } = await supabase.from('shares').insert(rows)
+
+  if (error) {
+    console.error('[buyShares] DB error:', error.code, error.message)
+    if (error.code === '23505') {
+      return {
+        success: false,
+        message: 'One or more names already have shares for this year',
+        errors: { names: ['Duplicate share entry for this year'] },
+      }
+    }
+    return { success: false, message: 'Failed to purchase shares' }
+  }
+
+  // 5. Revalidate and return
+  revalidatePath('/member')
+  return {
+    success: true,
+    message: `${parsed.data.names.length} share(s) purchased successfully`,
+  }
+}
+
+export async function markSharesPaid(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate
+  const parsed = markSharesPaidSchema.safeParse({
+    share_ids: parseStringArray(formData, 'share_ids'),
+    method: formData.get('method'),
+    note: formData.get('note') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, message: 'Unauthorized' }
+
+  // 3. Admin check
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.role !== 'admin') {
+    return { success: false, message: 'Forbidden: admin access required' }
+  }
+
+  // 4. Fetch shares to get family_id and amount for payment records
+  const { data: shares, error: fetchError } = await supabase
+    .from('shares')
+    .select('id, family_id, amount, paid')
+    .in('id', parsed.data.share_ids)
+
+  if (fetchError || !shares?.length) {
+    return { success: false, message: 'Failed to find the specified shares' }
+  }
+
+  const alreadyPaid = shares.filter((s) => s.paid)
+  if (alreadyPaid.length > 0) {
+    return {
+      success: false,
+      message: `${alreadyPaid.length} share(s) are already marked as paid`,
+    }
+  }
+
+  // 5. Mark shares as paid
+  const { error: updateError } = await supabase
+    .from('shares')
+    .update({ paid: true })
+    .in('id', parsed.data.share_ids)
+
+  if (updateError) {
+    console.error('[markSharesPaid] Update error:', updateError.code, updateError.message)
+    return { success: false, message: 'Failed to mark shares as paid' }
+  }
+
+  // 6. Create payment records
+  const paymentRows = shares.map((share) => ({
+    family_id: share.family_id,
+    type: 'share' as const,
+    amount: share.amount,
+    method: parsed.data.method,
+    note: parsed.data.note || null,
+    recorded_by: user.id,
+    related_share_id: share.id,
+  }))
+
+  const { error: paymentError } = await supabase.from('payments').insert(paymentRows)
+
+  if (paymentError) {
+    console.error('[markSharesPaid] Payment insert error:', paymentError.code, paymentError.message)
+    // Shares are already marked paid — log but don't fail the whole action
+    return {
+      success: true,
+      message: 'Shares marked as paid but payment records could not be created. Please contact support.',
+    }
+  }
+
+  // 7. Revalidate and return
+  revalidatePath('/admin')
+  return {
+    success: true,
+    message: `${shares.length} share(s) marked as paid`,
+  }
+}

--- a/src/actions/shares.ts
+++ b/src/actions/shares.ts
@@ -29,10 +29,7 @@ function parseStringArray(formData: FormData, key: string): string[] {
   return []
 }
 
-export async function buyShares(
-  prevState: ActionState,
-  formData: FormData
-): Promise<ActionState> {
+export async function buyShares(prevState: ActionState, formData: FormData): Promise<ActionState> {
   // 1. Validate with Zod
   const parsed = buySharesSchema.safeParse({
     names: parseStringArray(formData, 'names'),
@@ -183,7 +180,8 @@ export async function markSharesPaid(
     // Shares are already marked paid — log but don't fail the whole action
     return {
       success: true,
-      message: 'Shares marked as paid but payment records could not be created. Please contact support.',
+      message:
+        'Shares marked as paid but payment records could not be created. Please contact support.',
     }
   }
 

--- a/src/lib/validators/member.test.ts
+++ b/src/lib/validators/member.test.ts
@@ -7,6 +7,7 @@ import {
   recordDonationSchema,
   assignEventCostsSchema,
   recordPaymentSchema,
+  markSharesPaidSchema,
 } from '@/lib/validators/member'
 
 const validUuid = '550e8400-e29b-41d4-a716-446655440000'
@@ -278,6 +279,56 @@ describe('recordPaymentSchema', () => {
       type: 'donation',
       amount: -50,
       method: 'cash',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('markSharesPaidSchema', () => {
+  it('passes with one share_id and method', () => {
+    const result = markSharesPaidSchema.safeParse({
+      share_ids: [validUuid],
+      method: 'cash',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('passes with multiple share_ids and optional note', () => {
+    const result = markSharesPaidSchema.safeParse({
+      share_ids: [validUuid, '550e8400-e29b-41d4-a716-446655440001'],
+      method: 'check',
+      note: 'Paid together',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('fails with empty share_ids array', () => {
+    const result = markSharesPaidSchema.safeParse({
+      share_ids: [],
+      method: 'cash',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails with invalid UUID in share_ids', () => {
+    const result = markSharesPaidSchema.safeParse({
+      share_ids: ['not-a-uuid'],
+      method: 'cash',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails with invalid method', () => {
+    const result = markSharesPaidSchema.safeParse({
+      share_ids: [validUuid],
+      method: 'bitcoin',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('fails without method', () => {
+    const result = markSharesPaidSchema.safeParse({
+      share_ids: [validUuid],
     })
     expect(result.success).toBe(false)
   })

--- a/src/lib/validators/member.ts
+++ b/src/lib/validators/member.ts
@@ -85,6 +85,16 @@ export const recordPaymentSchema = z.object({
   note: z.string().max(500, 'Note must be 500 characters or less').optional().or(z.literal('')),
 })
 
+export const markSharesPaidSchema = z.object({
+  share_ids: z
+    .array(z.string().uuid('Invalid share ID'))
+    .min(1, 'At least one share ID is required'),
+  method: z.enum(['cash', 'check', 'zelle', 'online'], {
+    message: 'Payment method must be one of: cash, check, zelle, online',
+  }),
+  note: z.string().max(500, 'Note must be 500 characters or less').optional().or(z.literal('')),
+})
+
 export type UpdateFamilyData = z.infer<typeof updateFamilySchema>
 export type AddFamilyMemberData = z.infer<typeof addFamilyMemberSchema>
 export type RemoveFamilyMemberData = z.infer<typeof removeFamilyMemberSchema>
@@ -92,3 +102,4 @@ export type BuySharesData = z.infer<typeof buySharesSchema>
 export type RecordDonationData = z.infer<typeof recordDonationSchema>
 export type AssignEventCostsData = z.infer<typeof assignEventCostsSchema>
 export type RecordPaymentData = z.infer<typeof recordPaymentSchema>
+export type MarkSharesPaidData = z.infer<typeof markSharesPaidSchema>


### PR DESCRIPTION
## Summary
- Adds `buyShares` server action — members can purchase remembrance shares ($50 each) for their family, supporting multiple names per submission
- Adds `markSharesPaid` server action — admin marks shares as paid and creates corresponding payment records (type='share')
- Adds `markSharesPaidSchema` Zod validator with tests
- 14 new unit tests covering validation, auth, and DB paths

## Details
- Both actions follow the established `prevState + formData → ActionState` pattern
- `parseStringArray` helper handles both repeated form fields and JSON array strings
- `markSharesPaid` is non-atomic (update shares then insert payments); returns success-with-warning if payment insert fails after shares marked paid
- Duplicate share constraint (same person/year/family) handled with user-friendly error message

## Files changed
| File | Change |
|------|--------|
| `src/actions/shares.ts` | New — both server actions |
| `src/actions/shares.test.ts` | New — 14 unit tests |
| `src/lib/validators/member.ts` | Add `markSharesPaidSchema` + type export |
| `src/lib/validators/member.test.ts` | Add 6 validator test cases |

## Test plan
- [x] TypeScript compiles with 0 errors
- [x] Lint passes (0 errors)
- [x] All 214 unit tests pass (14 new)
- [ ] CI passes

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)