### PR TITLE
fix: make blocked migrations idempotent for safe re-application

### DIFF
--- a/supabase/migrations/20260412000002_create_site_settings.sql
+++ b/supabase/migrations/20260412000002_create_site_settings.sql
@@ -3,10 +3,11 @@
 --
 -- Single-row configuration table for site theme preferences.
 -- Stores font choices and homepage section ordering.
+-- NOTE: Idempotent — safe to re-run if table was partially created by a prior collision.
 
 -- ─── Table ────────────────────────────────────────────────────────────
 
-CREATE TABLE public.site_settings (
+CREATE TABLE IF NOT EXISTS public.site_settings (
   id             UUID DEFAULT gen_random_uuid() PRIMARY KEY,
   fonts          JSONB NOT NULL DEFAULT '{}',
   section_order  JSONB NOT NULL DEFAULT '[]',
@@ -15,7 +16,7 @@ CREATE TABLE public.site_settings (
 );
 
 -- Enforce single-row (singleton) constraint
-CREATE UNIQUE INDEX idx_site_settings_singleton ON public.site_settings ((true));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_site_settings_singleton ON public.site_settings ((true));
 
 -- ─── Auto-update trigger ─────────────────────────────────────────────
 
@@ -27,6 +28,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Drop and recreate trigger (no IF NOT EXISTS for triggers)
+DROP TRIGGER IF EXISTS trg_site_settings_updated_at ON public.site_settings;
 CREATE TRIGGER trg_site_settings_updated_at
   BEFORE UPDATE ON public.site_settings
   FOR EACH ROW
@@ -34,36 +37,49 @@ CREATE TRIGGER trg_site_settings_updated_at
 
 -- ─── Seed default row ────────────────────────────────────────────────
 
-INSERT INTO public.site_settings (fonts, section_order) VALUES (
+INSERT INTO public.site_settings (fonts, section_order)
+SELECT
   '{
     "heading": { "family": "Raleway", "weights": [300, 400, 600, 700] },
     "body":    { "family": "Roboto", "weights": [400, 500, 700] },
     "nav":     { "family": "Libre Baskerville", "weights": [400, 700] }
   }'::jsonb,
   '["hero", "service-times", "announcements", "events", "about", "contact"]'::jsonb
-);
+WHERE NOT EXISTS (SELECT 1 FROM public.site_settings);
 
 -- ─── RLS ──────────────────────────────────────────────────────────────
 
 ALTER TABLE public.site_settings ENABLE ROW LEVEL SECURITY;
 
 -- SELECT: anyone can read (public pages need font settings)
-CREATE POLICY "Anyone can read site settings"
-  ON public.site_settings FOR SELECT
-  TO anon, authenticated
-  USING (true);
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_settings' AND policyname = 'Anyone can read site settings') THEN
+    CREATE POLICY "Anyone can read site settings"
+      ON public.site_settings FOR SELECT
+      TO anon, authenticated
+      USING (true);
+  END IF;
+END $$;
 
 -- UPDATE: admins only
-CREATE POLICY "Admins can update site settings"
-  ON public.site_settings FOR UPDATE
-  TO authenticated
-  USING (public.is_admin())
-  WITH CHECK (public.is_admin());
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_settings' AND policyname = 'Admins can update site settings') THEN
+    CREATE POLICY "Admins can update site settings"
+      ON public.site_settings FOR UPDATE
+      TO authenticated
+      USING (public.is_admin())
+      WITH CHECK (public.is_admin());
+  END IF;
+END $$;
 
 -- INSERT: admins only (for re-seeding if row is missing)
-CREATE POLICY "Admins can insert site settings"
-  ON public.site_settings FOR INSERT
-  TO authenticated
-  WITH CHECK (public.is_admin());
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'site_settings' AND policyname = 'Admins can insert site settings') THEN
+    CREATE POLICY "Admins can insert site settings"
+      ON public.site_settings FOR INSERT
+      TO authenticated
+      WITH CHECK (public.is_admin());
+  END IF;
+END $$;
 
 -- No DELETE policy — settings row should never be deleted.

