### PR TITLE
feat: family management server actions

### DIFF
--- a/.pipeline/151/architect-review.md
+++ b/.pipeline/151/architect-review.md
@@ -1,0 +1,70 @@
+# Architect Review — Issue #151: Server actions: family management
+
+## VERDICT: APPROVED
+
+## Review Summary
+
+Clean, well-scoped plan for three server actions in a single new file. Correctly follows the established action pattern, reuses existing Zod validators, and relies on existing RLS policies for DB-level enforcement. The head-of-household guard is correctly designed. No new migrations or RLS changes needed.
+
+## Detailed Review
+
+### Correctness: PASS
+
+- All three actions follow the correct flow: Zod parse → auth check → profile/family_id lookup → DB operation → revalidatePath.
+- The head-of-household check correctly compares `family_members.profile_id` against `families.head_of_household` — both reference `profiles.id`.
+- Early return for `profile.family_id === null` prevents confusing DB errors.
+- Empty string → null conversion for phone/address is correct since these are nullable text columns.
+- Step ordering is correct — single file, no dependency ordering issues.
+
+### Architecture Alignment: PASS
+
+- RLS is the authorization layer — the plan relies on existing RLS policies for DB-level enforcement AND adds action-level checks for clear error messages. This is the correct double-layer approach.
+- Sanity for content, Supabase for data — family data correctly goes through Supabase.
+- Server components by default — `'use server'` directive, no client code.
+- One ticket per branch — correctly scoped to just the three actions.
+- `revalidatePath('/member')` is the correct path for the member portal.
+
+### Database Design: PASS
+
+- No new tables or migrations needed — existing schema from #145/#146 is sufficient.
+- RLS policies are comprehensive and already exist.
+- The plan correctly avoids updating admin-controlled columns (membership_status, etc.) which the RLS WITH CHECK would block anyway.
+- Column types in Zod schemas match DB column types.
+
+### Security: PASS
+
+- All inputs validated with Zod before use.
+- Auth check via `supabase.auth.getUser()` on every action.
+- Profile family_id lookup prevents cross-family access at the application level.
+- RLS provides DB-level enforcement as a second layer.
+- Head-of-household removal explicitly blocked.
+- No string interpolation in queries — using Supabase client's parameterized methods.
+
+### Implementation Quality: PASS
+
+- Single step with a clear verify command (`npx tsc --noEmit`).
+- Pattern references are specific (file paths, line numbers).
+- Zod schemas are already tested in `member.test.ts`.
+- ActionState type correctly duplicated per-file (matches project convention).
+
+### Risk Assessment: PASS
+
+- All three risks from context brief are addressed: head-of-household check, null family_id handling, cross-family protection.
+- No additional risks identified.
+
+## Required Changes (if REJECTED)
+
+N/A
+
+## Recommendations (non-blocking)
+
+- The `removeFamilyMember` action makes two sequential queries (fetch member, then fetch family head_of_household). These could be combined into a single query joining family_members with families, but the current approach is clearer and the performance difference is negligible for a member-facing action.
+
+## Approved Scope
+
+Implementation of `src/actions/family.ts` containing:
+
+1. `updateFamilyDetails` — Zod validate, auth, profile lookup, update families table (family_name, phone, address only)
+2. `addFamilyMember` — Zod validate, auth, profile lookup, insert into family_members
+3. `removeFamilyMember` — Zod validate, auth, profile lookup, head-of-household guard, delete from family_members
+   All with `revalidatePath('/member')` on success.

--- a/.pipeline/151/code-review.md
+++ b/.pipeline/151/code-review.md
@@ -1,0 +1,31 @@
+# Code Review — Issue #151: Server actions: family management
+
+## VERDICT: APPROVED
+
+## Summary
+
+Clean implementation of three server actions in a single new file, following the established project pattern exactly. All inputs are Zod-validated, auth-checked, and family-scoped. The head-of-household guard is correctly implemented with proper null handling. No security gaps, no logic errors, no type issues.
+
+## Plan Compliance
+
+COMPLETE — Every step in the plan was implemented exactly as specified. No deviations.
+
+## Findings
+
+### Critical (must fix before merge)
+
+None.
+
+### Suggestions (non-blocking)
+
+- **[src/actions/family.ts:62,63]** `parsed.data.phone || null` converts empty string to null, which is correct. However, if Zod already validated with `.optional().or(z.literal(''))`, the value could be `undefined` (when omitted) or `''` (when empty). Both `undefined || null` and `'' || null` produce `null`, so this is safe. Just noting the implicit behavior is correct.
+
+### Approved Files
+
+- `src/actions/family.ts` — no issues. All three actions (updateFamilyDetails, addFamilyMember, removeFamilyMember) are correct.
+
+## Verification
+
+- Lint: checked — 0 errors (3 pre-existing warnings in unrelated files)
+- TypeScript: checked — compiles cleanly
+- Tests: checked — 194/194 pass

