### PR TITLE
feat: member portal overview tab with summary cards and activity feed

### DIFF
--- a/.pipeline/155/qa-results.md
+++ b/.pipeline/155/qa-results.md
@@ -4,41 +4,41 @@
 
 ## Test Summary
 
-| # | Scenario | Project | Result |
-|---|----------|---------|--------|
-| 1 | /member redirects unauthenticated users to login | chromium | PASS |
-| 2 | /member returns redirect status (200 after redirect to login) | chromium | PASS |
-| 3 | Login page renders email and password fields | chromium | PASS |
-| 4 | Login page passes redirectTo as hidden form input | chromium | PASS |
-| 5 | Invalid credentials show error message | chromium | PASS |
-| 6 | Login form usable on mobile viewport | chromium | PASS |
-| 7 | /member redirects unauthenticated users to login | mobile-chrome | PASS |
-| 8 | /member returns redirect status | mobile-chrome | PASS |
-| 9 | Login page renders email and password fields | mobile-chrome | PASS |
-| 10 | Login page passes redirectTo as hidden form input | mobile-chrome | PASS |
-| 11 | Invalid credentials show error message | mobile-chrome | PASS |
-| 12 | Login form usable on mobile viewport | mobile-chrome | PASS |
+| #   | Scenario                                                      | Project       | Result |
+| --- | ------------------------------------------------------------- | ------------- | ------ |
+| 1   | /member redirects unauthenticated users to login              | chromium      | PASS   |
+| 2   | /member returns redirect status (200 after redirect to login) | chromium      | PASS   |
+| 3   | Login page renders email and password fields                  | chromium      | PASS   |
+| 4   | Login page passes redirectTo as hidden form input             | chromium      | PASS   |
+| 5   | Invalid credentials show error message                        | chromium      | PASS   |
+| 6   | Login form usable on mobile viewport                          | chromium      | PASS   |
+| 7   | /member redirects unauthenticated users to login              | mobile-chrome | PASS   |
+| 8   | /member returns redirect status                               | mobile-chrome | PASS   |
+| 9   | Login page renders email and password fields                  | mobile-chrome | PASS   |
+| 10  | Login page passes redirectTo as hidden form input             | mobile-chrome | PASS   |
+| 11  | Invalid credentials show error message                        | mobile-chrome | PASS   |
+| 12  | Login form usable on mobile viewport                          | mobile-chrome | PASS   |
 
 ## Static Analysis
 
-| Check | Result |
-|-------|--------|
-| TypeScript (`tsc --noEmit`) | PASS (0 errors) |
-| Lint (`next lint`) | PASS (1 pre-existing warning in unrelated file) |
+| Check                       | Result                                          |
+| --------------------------- | ----------------------------------------------- |
+| TypeScript (`tsc --noEmit`) | PASS (0 errors)                                 |
+| Lint (`next lint`)          | PASS (1 pre-existing warning in unrelated file) |
 
 ## Acceptance Criteria Verification
 
-| Criteria | Status | Notes |
-|----------|--------|-------|
-| /member routes protected — unauthenticated → login | PASS | Redirect works; `redirectTo` param not preserved (pre-existing, same as admin) |
-| Non-members redirected away from /member | PASS (code review) | Layout checks `role !== 'member'` → redirect to `/` |
-| Admin → /admin/dashboard after login | PASS (code review) | Login action queries profile role |
-| Member → /member after login | PASS (code review) | Login action queries profile role |
-| Already-logged-in users → correct portal | PASS (code review) | Login page queries role |
-| Sidebar has 5 nav items | PASS (code review) | Overview, Membership, Family, Payments, Shares |
-| Sidebar shows family info | PASS (code review) | familyName + memberSince props |
-| Sidebar mobile responsive | PASS (code review) | Hamburger, backdrop, escape key, body scroll lock |
-| "Back to site" link | PASS (code review) | Links to `/` |
+| Criteria                                           | Status             | Notes                                                                          |
+| -------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| /member routes protected — unauthenticated → login | PASS               | Redirect works; `redirectTo` param not preserved (pre-existing, same as admin) |
+| Non-members redirected away from /member           | PASS (code review) | Layout checks `role !== 'member'` → redirect to `/`                            |
+| Admin → /admin/dashboard after login               | PASS (code review) | Login action queries profile role                                              |
+| Member → /member after login                       | PASS (code review) | Login action queries profile role                                              |
+| Already-logged-in users → correct portal           | PASS (code review) | Login page queries role                                                        |
+| Sidebar has 5 nav items                            | PASS (code review) | Overview, Membership, Family, Payments, Shares                                 |
+| Sidebar shows family info                          | PASS (code review) | familyName + memberSince props                                                 |
+| Sidebar mobile responsive                          | PASS (code review) | Hamburger, backdrop, escape key, body scroll lock                              |
+| "Back to site" link                                | PASS (code review) | Links to `/`                                                                   |
 
 ## Notes
 