--- a/supabase/migrations/20260412000003_add_event_instance_note_and_modified_by.sql
+++ b/supabase/migrations/20260412000003_add_event_instance_note_and_modified_by.sql
@@ -1,8 +1,24 @@
 -- Migration: Add note and modified_by columns to event_instances
 -- Issue: #181 — Admin edit/cancel individual occurrences of recurring events
+-- NOTE: Idempotent — safe to re-run if columns were partially created by a prior collision.
 
-ALTER TABLE public.event_instances
-  ADD COLUMN note TEXT,
-  ADD COLUMN modified_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'event_instances' AND column_name = 'note'
+  ) THEN
+    ALTER TABLE public.event_instances ADD COLUMN note TEXT;
+  END IF;
+END $$;
 
-CREATE INDEX idx_event_instances_modified_by ON public.event_instances(modified_by);
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'event_instances' AND column_name = 'modified_by'
+  ) THEN
+    ALTER TABLE public.event_instances
+      ADD COLUMN modified_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_event_instances_modified_by ON public.event_instances(modified_by);

--- a/supabase/migrations/20260412000004_add_directory_visible.sql
+++ b/supabase/migrations/20260412000004_add_directory_visible.sql
@@ -1,39 +1,54 @@
 -- Migration: Add directory_visible column to families + directory RLS policies
 -- Issue: #185
+-- NOTE: Idempotent — safe to re-run if partially applied by a prior collision.
 
 -- ─── Step 1: Add column ──────────────────────────────────────────────
 
-ALTER TABLE public.families
-  ADD COLUMN directory_visible BOOLEAN NOT NULL DEFAULT true;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'families' AND column_name = 'directory_visible'
+  ) THEN
+    ALTER TABLE public.families ADD COLUMN directory_visible BOOLEAN NOT NULL DEFAULT true;
+  END IF;
+END $$;
 
 -- ─── Step 2: RLS policy — members can read directory-visible families ─
 
-CREATE POLICY "Members can read directory families"
-  ON public.families FOR SELECT
-  TO authenticated
-  USING (
-    directory_visible = true
-    AND EXISTS (
-      SELECT 1 FROM public.profiles
-      WHERE profiles.id = (SELECT auth.uid())
-      AND profiles.is_active = true
-    )
-  );
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'families' AND policyname = 'Members can read directory families') THEN
+    CREATE POLICY "Members can read directory families"
+      ON public.families FOR SELECT
+      TO authenticated
+      USING (
+        directory_visible = true
+        AND EXISTS (
+          SELECT 1 FROM public.profiles
+          WHERE profiles.id = (SELECT auth.uid())
+          AND profiles.is_active = true
+        )
+      );
+  END IF;
+END $$;
 
 -- ─── Step 3: RLS policy — members can read family members of visible families ─
 
-CREATE POLICY "Members can read directory family members"
-  ON public.family_members FOR SELECT
-  TO authenticated
-  USING (
-    EXISTS (
-      SELECT 1 FROM public.families
-      WHERE families.id = family_members.family_id
-      AND families.directory_visible = true
-    )
-    AND EXISTS (
-      SELECT 1 FROM public.profiles
-      WHERE profiles.id = (SELECT auth.uid())
-      AND profiles.is_active = true
-    )
-  );
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'family_members' AND policyname = 'Members can read directory family members') THEN
+    CREATE POLICY "Members can read directory family members"
+      ON public.family_members FOR SELECT
+      TO authenticated
+      USING (
+        EXISTS (
+          SELECT 1 FROM public.families
+          WHERE families.id = family_members.family_id
+          AND families.directory_visible = true
+        )
+        AND EXISTS (
+          SELECT 1 FROM public.profiles
+          WHERE profiles.id = (SELECT auth.uid())
+          AND profiles.is_active = true
+        )
+      );
+  END IF;
+END $$;

--- a/supabase/migrations/20260412000005_add_payment_status_and_methods.sql
+++ b/supabase/migrations/20260412000005_add_payment_status_and_methods.sql
@@ -3,35 +3,81 @@
 --
 -- Adds columns for the zero-fee payment flow: members submit pending payments
 -- via Zelle/Venmo/Cash App, treasurer confirms or rejects.
+-- NOTE: Idempotent — safe to re-run if partially applied by a prior collision.
 
 -- ─── New columns ──────────────────────────────────────────────────────
 