--- a/.pipeline/151/context.md
+++ b/.pipeline/151/context.md
@@ -1,0 +1,82 @@
+# Context Brief — Issue #151: Server actions: family management
+
+## Issue Summary
+
+Create three server actions in `src/actions/family.ts` that let authenticated members manage their own family: update family details (name, phone, address), add family members, and remove family members (with head-of-household protection). Follows the established server action pattern from `src/actions/announcements.ts`.
+
+## Type
+
+feature
+
+## Acceptance Criteria
+
+- Members can edit their own family details (family_name, phone, address)
+- Members can add family members to their own family
+- Members can remove family members from their own family
+- Members cannot modify other families' data
+- Head of household cannot be removed
+- All inputs validated with Zod before DB operations
+
+## Codebase Analysis
+
+### Files Directly Involved
+
+| File                                                           | Why                                                                                                                      |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/actions/family.ts`                                        | **CREATE** — new file containing all three server actions                                                                |
+| `src/lib/validators/member.ts`                                 | **READ** — contains `updateFamilySchema`, `addFamilyMemberSchema`, `removeFamilyMemberSchema` (already exists from #150) |
+| `src/lib/supabase/server.ts`                                   | **READ** — `createClient()` used for auth + DB operations                                                                |
+| `supabase/migrations/20260409000000_create_families.sql`       | **READ** — families table schema, RLS policies                                                                           |
+| `supabase/migrations/20260409000001_create_family_members.sql` | **READ** — family_members table schema, RLS policies                                                                     |
+
+### Database Impact
+
+- **Tables affected**: `families` (UPDATE), `family_members` (INSERT, DELETE), `profiles` (SELECT for auth/family_id lookup)
+- **New tables needed**: None — #145 and #146 already created them
+- **Migration dependencies**: `20260409000000_create_families.sql` and `20260409000001_create_family_members.sql` must exist (they do)
+- **RLS considerations**: Already comprehensive:
+  - `families` UPDATE policy: members can update own family but NOT membership_status, membership_type, membership_expires_at, or head_of_household
+  - `family_members` INSERT/DELETE policy: members can add/remove from their own family
+  - RLS handles cross-family protection at DB level, but server actions should also verify `profile.family_id` match before attempting operations
+
+### Existing Patterns to Follow
+
+| Pattern                                          | Example File                         | Notes                                                                      |
+| ------------------------------------------------ | ------------------------------------ | -------------------------------------------------------------------------- |
+| Server action signature                          | `src/actions/announcements.ts`       | `(prevState: ActionState, formData: FormData) => Promise<ActionState>`     |
+| ActionState type                                 | `src/actions/announcements.ts:9-13`  | `{ success: boolean; message: string; errors?: Record<string, string[]> }` |
+| Zod validation → auth check → DB op → revalidate | `src/actions/announcements.ts:15-98` | Parse with `.safeParse()`, check user, insert/update, `revalidatePath()`   |
+| Supabase client creation                         | `src/lib/supabase/server.ts`         | `const supabase = await createClient()`                                    |
+| FormData extraction                              | `src/actions/announcements.ts:21-29` | `formData.get('field')` with explicit casts                                |
+
+### Test Coverage
+
+- Existing tests: `src/lib/validators/member.test.ts` covers all three Zod schemas (updateFamily, addFamilyMember, removeFamilyMember)
+- Test gaps: No unit tests for the server actions themselves (consistent with other actions — no action files have unit tests except `users.test.ts`)
+
+### Related Issues
+
+| Issue | Relationship                                                           |
+| ----- | ---------------------------------------------------------------------- |
+| #145  | Dependency — families table migration (exists)                         |
+| #146  | Dependency — family_members table migration (exists)                   |
+| #150  | Dependency — Zod validators (exists in `src/lib/validators/member.ts`) |
+| #158  | Depends on this — Member portal Family tab will use these actions      |
+| #152  | Same batch — shares server actions (similar pattern)                   |
+| #153  | Same batch — donations server actions (similar pattern)                |
+
+## Risks
+
+- **Head-of-household check**: The `removeFamilyMember` action must prevent removing the family member whose `profile_id` matches `families.head_of_household`. This check is NOT enforced by RLS — it must be explicit in the action.
+- **No family assigned**: A member with `profile.family_id = NULL` should get a clear error, not a silent failure or DB error.
+- **RLS double-protection**: While RLS prevents cross-family access, the server action should also validate `profile.family_id` matches the target family for clear error messages.
+
+## Key Conventions
+
+- `'use server'` directive at top of action files
+- ActionState return type with `success`, `message`, `errors` fields
+- Zod `.safeParse()` first, then auth check, then DB operation
+- `revalidatePath('/member')` after mutations (member portal path)
+- No `'use client'` — these are server-only files
+- Import validators from `@/lib/validators/member`
+- Import supabase client from `@/lib/supabase/server`

--- a/.pipeline/151/implementation-summary.md
+++ b/.pipeline/151/implementation-summary.md
@@ -1,0 +1,37 @@
+# Implementation Summary — Issue #151: Server actions: family management
+
+## Changes Made
+
+### Step 1: Create `src/actions/family.ts` with all three server actions
+
+- `src/actions/family.ts` — created with `updateFamilyDetails`, `addFamilyMember`, `removeFamilyMember`
+- All three actions follow Zod validation → auth check → profile/family_id lookup → DB operation → revalidatePath pattern
+- `removeFamilyMember` includes head-of-household protection check
+- Verification: PASSED (TypeScript compiles cleanly, lint clean, all 194 unit tests pass)
+
+## Commits
+
+| Hash    | Message                                    |
+| ------- | ------------------------------------------ |
+| ba62893 | feat: add family management server actions |
+
+## Verification Results
+
+- Lint: PASS (0 errors, 3 pre-existing warnings in unrelated files)
+- TypeScript: PASS (no errors)
+- Unit tests: PASS (194/194)
+- Step verifications: all passed
+
+## Files Changed
+
+```
+src/actions/family.ts | 200 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 200 insertions(+)
+```
+
+## Notes for Reviewer
+
+- ActionState type is defined locally per the project convention (every action file defines its own)
+- Empty strings for phone/address are converted to null before DB write
+- The head-of-household check in `removeFamilyMember` makes two sequential queries (fetch member, then fetch family) — could be a single join query but clarity was prioritized over micro-optimization
+- No plan deviations

--- a/.pipeline/151/issue.json
+++ b/.pipeline/151/issue.json
@@ -1,0 +1,9 @@
+{
+  "number": 151,
+  "title": "Server actions: family management",
+  "labels": [{ "name": "enhancement", "color": "a2eeef" }],
+  "assignees": [],
+  "milestone": null,
+  "body": "## Context\nMembers manage their own family details and household members. Follows the server action pattern from `src/actions/announcements.ts`.\n\n## What to do\n\n### Create `src/actions/family.ts`\n\n**`updateFamilyDetails(prevState, formData)`**\n- Validate with Zod, auth check\n- Member can only update their own family (check `profile.family_id`)\n- Updates family_name, phone, address\n- `revalidatePath('/member')`\n\n**`addFamilyMember(prevState, formData)`**\n- Validate, auth check\n- Inserts into `family_members` for the member's own family\n- `revalidatePath('/member')`\n\n**`removeFamilyMember(prevState, formData)`**\n- Validate, auth check\n- Can only remove from own family\n- Cannot remove the head of household (self)\n- `revalidatePath('/member')`\n\n## Acceptance criteria\n- [ ] Members can edit their own family details\n- [ ] Members can add/remove family members\n- [ ] Members cannot modify other families\n- [ ] Head of household cannot be removed\n\n## Dependencies\n- #145 (families table)\n- #146 (family_members table)\n- #150 (validators)",
+  "comments": []
+}

--- a/.pipeline/151/plan.md
+++ b/.pipeline/151/plan.md
@@ -1,0 +1,236 @@
+# Implementation Plan — Issue #151: Server actions: family management
+
+## Approach Summary
+
+Create a single new file `src/actions/family.ts` containing three server actions (`updateFamilyDetails`, `addFamilyMember`, `removeFamilyMember`) following the exact pattern from `src/actions/announcements.ts`. All three actions share a common flow: Zod validation → auth check → profile/family_id lookup → DB operation → revalidatePath. The Zod validators already exist in `src/lib/validators/member.ts` from issue #150, so no new validator code is needed.
+
+## Prerequisites
+
+- Migration `20260409000000_create_families.sql` exists (✓ — issue #145)
+- Migration `20260409000001_create_family_members.sql` exists (✓ — issue #146)
+- Zod schemas exist in `src/lib/validators/member.ts` (✓ — issue #150)
+- Branch `issue/151-server-actions-family-management` exists and is clean (✓)
+
+## Steps
+
+### Step 1: Create `src/actions/family.ts` with all three server actions
+
+**Files:**
+
+- `src/actions/family.ts` — create
+
+**What to do:**
+
+Create `src/actions/family.ts` with `'use server'` directive. Define a local `ActionState` type identical to `src/actions/announcements.ts:9-13`:
+
+```
+type ActionState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+```
+
+Import:
+
+- `revalidatePath` from `next/cache`
+- `createClient` from `@/lib/supabase/server`
+- `updateFamilySchema`, `addFamilyMemberSchema`, `removeFamilyMemberSchema` from `@/lib/validators/member`
+
+**Action 1: `updateFamilyDetails(prevState: ActionState, formData: FormData): Promise<ActionState>`**
+
+1. Parse formData with Zod:
+
+   ```
+   const parsed = updateFamilySchema.safeParse({
+     family_name: formData.get('family_name'),
+     phone: formData.get('phone'),
+     address: formData.get('address'),
+   })
+   ```
+
+   Return validation errors if `!parsed.success` (same pattern as announcements.ts:31-36).
+
+2. Auth check:
+
+   ```
+   const supabase = await createClient()
+   const { data: { user } } = await supabase.auth.getUser()
+   if (!user) return { success: false, message: 'Unauthorized' }
+   ```
+
+3. Fetch profile to get `family_id`:
+
+   ```
+   const { data: profile } = await supabase
+     .from('profiles')
+     .select('family_id')
+     .eq('id', user.id)
+     .single()
+   ```
+
+   If `!profile?.family_id` return `{ success: false, message: 'No family assigned to your account' }`.
+
+4. Update the family (RLS enforces own-family-only + blocks admin columns):
+
+   ```
+   const { error } = await supabase
+     .from('families')
+     .update({
+       family_name: parsed.data.family_name,
+       phone: parsed.data.phone || null,
+       address: parsed.data.address || null,
+     })
+     .eq('id', profile.family_id)
+   ```
+
+   If error, return `{ success: false, message: 'Failed to update family details' }`.
+
+5. `revalidatePath('/member')` and return success.
+
+**Action 2: `addFamilyMember(prevState: ActionState, formData: FormData): Promise<ActionState>`**
+
+1. Parse formData with Zod:
+
+   ```
+   const parsed = addFamilyMemberSchema.safeParse({
+     full_name: formData.get('full_name'),
+     relationship: formData.get('relationship'),
+   })
+   ```
+
+   Return validation errors if fails.
+
+2. Auth check (same as above).
+
+3. Fetch profile for `family_id`. Return error if no family assigned.
+
+4. Insert into `family_members` (RLS enforces own-family-only):
+
+   ```
+   const { error } = await supabase
+     .from('family_members')
+     .insert({
+       family_id: profile.family_id,
+       full_name: parsed.data.full_name,
+       relationship: parsed.data.relationship,
+     })
+   ```
+
+   If error, return `{ success: false, message: 'Failed to add family member' }`.
+
+5. `revalidatePath('/member')` and return success.
+
+**Action 3: `removeFamilyMember(prevState: ActionState, formData: FormData): Promise<ActionState>`**
+
+1. Parse formData with Zod:
+
+   ```
+   const parsed = removeFamilyMemberSchema.safeParse({
+     member_id: formData.get('member_id'),
+   })
+   ```
+
+   Return validation errors if fails.
+
+2. Auth check (same as above).
+
+3. Fetch profile for `family_id`. Return error if no family assigned.
+
+4. **Head-of-household protection** — fetch the family_member row being removed and check if their `profile_id` matches the family's `head_of_household`:
+
+   ```
+   const { data: member } = await supabase
+     .from('family_members')
+     .select('id, family_id, profile_id')
+     .eq('id', parsed.data.member_id)
+     .single()
+   ```
+
+   If `!member` return `{ success: false, message: 'Family member not found' }`.
+   If `member.family_id !== profile.family_id` return `{ success: false, message: 'You can only remove members from your own family' }`.
+
+   Then check head of household:
+
+   ```
+   const { data: family } = await supabase
+     .from('families')
+     .select('head_of_household')
+     .eq('id', profile.family_id)
+     .single()
+
+   if (family && member.profile_id && member.profile_id === family.head_of_household) {
+     return { success: false, message: 'Cannot remove the head of household' }
+   }
+   ```
+
+5. Delete the family member (RLS also enforces own-family-only):
+
+   ```
+   const { error } = await supabase
+     .from('family_members')
+     .delete()
+     .eq('id', parsed.data.member_id)
+   ```
+
+   If error, return `{ success: false, message: 'Failed to remove family member' }`.
+
+6. `revalidatePath('/member')` and return success.
+
+**Pattern to follow:**
+
+- `src/actions/announcements.ts` — overall structure, ActionState type, validation → auth → DB → revalidate flow
+- `src/actions/events.ts` — similar auth check pattern
+
+**Verify:**
+
+```bash
+npx tsc --noEmit
+```
+
+**Done when:**
+
+- `src/actions/family.ts` exists with all three exported async functions
+- TypeScript compiles with no errors
+- All three actions follow the Zod → auth → profile lookup → DB → revalidate pattern
+- `removeFamilyMember` has explicit head-of-household check
+
+## Acceptance Criteria (Full)
+
+- [x] `updateFamilyDetails` validates input with `updateFamilySchema`, checks auth, verifies family_id, updates families table, revalidates `/member`
+- [x] `addFamilyMember` validates input with `addFamilyMemberSchema`, checks auth, verifies family_id, inserts into family_members, revalidates `/member`
+- [x] `removeFamilyMember` validates input with `removeFamilyMemberSchema`, checks auth, verifies family_id, prevents head-of-household removal, deletes from family_members, revalidates `/member`
+- [x] Members cannot modify other families (enforced by both action logic and RLS)
+- [x] Head of household cannot be removed (enforced by explicit check in action)
+- [x] All inputs validated with Zod before any DB operation
+- [x] TypeScript compiles cleanly
+
+## RLS Policy Plan
+
+| Table            | Policy                                  | Rule                                                                                                                              |
+| ---------------- | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `families`       | "Update families" (existing)            | Members can update own family; blocked from changing membership_status, membership_type, membership_expires_at, head_of_household |
+| `family_members` | "Insert family members" (existing)      | Members insert into own family only                                                                                               |
+| `family_members` | "Delete family members" (existing)      | Members delete from own family only                                                                                               |
+| `profiles`       | "Users can read own profile" (existing) | Needed for family_id lookup                                                                                                       |
+
+No new RLS policies needed — #145 and #146 migrations already have comprehensive policies.
+
+## Risk Mitigation
+
+| Risk                                         | Mitigation                                                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Head-of-household removal not blocked by RLS | Explicit check in `removeFamilyMember` — fetch family's `head_of_household`, compare to member's `profile_id` |
+| Member with no family_id                     | Early return with clear error message before any DB write                                                     |
+| Cross-family access                          | Double protection: action checks `profile.family_id` match + RLS policies enforce at DB level                 |
+| Empty string vs null for phone/address       | Convert empty strings to null before DB write (`parsed.data.phone \|\| null`)                                 |
+
+## Out of Scope
+
+- UI components for the member portal Family tab (that's #158)
+- Admin family management actions (different issue)
+- Unit tests for server actions (no other action files have them — `users.test.ts` is the only exception and tests a different pattern)
+
+## Estimated Complexity
+
+low — Single file creation following an established pattern, with existing validators and DB schema. Only complexity is the head-of-household guard in `removeFamilyMember`.

--- a/.pipeline/151/qa-results.md
+++ b/.pipeline/151/qa-results.md
@@ -1,0 +1,36 @@
+# QA Results — Issue #151: Server actions: family management
+
+## Overall: ALL_PASSED
+
+## Test Summary
+
+| Category | Result | Details |
+|----------|--------|---------|
+| TypeScript | PASS | `npx tsc --noEmit` — 0 errors |
+| Lint | PASS | `npx eslint src/actions/family.ts` — 0 errors |
+| Unit tests | PASS | 194/194 (vitest) |
+| Zod validators | PASS | 31/31 in `member.test.ts` |
+| Playwright (chromium) | PASS | 7/7 |
+| Playwright (mobile-chrome) | PASS | 7/7 |
+| Code review | PASS | Pattern matches `announcements.ts` exactly |
+
+## Playwright Test Results (14/14 pass)
+
+Tested against local dev server (`http://localhost:3051`).
+
+- S5: `/member` route loads without server error (both viewports)
+- S6: Public pages regression — Homepage, Events, Contact, About, Giving (both viewports)
+- S6: Login route loads without server error (both viewports)
+
+No console errors on any page. No regressions detected.
+
+## Code Review Findings
+
+1. **Pattern compliance**: All 3 actions follow Zod → auth → profile/family_id → DB → revalidate
+2. **Head-of-household guard**: Correctly implemented with null-safe comparison
+3. **Cross-family protection**: Double-layer (action-level + RLS)
+4. **Empty string handling**: `|| null` correctly converts both `undefined` and `''` to `null`
+5. **No security issues**: Parameterized queries via Supabase client, no string interpolation
+
+## Bugs Found
+None.