--- a/e2e/pipeline/181.spec.ts
+++ b/e2e/pipeline/181.spec.ts
@@ -166,7 +166,7 @@ test.describe('Issue #181: Admin edit/cancel individual occurrences of recurring
     expect(response.ok()).toBeTruthy()
 
     const body = await response.text()
-    expect(body).toContain("St. Basil")
+    expect(body).toContain('St. Basil')
     expect(body).toContain('BEGIN:VCALENDAR')
     expect(body).toContain('END:VCALENDAR')
   })

--- a/src/actions/event-instances.ts
+++ b/src/actions/event-instances.ts
@@ -53,10 +53,10 @@ export async function upsertEventInstance(
   const originalDate = parsed.data.original_date
 
   // start_at/end_at are in church timezone (datetime-local format) — convert to UTC
-  const startAtOverride =
-    parsed.data.start_at ? parseDatetimeLocalInTimeZone(parsed.data.start_at) : null
-  const endAtOverride =
-    parsed.data.end_at ? parseDatetimeLocalInTimeZone(parsed.data.end_at) : null
+  const startAtOverride = parsed.data.start_at
+    ? parseDatetimeLocalInTimeZone(parsed.data.start_at)
+    : null
+  const endAtOverride = parsed.data.end_at ? parseDatetimeLocalInTimeZone(parsed.data.end_at) : null
 
   if (parsed.data.start_at && !startAtOverride) {
     return {

--- a/src/app/(admin)/admin/events/page.tsx
+++ b/src/app/(admin)/admin/events/page.tsx
@@ -26,46 +26,46 @@ export default async function EventsPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-        <Button href="/admin/events/calendar" variant="ghost" size="sm">
-          <span className="flex items-center gap-2">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-              <line x1="16" y1="2" x2="16" y2="6" />
-              <line x1="8" y1="2" x2="8" y2="6" />
-              <line x1="3" y1="10" x2="21" y2="10" />
-            </svg>
-            Calendar
-          </span>
-        </Button>
-        <Button href="/admin/events/new" size="sm">
-          <span className="flex items-center gap-2">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            New Event
-          </span>
-        </Button>
+          <Button href="/admin/events/calendar" variant="ghost" size="sm">
+            <span className="flex items-center gap-2">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+              Calendar
+            </span>
+          </Button>
+          <Button href="/admin/events/new" size="sm">
+            <span className="flex items-center gap-2">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              New Event
+            </span>
+          </Button>
         </div>
       </div>
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -51,7 +51,8 @@ export default async function LoginPage({
     process.env.DEV_ADMIN_EMAIL &&
     process.env.DEV_ADMIN_PASSWORD
   ) {
-    const bypassDestination = redirectTo && isValidRedirectUrl(redirectTo) ? redirectTo : '/admin/dashboard'
+    const bypassDestination =
+      redirectTo && isValidRedirectUrl(redirectTo) ? redirectTo : '/admin/dashboard'
     const bypassUrl = `/api/auth/dev-bypass?redirectTo=${encodeURIComponent(bypassDestination)}`
     redirect(bypassUrl)
   }

--- a/src/app/(member)/member/page.tsx
+++ b/src/app/(member)/member/page.tsx
@@ -92,22 +92,14 @@ export default async function MemberOverviewPage() {
         .from('family_members')
         .select('id', { count: 'exact', head: true })
         .eq('family_id', familyId),
-      supabase
-        .from('shares')
-        .select('id')
-        .eq('family_id', familyId)
-        .eq('year', currentYear),
+      supabase.from('shares').select('id').eq('family_id', familyId).eq('year', currentYear),
       supabase
         .from('payments')
         .select('id, type, amount, note, created_at, related_event_id')
         .eq('family_id', familyId)
         .order('created_at', { ascending: false })
         .limit(5),
-      supabase
-        .from('event_charges')
-        .select('amount')
-        .eq('family_id', familyId)
-        .eq('paid', false),
+      supabase.from('event_charges').select('amount').eq('family_id', familyId).eq('paid', false),
     ])
 
   const family = familyResult.data
@@ -136,16 +128,11 @@ export default async function MemberOverviewPage() {
   }
 
   // ─── Fetch event titles for payments that reference events ────
-  const eventIds = recentPayments
-    .filter((p) => p.related_event_id)
-    .map((p) => p.related_event_id!)
+  const eventIds = recentPayments.filter((p) => p.related_event_id).map((p) => p.related_event_id!)
 
   let eventTitles: Record<string, string> = {}
   if (eventIds.length > 0) {
-    const { data: events } = await supabase
-      .from('events')
-      .select('id, title')
-      .in('id', eventIds)
+    const { data: events } = await supabase.from('events').select('id, title').in('id', eventIds)
     if (events) {
       eventTitles = Object.fromEntries(events.map((e) => [e.id, e.title]))
     }
@@ -238,7 +225,7 @@ export default async function MemberOverviewPage() {
               outstandingBalance > 0 ? 'text-red-600' : 'text-wood-900'
             }`}
           >
-            ${outstandingBalance.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+            {`$${outstandingBalance.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`}
           </div>
           <div className="mt-0.5 text-xs text-wood-800/45">
             {outstandingBalance > 0 ? 'outstanding' : 'all clear'}
@@ -276,11 +263,9 @@ export default async function MemberOverviewPage() {
                           {badge.label}
                         </span>
                       </td>
-                      <td className="px-[18px] py-3 text-wood-900">
-                        {describePayment(payment)}
-                      </td>
+                      <td className="px-[18px] py-3 text-wood-900">{describePayment(payment)}</td>
                       <td className="px-[18px] py-3 text-right font-heading font-semibold text-wood-900">
-                        ${Number(payment.amount).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                        {`$${Number(payment.amount).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
                       </td>
                       <td className="px-[18px] py-3 text-right text-[13px] text-wood-800/40">
                         {shortDate.format(new Date(payment.created_at))}

--- a/src/app/(member)/member/page.tsx
+++ b/src/app/(member)/member/page.tsx
@@ -1,17 +1,298 @@
 import type { Metadata } from 'next'
 
+import { createClient } from '@/lib/supabase/server'
+import { Card } from '@/components/ui'
+
 export const metadata: Metadata = {
   title: 'Member Portal',
   description: "Your St. Basil's parish member portal.",
 }
 
-export default function MemberOverviewPage() {
+// ─── Date formatting ───────────────────────────────────────────────
+
+const shortDate = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  timeZone: 'America/New_York',
+})
+
+const fullDate = new Intl.DateTimeFormat('en-US', {
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'America/New_York',
+})
+
+// ─── Badge styles by payment type ──────────────────────────────────
+
+const badgeStyles: Record<string, { className: string; label: string }> = {
+  membership: { className: 'bg-emerald-100 text-emerald-800', label: 'Paid' },
+  donation: { className: 'bg-blue-100 text-blue-800', label: 'Donation' },
+  share: { className: 'bg-purple-100 text-purple-800', label: 'Share' },
+  event: { className: 'bg-amber-100 text-amber-800', label: 'Event' },
+}
+
+// ─── Summary card dot colors ───────────────────────────────────────
+
+const dotColors = {
+  nextDue: 'bg-emerald-500',
+  family: 'bg-blue-500',
+  shares: 'bg-gold-500',
+  balance: 'bg-red-500',
+}
+
+// ─── Page ──────────────────────────────────────────────────────────
+
+export default async function MemberOverviewPage() {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return null // Layout handles redirect
+
+  // Get profile with family_id
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  const familyId = profile?.family_id
+
+  // ─── No-family state ──────────────────────────────────────────
+  if (!familyId) {
+    return (
+      <main className="px-4 py-8 sm:px-6 lg:px-8">
+        <h1 className="font-heading text-2xl font-semibold text-wood-900">
+          Welcome to your Parish Portal
+        </h1>
+        <Card variant="outlined" className="mt-6 p-6">
+          <p className="text-sm text-wood-800/60">
+            Your family hasn&apos;t been set up yet. Please contact the church office to get
+            started.
+          </p>
+        </Card>
+      </main>
+    )
+  }
+
+  // ─── Fetch all data in parallel ───────────────────────────────
+  const currentYear = new Date().getFullYear()
+
+  const [familyResult, membersResult, sharesResult, paymentsResult, unpaidChargesResult] =
+    await Promise.all([
+      supabase
+        .from('families')
+        .select('membership_status, membership_type, membership_expires_at')
+        .eq('id', familyId)
+        .single(),
+      supabase
+        .from('family_members')
+        .select('id', { count: 'exact', head: true })
+        .eq('family_id', familyId),
+      supabase
+        .from('shares')
+        .select('id')
+        .eq('family_id', familyId)
+        .eq('year', currentYear),
+      supabase
+        .from('payments')
+        .select('id, type, amount, note, created_at, related_event_id')
+        .eq('family_id', familyId)
+        .order('created_at', { ascending: false })
+        .limit(5),
+      supabase
+        .from('event_charges')
+        .select('amount')
+        .eq('family_id', familyId)
+        .eq('paid', false),
+    ])
+
+  const family = familyResult.data
+  const memberCount = membersResult.count ?? 0
+  const sharesCount = sharesResult.data?.length ?? 0
+  const recentPayments = paymentsResult.data ?? []
+
+  // ─── Compute balance (sum of unpaid event charges) ────────────
+  const outstandingBalance =
+    unpaidChargesResult.data?.reduce((sum, charge) => sum + Number(charge.amount), 0) ?? 0
+
+  // ─── Compute "Next Due" card ──────────────────────────────────
+  let nextDueValue = '—'
+  let nextDueSub = ''
+  if (family?.membership_status === 'expired') {
+    nextDueValue = 'Expired'
+    nextDueSub = family.membership_expires_at
+      ? `since ${fullDate.format(new Date(family.membership_expires_at + 'T00:00:00'))}`
+      : ''
+  } else if (family?.membership_status === 'active' && family.membership_expires_at) {
+    const expiresDate = new Date(family.membership_expires_at + 'T00:00:00')
+    nextDueValue = shortDate.format(expiresDate)
+    const amountLabel = family.membership_type === 'monthly' ? '$100' : '$1,200'
+    const typeLabel = family.membership_type === 'monthly' ? 'Monthly' : 'Annual'
+    nextDueSub = `${amountLabel} · ${typeLabel}`
+  }
+
+  // ─── Fetch event titles for payments that reference events ────
+  const eventIds = recentPayments
+    .filter((p) => p.related_event_id)
+    .map((p) => p.related_event_id!)
+
+  let eventTitles: Record<string, string> = {}
+  if (eventIds.length > 0) {
+    const { data: events } = await supabase
+      .from('events')
+      .select('id, title')
+      .in('id', eventIds)
+    if (events) {
+      eventTitles = Object.fromEntries(events.map((e) => [e.id, e.title]))
+    }
+  }
+
+  // ─── Build activity descriptions ─────────────────────────────
+  function describePayment(p: (typeof recentPayments)[number]): string {
+    switch (p.type) {
+      case 'membership': {
+        const date = new Date(p.created_at)
+        const monthYear = date.toLocaleDateString('en-US', {
+          month: 'long',
+          year: 'numeric',
+          timeZone: 'America/New_York',
+        })
+        return `Membership — ${monthYear}`
+      }
+      case 'event':
+        return p.related_event_id && eventTitles[p.related_event_id]
+          ? eventTitles[p.related_event_id]
+          : 'Event payment'
+      case 'donation':
+        return p.note || 'Donation'
+      case 'share':
+        return `Purchased shares`
+      default:
+        return 'Payment'
+    }
+  }
+
   return (
-    <div className="p-8">
-      <h1 className="font-heading text-2xl font-semibold text-wood-900">
-        Welcome to your Parish Portal
-      </h1>
-      <p className="mt-2 text-sm text-wood-800/60">Your member dashboard is coming soon.</p>
-    </div>
+    <main className="px-4 py-8 sm:px-6 lg:px-8">
+      <h1 className="font-heading text-2xl font-semibold text-wood-900">Overview</h1>
+      <p className="mt-1 text-sm text-wood-800/60">Your family&apos;s parish snapshot</p>
+
+      {/* ─── Summary Cards ────────────────────────────────────────── */}
+      <div
+        className="mt-6 grid grid-cols-2 gap-4 lg:grid-cols-4"
+        aria-label="Summary cards"
+        role="region"
+      >
+        {/* Next Due */}
+        <Card variant="outlined" className="p-[18px]">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-wood-800/60">
+            <span className={`h-2 w-2 rounded-full ${dotColors.nextDue}`} aria-hidden="true" />
+            Next Due
+          </div>
+          <div className="mt-1.5 font-heading text-[22px] font-semibold text-wood-900">
+            {nextDueValue}
+          </div>
+          {nextDueSub && <div className="mt-0.5 text-xs text-wood-800/45">{nextDueSub}</div>}
+        </Card>
+
+        {/* Family */}
+        <Card variant="outlined" className="p-[18px]">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-wood-800/60">
+            <span className={`h-2 w-2 rounded-full ${dotColors.family}`} aria-hidden="true" />
+            Family
+          </div>
+          <div className="mt-1.5 font-heading text-[26px] font-semibold text-wood-900">
+            {memberCount}
+          </div>
+          <div className="mt-0.5 text-xs text-wood-800/45">
+            {memberCount === 1 ? 'member' : 'members'}
+          </div>
+        </Card>
+
+        {/* Shares */}
+        <Card variant="outlined" className="p-[18px]">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-wood-800/60">
+            <span className={`h-2 w-2 rounded-full ${dotColors.shares}`} aria-hidden="true" />
+            Shares
+          </div>
+          <div className="mt-1.5 font-heading text-[26px] font-semibold text-wood-900">
+            {sharesCount}
+          </div>
+          <div className="mt-0.5 text-xs text-wood-800/45">
+            {sharesCount === 1 ? 'name this year' : 'names this year'}
+          </div>
+        </Card>
+
+        {/* Balance */}
+        <Card variant="outlined" className="p-[18px]">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-wood-800/60">
+            <span className={`h-2 w-2 rounded-full ${dotColors.balance}`} aria-hidden="true" />
+            Balance
+          </div>
+          <div
+            className={`mt-1.5 font-heading text-[26px] font-semibold ${
+              outstandingBalance > 0 ? 'text-red-600' : 'text-wood-900'
+            }`}
+          >
+            ${outstandingBalance.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+          </div>
+          <div className="mt-0.5 text-xs text-wood-800/45">
+            {outstandingBalance > 0 ? 'outstanding' : 'all clear'}
+          </div>
+        </Card>
+      </div>
+
+      {/* ─── Recent Activity ──────────────────────────────────────── */}
+      <div className="mt-7">
+        <Card variant="outlined">
+          <div className="flex items-center justify-between border-b border-wood-800/[0.06] px-[18px] py-3.5">
+            <h2 className="text-[15px] font-semibold text-wood-900">Recent Activity</h2>
+          </div>
+          {recentPayments.length === 0 ? (
+            <div className="px-[18px] py-10 text-center text-sm text-wood-800/40">
+              No recent activity
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <tbody>
+                {recentPayments.map((payment) => {
+                  const badge = badgeStyles[payment.type] ?? {
+                    className: 'bg-gray-100 text-gray-800',
+                    label: payment.type,
+                  }
+                  return (
+                    <tr
+                      key={payment.id}
+                      className="border-b border-wood-800/[0.05] last:border-b-0 hover:bg-wood-800/[0.015]"
+                    >
+                      <td className="px-[18px] py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold ${badge.className}`}
+                        >
+                          {badge.label}
+                        </span>
+                      </td>
+                      <td className="px-[18px] py-3 text-wood-900">
+                        {describePayment(payment)}
+                      </td>
+                      <td className="px-[18px] py-3 text-right font-heading font-semibold text-wood-900">
+                        ${Number(payment.amount).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </td>
+                      <td className="px-[18px] py-3 text-right text-[13px] text-wood-800/40">
+                        {shortDate.format(new Date(payment.created_at))}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </Card>
+      </div>
+    </main>
   )
 }

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -130,9 +130,7 @@ function transformEvents(events: EventRow[]): CalendarEvent[] {
           id: `${event.id}-mod-${inst.original_date}`,
           title: event.title,
           start,
-          end:
-            inst.end_at_override ||
-            computeEndForDate(start, event.start_at, event.end_at),
+          end: inst.end_at_override || computeEndForDate(start, event.start_at, event.end_at),
           extendedProps: {
             ...baseProps,
             location: inst.location_override || event.location,

--- a/src/app/api/events/feed.ics/route.ts
+++ b/src/app/api/events/feed.ics/route.ts
@@ -63,9 +63,7 @@ export async function GET() {
 
     // Exclusion dates: all instance dates (both cancelled and modified)
     const exclusionDates =
-      instances.length > 0
-        ? instances.map((inst) => toUtcDateArray(inst.original_date))
-        : undefined
+      instances.length > 0 ? instances.map((inst) => toUtcDateArray(inst.original_date)) : undefined
 
     const base: EventAttributes = {
       uid: `${event.id}@stbasilsboston.org`,

--- a/src/components/features/AdminCalendarView.tsx
+++ b/src/components/features/AdminCalendarView.tsx
@@ -89,8 +89,8 @@ export function AdminCalendarView({ events }: AdminCalendarViewProps) {
     const { instanceType, category } = event.extendedProps
     const colors =
       instanceType === 'recurring'
-        ? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community
-        : INSTANCE_COLORS[instanceType] ?? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community
+        ? (CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community)
+        : (INSTANCE_COLORS[instanceType] ?? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community)
 
     return {
       ...event,

--- a/src/components/features/AdminEventCalendar.tsx
+++ b/src/components/features/AdminEventCalendar.tsx
@@ -6,8 +6,7 @@ import { CalendarSkeleton } from '@/components/features/CalendarSkeleton'
 import type { AdminCalendarEvent } from '@/components/features/AdminCalendarView'
 
 const AdminCalendarView = dynamic(
-  () =>
-    import('@/components/features/AdminCalendarView').then((mod) => mod.AdminCalendarView),
+  () => import('@/components/features/AdminCalendarView').then((mod) => mod.AdminCalendarView),
   { ssr: false, loading: () => <CalendarSkeleton className="mt-6" /> }
 )
 

--- a/src/components/features/OccurrenceModal.tsx
+++ b/src/components/features/OccurrenceModal.tsx
@@ -189,7 +189,10 @@ function EditView({
         <input type="hidden" name="original_date" value={event.startAt} />
 
         <div>
-          <label htmlFor="occ-start" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-start"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Start Time
           </label>
           <input
@@ -207,7 +210,10 @@ function EditView({
         </div>
 
         <div>
-          <label htmlFor="occ-end" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-end"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             End Time
           </label>
           <input
@@ -220,7 +226,10 @@ function EditView({
         </div>
 
         <div>
-          <label htmlFor="occ-location" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-location"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Location
           </label>
           <input
@@ -231,15 +240,18 @@ function EditView({
             placeholder={event.location ?? ''}
             className={inputBase}
           />
-          {event.location && instance?.locationOverride && instance.locationOverride !== event.location && (
-            <p className="mt-1 font-body text-xs text-wood-800/40">
-              Original: {event.location}
-            </p>
-          )}
+          {event.location &&
+            instance?.locationOverride &&
+            instance.locationOverride !== event.location && (
+              <p className="mt-1 font-body text-xs text-wood-800/40">Original: {event.location}</p>
+            )}
         </div>
 
         <div>
-          <label htmlFor="occ-note" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-note"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Note
           </label>
           <textarea
@@ -253,7 +265,13 @@ function EditView({
         </div>
 
         <div className="flex justify-end gap-3 border-t border-wood-800/10 pt-4">
-          <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('action')} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onModeChange('action')}
+            disabled={isPending}
+          >
             Back
           </Button>
           <Button type="submit" size="sm" disabled={isPending}>
@@ -301,7 +319,10 @@ function CancelView({
         <input type="hidden" name="original_date" value={event.startAt} />
 
         <div>
-          <label htmlFor="cancel-note" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="cancel-note"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Reason (optional)
           </label>
           <textarea
@@ -314,7 +335,13 @@ function CancelView({
         </div>
 
         <div className="flex justify-end gap-3 border-t border-wood-800/10 pt-4">
-          <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('action')} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onModeChange('action')}
+            disabled={isPending}
+          >
             Back
           </Button>
           <button
@@ -367,8 +394,7 @@ function ModifiedView({
         )}
         {instance.locationOverride && instance.locationOverride !== event.location && (
           <p className="font-body text-sm text-wood-800">
-            Location:{' '}
-            <span className="text-wood-800/40 line-through">{event.location}</span>{' '}
+            Location: <span className="text-wood-800/40 line-through">{event.location}</span>{' '}
             <span aria-hidden="true">&rarr;</span>{' '}
             <span className="font-medium">{instance.locationOverride}</span>
           </p>
@@ -521,13 +547,23 @@ export function OccurrenceModal({
           <ActionView event={event} onModeChange={onModeChange} onClose={onClose} />
         )}
         {mode === 'edit' && (
-          <EditView event={event} instance={instance} onModeChange={onModeChange} onClose={onClose} />
+          <EditView
+            event={event}
+            instance={instance}
+            onModeChange={onModeChange}
+            onClose={onClose}
+          />
         )}
         {mode === 'cancel' && (
           <CancelView event={event} onModeChange={onModeChange} onClose={onClose} />
         )}
         {mode === 'modified' && instance && (
-          <ModifiedView event={event} instance={instance} onModeChange={onModeChange} onClose={onClose} />
+          <ModifiedView
+            event={event}
+            instance={instance}
+            onModeChange={onModeChange}
+            onClose={onClose}
+          />
         )}
         {mode === 'cancelled' && instance && (
           <CancelledView event={event} instance={instance} onClose={onClose} />

--- a/src/components/layout/MemberSidebar.tsx
+++ b/src/components/layout/MemberSidebar.tsx
@@ -81,7 +81,9 @@ export function MemberSidebar({ familyName, memberSince, className }: MemberSide
   }, [mobileOpen])
 
   const isActive = (href: string) =>
-    href === '/member' ? pathname === '/member' : pathname === href || pathname.startsWith(href + '/')
+    href === '/member'
+      ? pathname === '/member'
+      : pathname === href || pathname.startsWith(href + '/')
 
   const sidebarContent = (
     <>


### PR DESCRIPTION
## Summary
- Rewrites the member portal landing page (`/member`) from placeholder to full server component
- Displays 4 summary cards: Next Due (membership expiry), Family (member count), Shares (current year), Balance (unpaid event charges)
- Adds recent activity table showing the last 5 transactions with type badges, descriptions, amounts, and dates
- Handles edge cases: no family assigned, empty data states, expired memberships

## Details
- All data fetched server-side via 5 parallel Supabase queries (RLS-scoped to member's family)
- Event titles resolved in a follow-up query for payments referencing events
- Dates formatted in America/New_York timezone
- Design matches `mockup-member-portal.html` Overview tab

Closes #156

## Test plan
- [ ] Verify page loads at `/member` for authenticated member
- [ ] Summary cards display correct data from families, family_members, shares, payments, event_charges
- [ ] Recent activity shows latest transactions across all payment types
- [ ] No-family state shows friendly message
- [ ] Empty data states show sensible defaults (0 members, no activity, $0 balance)
- [ ] Expired membership shows "Expired" with date
- [ ] Lint, typecheck, and unit tests pass