-ALTER TABLE public.payments
-  ADD COLUMN status TEXT NOT NULL DEFAULT 'confirmed'
-    CHECK (status IN ('pending', 'confirmed', 'rejected')),
-  ADD COLUMN reference_memo TEXT,
-  ADD COLUMN confirmed_by UUID REFERENCES public.profiles(id),
-  ADD COLUMN confirmed_at TIMESTAMPTZ,
-  ADD COLUMN rejected_reason TEXT;
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'payments' AND column_name = 'status'
+  ) THEN
+    ALTER TABLE public.payments
+      ADD COLUMN status TEXT NOT NULL DEFAULT 'confirmed'
+        CHECK (status IN ('pending', 'confirmed', 'rejected'));
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'payments' AND column_name = 'reference_memo'
+  ) THEN
+    ALTER TABLE public.payments ADD COLUMN reference_memo TEXT;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'payments' AND column_name = 'confirmed_by'
+  ) THEN
+    ALTER TABLE public.payments ADD COLUMN confirmed_by UUID REFERENCES public.profiles(id);
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'payments' AND column_name = 'confirmed_at'
+  ) THEN
+    ALTER TABLE public.payments ADD COLUMN confirmed_at TIMESTAMPTZ;
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'payments' AND column_name = 'rejected_reason'
+  ) THEN
+    ALTER TABLE public.payments ADD COLUMN rejected_reason TEXT;
+  END IF;
+END $$;
 
 -- ─── Expand method CHECK constraint ──────────────────────────────────
 -- Add 'venmo' and 'cashapp' as valid payment methods.
 
-ALTER TABLE public.payments DROP CONSTRAINT payments_method_check;
+ALTER TABLE public.payments DROP CONSTRAINT IF EXISTS payments_method_check;
 
-ALTER TABLE public.payments
-  ADD CONSTRAINT payments_method_check
-    CHECK (method IN ('cash', 'check', 'zelle', 'venmo', 'cashapp', 'online'));
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'payments_method_check'
+  ) THEN
+    ALTER TABLE public.payments
+      ADD CONSTRAINT payments_method_check
+        CHECK (method IN ('cash', 'check', 'zelle', 'venmo', 'cashapp', 'online'));
+  END IF;
+END $$;
 
 -- ─── Index for pending queue ─────────────────────────────────────────
 
-CREATE INDEX idx_payments_status ON public.payments(status);
+CREATE INDEX IF NOT EXISTS idx_payments_status ON public.payments(status);
 
 -- ─── Update INSERT RLS policy ────────────────────────────────────────
 -- Members can now submit any payment type with status = 'pending'.
 -- Admin INSERT is unchanged (can insert any status).
 
-DROP POLICY "Insert payments" ON public.payments;
+DROP POLICY IF EXISTS "Insert payments" ON public.payments;
 
 CREATE POLICY "Insert payments"
   ON public.payments FOR INSERT


### PR DESCRIPTION
## Summary
- Follows up on #208 which renamed duplicate-timestamped migrations
- The original SQL had already been **partially applied** to production (objects exist, but migration versions weren't tracked in `schema_migrations`)
- Rewrote all 4 blocked migrations with `IF NOT EXISTS` / `IF EXISTS` / `DROP ... IF EXISTS` guards so they safely skip already-applied DDL
- This unblocks: site_settings (#129), event instance editing (#181), member directory (#185), and **payments status/methods (#180)** — fixing the broken Payments admin page

## Migrations made idempotent
| Migration | What it does |
|---|---|
| `000002_create_site_settings` | `CREATE TABLE IF NOT EXISTS`, policy guards |
| `000003_add_event_instance_note_and_modified_by` | Column existence checks via `information_schema` |
| `000004_add_directory_visible` | Column + policy existence checks |
| `000005_add_payment_status_and_methods` | Column checks, `DROP CONSTRAINT IF EXISTS`, policy guards |

## Test plan
- [ ] `migrate.yml` workflow passes (supabase db push succeeds)
- [ ] Admin Payments page loads at st-basils-rebuild.vercel.app/admin/payments
- [ ] Site settings, event editing, member directory pages all functional