--- a/.pipeline/151/qa-results.md
+++ b/.pipeline/151/qa-results.md
@@ -4,15 +4,15 @@
 
 ## Test Summary
 
-| Category | Result | Details |
-|----------|--------|---------|
-| TypeScript | PASS | `npx tsc --noEmit` — 0 errors |
-| Lint | PASS | `npx eslint src/actions/family.ts` — 0 errors |
-| Unit tests | PASS | 194/194 (vitest) |
-| Zod validators | PASS | 31/31 in `member.test.ts` |
-| Playwright (chromium) | PASS | 7/7 |
-| Playwright (mobile-chrome) | PASS | 7/7 |
-| Code review | PASS | Pattern matches `announcements.ts` exactly |
+| Category                   | Result | Details                                       |
+| -------------------------- | ------ | --------------------------------------------- |
+| TypeScript                 | PASS   | `npx tsc --noEmit` — 0 errors                 |
+| Lint                       | PASS   | `npx eslint src/actions/family.ts` — 0 errors |
+| Unit tests                 | PASS   | 194/194 (vitest)                              |
+| Zod validators             | PASS   | 31/31 in `member.test.ts`                     |
+| Playwright (chromium)      | PASS   | 7/7                                           |
+| Playwright (mobile-chrome) | PASS   | 7/7                                           |
+| Code review                | PASS   | Pattern matches `announcements.ts` exactly    |
 
 ## Playwright Test Results (14/14 pass)
 
@@ -33,4 +33,5 @@ No console errors on any page. No regressions detected.
 5. **No security issues**: Parameterized queries via Supabase client, no string interpolation
 
 ## Bugs Found
+
 None.

--- a/.pipeline/151/qa-scenarios.md
+++ b/.pipeline/151/qa-scenarios.md
@@ -1,0 +1,55 @@
+# QA Scenarios — Issue #151: Server actions: family management
+
+## Scope
+This issue adds server-only code (`src/actions/family.ts`) with no UI changes.
+The UI that consumes these actions is #158 (out of scope). Testing focuses on:
+- Code correctness (TypeScript, lint, unit tests)
+- Module import safety (no runtime errors from adding the file)
+- Regression (existing pages/routes still work)
+
+## Scenarios
+
+### S1: TypeScript compiles cleanly
+- Run `npx tsc --noEmit` — expect 0 errors
+- **Result:** PASS
+
+### S2: Lint passes on new file
+- Run `npx eslint src/actions/family.ts` — expect 0 errors
+- **Result:** PASS
+
+### S3: All existing unit tests pass (194 tests)
+- Run `npx vitest run` — expect 194/194 pass
+- **Result:** PASS
+
+### S4: Zod validators cover edge cases (31 tests in member.test.ts)
+- The Zod schemas used by the actions are tested in `src/lib/validators/member.test.ts`
+- **Result:** PASS (31/31)
+
+### S5: /member route still redirects unauthenticated users to /login
+- Playwright: navigate to /member, verify redirect to /login
+- **Result:** (run via Playwright)
+
+### S6: Public pages regression — homepage, events, contact, about, giving
+- Playwright: navigate to each, verify 200 status and no console errors
+- **Result:** (run via Playwright)
+
+### S7: Action follows established pattern
+- Manual code review: Zod validate → auth → profile/family_id → DB → revalidate
+- Matches `src/actions/announcements.ts` pattern exactly
+- ActionState type matches project convention (local per file)
+- **Result:** PASS
+
+### S8: Head-of-household guard in removeFamilyMember
+- Code review: fetches member, verifies family_id match, fetches family head_of_household, compares
+- Null-safe: `family && member.profile_id && member.profile_id === family.head_of_household`
+- **Result:** PASS
+
+### S9: Cross-family protection
+- Code review: action-level check `member.family_id !== profile.family_id` + RLS at DB level
+- Double-layer protection as per architect review
+- **Result:** PASS
+
+### S10: Empty string → null conversion for optional fields
+- `parsed.data.phone || null` and `parsed.data.address || null`
+- Handles both `undefined` and `''` from Zod correctly
+- **Result:** PASS

--- a/.pipeline/151/qa-scenarios.md
+++ b/.pipeline/151/qa-scenarios.md
@@ -1,8 +1,10 @@
 # QA Scenarios — Issue #151: Server actions: family management
 
 ## Scope
+
 This issue adds server-only code (`src/actions/family.ts`) with no UI changes.
 The UI that consumes these actions is #158 (out of scope). Testing focuses on:
+
 - Code correctness (TypeScript, lint, unit tests)
 - Module import safety (no runtime errors from adding the file)
 - Regression (existing pages/routes still work)
@@ -10,46 +12,56 @@ The UI that consumes these actions is #158 (out of scope). Testing focuses on:
 ## Scenarios
 
 ### S1: TypeScript compiles cleanly
+
 - Run `npx tsc --noEmit` — expect 0 errors
 - **Result:** PASS
 
 ### S2: Lint passes on new file
+
 - Run `npx eslint src/actions/family.ts` — expect 0 errors
 - **Result:** PASS
 
 ### S3: All existing unit tests pass (194 tests)
+
 - Run `npx vitest run` — expect 194/194 pass
 - **Result:** PASS
 
 ### S4: Zod validators cover edge cases (31 tests in member.test.ts)
+
 - The Zod schemas used by the actions are tested in `src/lib/validators/member.test.ts`
 - **Result:** PASS (31/31)
 
 ### S5: /member route still redirects unauthenticated users to /login
+
 - Playwright: navigate to /member, verify redirect to /login
 - **Result:** (run via Playwright)
 
 ### S6: Public pages regression — homepage, events, contact, about, giving
+
 - Playwright: navigate to each, verify 200 status and no console errors
 - **Result:** (run via Playwright)
 
 ### S7: Action follows established pattern
+
 - Manual code review: Zod validate → auth → profile/family_id → DB → revalidate
 - Matches `src/actions/announcements.ts` pattern exactly
 - ActionState type matches project convention (local per file)
 - **Result:** PASS
 
 ### S8: Head-of-household guard in removeFamilyMember
+
 - Code review: fetches member, verifies family_id match, fetches family head_of_household, compares
 - Null-safe: `family && member.profile_id && member.profile_id === family.head_of_household`
 - **Result:** PASS
 
 ### S9: Cross-family protection
+
 - Code review: action-level check `member.family_id !== profile.family_id` + RLS at DB level
 - Double-layer protection as per architect review
 - **Result:** PASS
 
 ### S10: Empty string → null conversion for optional fields
+
 - `parsed.data.phone || null` and `parsed.data.address || null`
 - Handles both `undefined` and `''` from Zod correctly
 - **Result:** PASS

--- a/.pipeline/155/qa-results.md
+++ b/.pipeline/155/qa-results.md
@@ -4,41 +4,41 @@
 
 ## Test Summary
 
-| # | Scenario | Project | Result |
-|---|----------|---------|--------|
-| 1 | /member redirects unauthenticated users to login | chromium | PASS |
-| 2 | /member returns redirect status (200 after redirect to login) | chromium | PASS |
-| 3 | Login page renders email and password fields | chromium | PASS |
-| 4 | Login page passes redirectTo as hidden form input | chromium | PASS |
-| 5 | Invalid credentials show error message | chromium | PASS |
-| 6 | Login form usable on mobile viewport | chromium | PASS |
-| 7 | /member redirects unauthenticated users to login | mobile-chrome | PASS |
-| 8 | /member returns redirect status | mobile-chrome | PASS |
-| 9 | Login page renders email and password fields | mobile-chrome | PASS |
-| 10 | Login page passes redirectTo as hidden form input | mobile-chrome | PASS |
-| 11 | Invalid credentials show error message | mobile-chrome | PASS |
-| 12 | Login form usable on mobile viewport | mobile-chrome | PASS |
+| #   | Scenario                                                      | Project       | Result |
+| --- | ------------------------------------------------------------- | ------------- | ------ |
+| 1   | /member redirects unauthenticated users to login              | chromium      | PASS   |
+| 2   | /member returns redirect status (200 after redirect to login) | chromium      | PASS   |
+| 3   | Login page renders email and password fields                  | chromium      | PASS   |
+| 4   | Login page passes redirectTo as hidden form input             | chromium      | PASS   |
+| 5   | Invalid credentials show error message                        | chromium      | PASS   |
+| 6   | Login form usable on mobile viewport                          | chromium      | PASS   |
+| 7   | /member redirects unauthenticated users to login              | mobile-chrome | PASS   |
+| 8   | /member returns redirect status                               | mobile-chrome | PASS   |
+| 9   | Login page renders email and password fields                  | mobile-chrome | PASS   |
+| 10  | Login page passes redirectTo as hidden form input             | mobile-chrome | PASS   |
+| 11  | Invalid credentials show error message                        | mobile-chrome | PASS   |
+| 12  | Login form usable on mobile viewport                          | mobile-chrome | PASS   |
 
 ## Static Analysis
 
-| Check | Result |
-|-------|--------|
-| TypeScript (`tsc --noEmit`) | PASS (0 errors) |
-| Lint (`next lint`) | PASS (1 pre-existing warning in unrelated file) |
+| Check                       | Result                                          |
+| --------------------------- | ----------------------------------------------- |
+| TypeScript (`tsc --noEmit`) | PASS (0 errors)                                 |
+| Lint (`next lint`)          | PASS (1 pre-existing warning in unrelated file) |
 
 ## Acceptance Criteria Verification
 
-| Criteria | Status | Notes |
-|----------|--------|-------|
-| /member routes protected — unauthenticated → login | PASS | Redirect works; `redirectTo` param not preserved (pre-existing, same as admin) |
-| Non-members redirected away from /member | PASS (code review) | Layout checks `role !== 'member'` → redirect to `/` |
-| Admin → /admin/dashboard after login | PASS (code review) | Login action queries profile role |
-| Member → /member after login | PASS (code review) | Login action queries profile role |
-| Already-logged-in users → correct portal | PASS (code review) | Login page queries role |
-| Sidebar has 5 nav items | PASS (code review) | Overview, Membership, Family, Payments, Shares |
-| Sidebar shows family info | PASS (code review) | familyName + memberSince props |
-| Sidebar mobile responsive | PASS (code review) | Hamburger, backdrop, escape key, body scroll lock |
-| "Back to site" link | PASS (code review) | Links to `/` |
+| Criteria                                           | Status             | Notes                                                                          |
+| -------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| /member routes protected — unauthenticated → login | PASS               | Redirect works; `redirectTo` param not preserved (pre-existing, same as admin) |
+| Non-members redirected away from /member           | PASS (code review) | Layout checks `role !== 'member'` → redirect to `/`                            |
+| Admin → /admin/dashboard after login               | PASS (code review) | Login action queries profile role                                              |
+| Member → /member after login                       | PASS (code review) | Login action queries profile role                                              |
+| Already-logged-in users → correct portal           | PASS (code review) | Login page queries role                                                        |
+| Sidebar has 5 nav items                            | PASS (code review) | Overview, Membership, Family, Payments, Shares                                 |
+| Sidebar shows family info                          | PASS (code review) | familyName + memberSince props                                                 |
+| Sidebar mobile responsive                          | PASS (code review) | Hamburger, backdrop, escape key, body scroll lock                              |
+| "Back to site" link                                | PASS (code review) | Links to `/`                                                                   |
 
 ## Notes
 

--- a/e2e/pipeline/151.spec.ts
+++ b/e2e/pipeline/151.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Issue #151: Server actions: family management
+ *
+ * This issue adds server actions only (no UI). Tests verify:
+ * 1. /member auth guard still works (regression)
+ * 2. Public pages still load without errors (regression)
+ * 3. Login page still renders correctly (regression)
+ */
+
+// ── S5: /member auth guard regression ──────────────────────────────
+test.describe('Issue #151: Family actions — regression @pipeline', () => {
+  test('S5: /member route loads without server error', async ({ page }) => {
+    const response = await page.goto('/member', { waitUntil: 'domcontentloaded' })
+    const status = response?.status() ?? 0
+    // Should be 200 (authenticated) or redirect to login — never 500
+    expect(status).toBeLessThan(500)
+  })
+
+  // ── S6: Public pages regression ────────────────────────────────────
+  const REGRESSION_PAGES = [
+    { path: '/', label: 'Homepage' },
+    { path: '/events', label: 'Events Calendar' },
+    { path: '/contact', label: 'Contact Us' },
+    { path: '/about', label: 'About' },
+    { path: '/giving', label: 'Giving' },
+  ]
+
+  for (const { path, label } of REGRESSION_PAGES) {
+    test(`S6: Regression — ${label} (${path}) loads`, async ({ page }) => {
+      const consoleErrors: string[] = []
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') {
+          const text = msg.text()
+          if (text.includes('Turnstile') || text.includes('cf-turnstile')) return
+          if (text.includes('NEXT_PUBLIC_')) return
+          consoleErrors.push(text)
+        }
+      })
+
+      const response = await page.goto(path, { waitUntil: 'domcontentloaded' })
+      expect(response?.status()).toBe(200)
+      expect(consoleErrors).toEqual([])
+    })
+  }
+
+  // ── Login page renders (regression for member portal) ──────────────
+  test('S6: Login route loads without server error', async ({ page }) => {
+    const response = await page.goto('/login', { waitUntil: 'domcontentloaded' })
+    const status = response?.status() ?? 0
+    // Should be 200 (renders form) or redirect (already authenticated) — never 500
+    expect(status).toBeLessThan(500)
+  })
+})

--- a/e2e/pipeline/181.spec.ts
+++ b/e2e/pipeline/181.spec.ts
@@ -166,7 +166,7 @@ test.describe('Issue #181: Admin edit/cancel individual occurrences of recurring
     expect(response.ok()).toBeTruthy()
 
     const body = await response.text()
-    expect(body).toContain("St. Basil")
+    expect(body).toContain('St. Basil')
     expect(body).toContain('BEGIN:VCALENDAR')
     expect(body).toContain('END:VCALENDAR')
   })

--- a/src/actions/event-instances.ts
+++ b/src/actions/event-instances.ts
@@ -53,10 +53,10 @@ export async function upsertEventInstance(
   const originalDate = parsed.data.original_date
 
   // start_at/end_at are in church timezone (datetime-local format) — convert to UTC
-  const startAtOverride =
-    parsed.data.start_at ? parseDatetimeLocalInTimeZone(parsed.data.start_at) : null
-  const endAtOverride =
-    parsed.data.end_at ? parseDatetimeLocalInTimeZone(parsed.data.end_at) : null
+  const startAtOverride = parsed.data.start_at
+    ? parseDatetimeLocalInTimeZone(parsed.data.start_at)
+    : null
+  const endAtOverride = parsed.data.end_at ? parseDatetimeLocalInTimeZone(parsed.data.end_at) : null
 
   if (parsed.data.start_at && !startAtOverride) {
     return {

--- a/src/actions/family.ts
+++ b/src/actions/family.ts
@@ -185,10 +185,7 @@ export async function removeFamilyMember(
   }
 
   // 6. Delete the family member (RLS also enforces own-family-only)
-  const { error } = await supabase
-    .from('family_members')
-    .delete()
-    .eq('id', parsed.data.member_id)
+  const { error } = await supabase.from('family_members').delete().eq('id', parsed.data.member_id)
 
   if (error) {
     return { success: false, message: 'Failed to remove family member' }

--- a/src/actions/family.ts
+++ b/src/actions/family.ts
@@ -1,0 +1,200 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+import { createClient } from '@/lib/supabase/server'
+import {
+  updateFamilySchema,
+  addFamilyMemberSchema,
+  removeFamilyMemberSchema,
+} from '@/lib/validators/member'
+
+type ActionState = {
+  success: boolean
+  message: string
+  errors?: Record<string, string[]>
+}
+
+export async function updateFamilyDetails(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate with Zod
+  const parsed = updateFamilySchema.safeParse({
+    family_name: formData.get('family_name'),
+    phone: formData.get('phone'),
+    address: formData.get('address'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, message: 'Unauthorized' }
+
+  // 3. Fetch profile for family_id
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return { success: false, message: 'No family assigned to your account' }
+  }
+
+  // 4. Update family details (RLS enforces own-family-only + blocks admin columns)
+  const { error } = await supabase
+    .from('families')
+    .update({
+      family_name: parsed.data.family_name,
+      phone: parsed.data.phone || null,
+      address: parsed.data.address || null,
+    })
+    .eq('id', profile.family_id)
+
+  if (error) {
+    return { success: false, message: 'Failed to update family details' }
+  }
+
+  // 5. Revalidate and return
+  revalidatePath('/member')
+  return { success: true, message: 'Family details updated successfully' }
+}
+
+export async function addFamilyMember(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate with Zod
+  const parsed = addFamilyMemberSchema.safeParse({
+    full_name: formData.get('full_name'),
+    relationship: formData.get('relationship'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, message: 'Unauthorized' }
+
+  // 3. Fetch profile for family_id
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return { success: false, message: 'No family assigned to your account' }
+  }
+
+  // 4. Insert family member (RLS enforces own-family-only)
+  const { error } = await supabase.from('family_members').insert({
+    family_id: profile.family_id,
+    full_name: parsed.data.full_name,
+    relationship: parsed.data.relationship,
+  })
+
+  if (error) {
+    return { success: false, message: 'Failed to add family member' }
+  }
+
+  // 5. Revalidate and return
+  revalidatePath('/member')
+  return { success: true, message: 'Family member added successfully' }
+}
+
+export async function removeFamilyMember(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate with Zod
+  const parsed = removeFamilyMemberSchema.safeParse({
+    member_id: formData.get('member_id'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, message: 'Unauthorized' }
+
+  // 3. Fetch profile for family_id
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('family_id')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.family_id) {
+    return { success: false, message: 'No family assigned to your account' }
+  }
+
+  // 4. Fetch the member being removed
+  const { data: member } = await supabase
+    .from('family_members')
+    .select('id, family_id, profile_id')
+    .eq('id', parsed.data.member_id)
+    .single()
+
+  if (!member) {
+    return { success: false, message: 'Family member not found' }
+  }
+
+  if (member.family_id !== profile.family_id) {
+    return { success: false, message: 'You can only remove members from your own family' }
+  }
+
+  // 5. Head-of-household protection
+  const { data: family } = await supabase
+    .from('families')
+    .select('head_of_household')
+    .eq('id', profile.family_id)
+    .single()
+
+  if (family && member.profile_id && member.profile_id === family.head_of_household) {
+    return { success: false, message: 'Cannot remove the head of household' }
+  }
+
+  // 6. Delete the family member (RLS also enforces own-family-only)
+  const { error } = await supabase
+    .from('family_members')
+    .delete()
+    .eq('id', parsed.data.member_id)
+
+  if (error) {
+    return { success: false, message: 'Failed to remove family member' }
+  }
+
+  // 7. Revalidate and return
+  revalidatePath('/member')
+  return { success: true, message: 'Family member removed successfully' }
+}

--- a/src/app/(admin)/admin/events/page.tsx
+++ b/src/app/(admin)/admin/events/page.tsx
@@ -26,46 +26,46 @@ export default async function EventsPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-        <Button href="/admin/events/calendar" variant="ghost" size="sm">
-          <span className="flex items-center gap-2">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-              <line x1="16" y1="2" x2="16" y2="6" />
-              <line x1="8" y1="2" x2="8" y2="6" />
-              <line x1="3" y1="10" x2="21" y2="10" />
-            </svg>
-            Calendar
-          </span>
-        </Button>
-        <Button href="/admin/events/new" size="sm">
-          <span className="flex items-center gap-2">
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-            New Event
-          </span>
-        </Button>
+          <Button href="/admin/events/calendar" variant="ghost" size="sm">
+            <span className="flex items-center gap-2">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+              </svg>
+              Calendar
+            </span>
+          </Button>
+          <Button href="/admin/events/new" size="sm">
+            <span className="flex items-center gap-2">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              New Event
+            </span>
+          </Button>
         </div>
       </div>
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -51,7 +51,8 @@ export default async function LoginPage({
     process.env.DEV_ADMIN_EMAIL &&
     process.env.DEV_ADMIN_PASSWORD
   ) {
-    const bypassDestination = redirectTo && isValidRedirectUrl(redirectTo) ? redirectTo : '/admin/dashboard'
+    const bypassDestination =
+      redirectTo && isValidRedirectUrl(redirectTo) ? redirectTo : '/admin/dashboard'
     const bypassUrl = `/api/auth/dev-bypass?redirectTo=${encodeURIComponent(bypassDestination)}`
     redirect(bypassUrl)
   }

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -130,9 +130,7 @@ function transformEvents(events: EventRow[]): CalendarEvent[] {
           id: `${event.id}-mod-${inst.original_date}`,
           title: event.title,
           start,
-          end:
-            inst.end_at_override ||
-            computeEndForDate(start, event.start_at, event.end_at),
+          end: inst.end_at_override || computeEndForDate(start, event.start_at, event.end_at),
           extendedProps: {
             ...baseProps,
             location: inst.location_override || event.location,

--- a/src/app/api/events/feed.ics/route.ts
+++ b/src/app/api/events/feed.ics/route.ts
@@ -63,9 +63,7 @@ export async function GET() {
 
     // Exclusion dates: all instance dates (both cancelled and modified)
     const exclusionDates =
-      instances.length > 0
-        ? instances.map((inst) => toUtcDateArray(inst.original_date))
-        : undefined
+      instances.length > 0 ? instances.map((inst) => toUtcDateArray(inst.original_date)) : undefined
 
     const base: EventAttributes = {
       uid: `${event.id}@stbasilsboston.org`,

--- a/src/components/features/AdminCalendarView.tsx
+++ b/src/components/features/AdminCalendarView.tsx
@@ -89,8 +89,8 @@ export function AdminCalendarView({ events }: AdminCalendarViewProps) {
     const { instanceType, category } = event.extendedProps
     const colors =
       instanceType === 'recurring'
-        ? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community
-        : INSTANCE_COLORS[instanceType] ?? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community
+        ? (CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community)
+        : (INSTANCE_COLORS[instanceType] ?? CATEGORY_COLORS[category] ?? CATEGORY_COLORS.community)
 
     return {
       ...event,

--- a/src/components/features/AdminEventCalendar.tsx
+++ b/src/components/features/AdminEventCalendar.tsx
@@ -6,8 +6,7 @@ import { CalendarSkeleton } from '@/components/features/CalendarSkeleton'
 import type { AdminCalendarEvent } from '@/components/features/AdminCalendarView'
 
 const AdminCalendarView = dynamic(
-  () =>
-    import('@/components/features/AdminCalendarView').then((mod) => mod.AdminCalendarView),
+  () => import('@/components/features/AdminCalendarView').then((mod) => mod.AdminCalendarView),
   { ssr: false, loading: () => <CalendarSkeleton className="mt-6" /> }
 )
 

--- a/src/components/features/OccurrenceModal.tsx
+++ b/src/components/features/OccurrenceModal.tsx
@@ -189,7 +189,10 @@ function EditView({
         <input type="hidden" name="original_date" value={event.startAt} />
 
         <div>
-          <label htmlFor="occ-start" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-start"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Start Time
           </label>
           <input
@@ -207,7 +210,10 @@ function EditView({
         </div>
 
         <div>
-          <label htmlFor="occ-end" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-end"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             End Time
           </label>
           <input
@@ -220,7 +226,10 @@ function EditView({
         </div>
 
         <div>
-          <label htmlFor="occ-location" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-location"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Location
           </label>
           <input
@@ -231,15 +240,18 @@ function EditView({
             placeholder={event.location ?? ''}
             className={inputBase}
           />
-          {event.location && instance?.locationOverride && instance.locationOverride !== event.location && (
-            <p className="mt-1 font-body text-xs text-wood-800/40">
-              Original: {event.location}
-            </p>
-          )}
+          {event.location &&
+            instance?.locationOverride &&
+            instance.locationOverride !== event.location && (
+              <p className="mt-1 font-body text-xs text-wood-800/40">Original: {event.location}</p>
+            )}
         </div>
 
         <div>
-          <label htmlFor="occ-note" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="occ-note"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Note
           </label>
           <textarea
@@ -253,7 +265,13 @@ function EditView({
         </div>
 
         <div className="flex justify-end gap-3 border-t border-wood-800/10 pt-4">
-          <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('action')} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onModeChange('action')}
+            disabled={isPending}
+          >
             Back
           </Button>
           <Button type="submit" size="sm" disabled={isPending}>
@@ -301,7 +319,10 @@ function CancelView({
         <input type="hidden" name="original_date" value={event.startAt} />
 
         <div>
-          <label htmlFor="cancel-note" className="mb-1.5 block font-body text-sm font-medium text-wood-900">
+          <label
+            htmlFor="cancel-note"
+            className="mb-1.5 block font-body text-sm font-medium text-wood-900"
+          >
             Reason (optional)
           </label>
           <textarea
@@ -314,7 +335,13 @@ function CancelView({
         </div>
 
         <div className="flex justify-end gap-3 border-t border-wood-800/10 pt-4">
-          <Button type="button" variant="ghost" size="sm" onClick={() => onModeChange('action')} disabled={isPending}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onModeChange('action')}
+            disabled={isPending}
+          >
             Back
           </Button>
           <button
@@ -367,8 +394,7 @@ function ModifiedView({
         )}
         {instance.locationOverride && instance.locationOverride !== event.location && (
           <p className="font-body text-sm text-wood-800">
-            Location:{' '}
-            <span className="text-wood-800/40 line-through">{event.location}</span>{' '}
+            Location: <span className="text-wood-800/40 line-through">{event.location}</span>{' '}
             <span aria-hidden="true">&rarr;</span>{' '}
             <span className="font-medium">{instance.locationOverride}</span>
           </p>
@@ -521,13 +547,23 @@ export function OccurrenceModal({
           <ActionView event={event} onModeChange={onModeChange} onClose={onClose} />
         )}
         {mode === 'edit' && (
-          <EditView event={event} instance={instance} onModeChange={onModeChange} onClose={onClose} />
+          <EditView
+            event={event}
+            instance={instance}
+            onModeChange={onModeChange}
+            onClose={onClose}
+          />
         )}
         {mode === 'cancel' && (
           <CancelView event={event} onModeChange={onModeChange} onClose={onClose} />
         )}
         {mode === 'modified' && instance && (
-          <ModifiedView event={event} instance={instance} onModeChange={onModeChange} onClose={onClose} />
+          <ModifiedView
+            event={event}
+            instance={instance}
+            onModeChange={onModeChange}
+            onClose={onClose}
+          />
         )}
         {mode === 'cancelled' && instance && (
           <CancelledView event={event} instance={instance} onClose={onClose} />

--- a/src/components/layout/MemberSidebar.tsx
+++ b/src/components/layout/MemberSidebar.tsx
@@ -81,7 +81,9 @@ export function MemberSidebar({ familyName, memberSince, className }: MemberSide
   }, [mobileOpen])
 
   const isActive = (href: string) =>
-    href === '/member' ? pathname === '/member' : pathname === href || pathname.startsWith(href + '/')
+    href === '/member'
+      ? pathname === '/member'
+      : pathname === href || pathname.startsWith(href + '/')
 
   const sidebarContent = (
     <>


### PR DESCRIPTION
## Summary
- Add three server actions for family management: `updateFamilyDetails`, `addFamilyMember`, `removeFamilyMember`
- All actions follow established Zod → auth → profile/family_id → DB → revalidate pattern
- `removeFamilyMember` includes head-of-household protection guard

## Changes
- `src/actions/family.ts` — new file with three server actions
- `e2e/pipeline/151.spec.ts` — Playwright regression tests (14 pass)
- `.pipeline/151/` — QA scenarios and results

## Test Plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Lint passes (`npx eslint src/actions/family.ts`)
- [x] All 194 unit tests pass (`npx vitest run`)
- [x] Zod validators pass (31/31 in `member.test.ts`)
- [x] Playwright regression: 14/14 (chromium + mobile-chrome)
- [x] Code review: pattern matches `announcements.ts`, security verified

Closes #151