### PR TITLE
feat: branded invite email via Resend (#212)

### DIFF
--- a/src/actions/users.test.ts
+++ b/src/actions/users.test.ts
@@ -20,28 +20,44 @@ vi.mock('@/lib/supabase/server', () => ({
 }))
 
 const mockAdminFrom = vi.fn()
-const mockAdminInvite = vi.fn()
+const mockGenerateLink = vi.fn()
+const mockGetUserById = vi.fn()
 const mockAdminUpdate = vi.fn()
 const mockAdminEq = vi.fn()
 
 vi.mock('@/lib/supabase/admin', () => ({
   createAdminClient: vi.fn(() => ({
-    auth: { admin: { inviteUserByEmail: mockAdminInvite } },
+    auth: { admin: { generateLink: mockGenerateLink, getUserById: mockGetUserById } },
     from: mockAdminFrom,
   })),
+}))
+
+const mockSendInviteEmail = vi.fn()
+vi.mock('@/lib/invite-email', () => ({
+  sendInviteEmail: (...args: unknown[]) => mockSendInviteEmail(...args),
 }))
 
 vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
 
-import { inviteUser, updateUserRole } from '@/actions/users'
+import { inviteUser, resendInvite, updateUserRole } from '@/actions/users'
 
 // --- Helpers ---
 
 const ADMIN_ID = '550e8400-e29b-41d4-a716-446655440001'
 const TARGET_ID = '550e8400-e29b-41d4-a716-446655440002'
 const INITIAL_STATE = { success: false, message: '' }
+
+// generateLink success payload: returns the created user + the hashed token we
+// build the (server-verified) callback link from.
+const LINK_SUCCESS = {
+  data: {
+    user: { id: TARGET_ID },
+    properties: { hashed_token: 'hash123', action_link: 'https://supabase.co/verify' },
+  },
+  error: null,
+}
 
 function makeFormData(entries: Record<string, string>): FormData {
   const fd = new FormData()
@@ -85,6 +101,7 @@ function mockAuthenticatedAdmin() {
 describe('inviteUser', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSendInviteEmail.mockResolvedValue({ data: {}, error: null })
   })
 
   it('returns validation errors for invalid input', async () => {
@@ -125,8 +142,8 @@ describe('inviteUser', () => {
 
   it('returns error for duplicate email', async () => {
     mockAuthenticatedAdmin()
-    mockAdminInvite.mockResolvedValue({
-      data: null,
+    mockGenerateLink.mockResolvedValue({
+      data: { user: null, properties: null },
       error: { message: 'User already registered' },
     })
 
@@ -140,8 +157,8 @@ describe('inviteUser', () => {
 
   it('returns generic error for other invite failures', async () => {
     mockAuthenticatedAdmin()
-    mockAdminInvite.mockResolvedValue({
-      data: null,
+    mockGenerateLink.mockResolvedValue({
+      data: { user: null, properties: null },
       error: { message: 'SMTP connection failed' },
     })
 
@@ -152,12 +169,9 @@ describe('inviteUser', () => {
     expect(result.message).toBe('Failed to invite user')
   })
 
-  it('invites a member successfully', async () => {
+  it('invites a member successfully and sends the branded email', async () => {
     mockAuthenticatedAdmin()
-    mockAdminInvite.mockResolvedValue({
-      data: { user: { id: TARGET_ID } },
-      error: null,
-    })
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
     mockInsert.mockResolvedValue({ error: null })
 
     const fd = makeFormData({ email: 'new@example.com', full_name: 'New User', role: 'member' })
@@ -165,16 +179,48 @@ describe('inviteUser', () => {
 
     expect(result.success).toBe(true)
     expect(result.message).toBe('Invitation sent successfully')
+    // Branded email sent via Resend with a server-verified callback link
+    // (token_hash → verifyOtp), not Supabase's implicit action_link.
+    expect(mockSendInviteEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'new@example.com',
+        role: 'member',
+        actionUrl: expect.stringContaining('/api/auth/callback?token_hash=hash123&type=invite'),
+      })
+    )
     // Should NOT update role for members (default is member)
     expect(mockAdminFrom).not.toHaveBeenCalled()
   })
 
+  it('generates an invite-type link (no Supabase mailer)', async () => {
+    mockAuthenticatedAdmin()
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
+    mockInsert.mockResolvedValue({ error: null })
+
+    const fd = makeFormData({ email: 'new@example.com', full_name: 'New User', role: 'member' })
+    await inviteUser(INITIAL_STATE, fd)
+
+    expect(mockGenerateLink).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'invite', email: 'new@example.com' })
+    )
+  })
+
+  it('reports a non-fatal warning when the invite email fails', async () => {
+    mockAuthenticatedAdmin()
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
+    mockInsert.mockResolvedValue({ error: null })
+    mockSendInviteEmail.mockResolvedValue({ data: null, error: { message: 'Resend down' } })
+
+    const fd = makeFormData({ email: 'new@example.com', full_name: 'New User', role: 'member' })
+    const result = await inviteUser(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('failed to send')
+  })
+
   it('invites an admin and updates role', async () => {
     mockAuthenticatedAdmin()
-    mockAdminInvite.mockResolvedValue({
-      data: { user: { id: TARGET_ID } },
-      error: null,
-    })
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
     mockAdminEq.mockResolvedValue({ error: null })
     mockAdminUpdate.mockReturnValue({ eq: mockAdminEq })
     mockAdminFrom.mockReturnValue({ update: mockAdminUpdate })
@@ -189,10 +235,7 @@ describe('inviteUser', () => {
 
   it('returns error when admin role update fails', async () => {
     mockAuthenticatedAdmin()
-    mockAdminInvite.mockResolvedValue({
-      data: { user: { id: TARGET_ID } },
-      error: null,
-    })
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
     mockAdminEq.mockResolvedValue({ error: { message: 'update failed' } })
     mockAdminUpdate.mockReturnValue({ eq: mockAdminEq })
     mockAdminFrom.mockReturnValue({ update: mockAdminUpdate })
@@ -202,6 +245,99 @@ describe('inviteUser', () => {
 
     expect(result.success).toBe(false)
     expect(result.message).toBe('User invited but failed to set admin role')
+  })
+})
+
+describe('resendInvite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendInviteEmail.mockResolvedValue({ data: {}, error: null })
+  })
+
+  // Sets up: authenticated admin, target profile fetch, pending auth user.
+  function mockResendHappyPath(authUserOverride: Record<string, unknown> = {}) {
+    mockAuthenticatedAdmin()
+    // 2nd profiles call = target fetch (email, full_name, role)
+    mockSingle.mockResolvedValue({
+      data: { email: 'pending@example.com', full_name: 'Pending User', role: 'member' },
+      error: null,
+    })
+    mockEq.mockReturnValue({ single: mockSingle })
+    mockSelect.mockReturnValue({ eq: mockEq })
+    mockInsert.mockResolvedValue({ error: null })
+    mockGetUserById.mockResolvedValue({
+      data: { user: { last_sign_in_at: null, ...authUserOverride } },
+      error: null,
+    })
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
+  }
+
+  it('returns Unauthorized when no user session', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } })
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await resendInvite(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Unauthorized')
+  })
+
+  it('returns Forbidden when caller is not admin', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: ADMIN_ID } } })
+    mockFrom.mockReturnValue({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: { role: 'member' }, error: null }),
+        }),
+      }),
+    })
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await resendInvite(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Forbidden: admin access required')
+  })
+
+  it('blocks resending to a user who has already accepted', async () => {
+    mockResendHappyPath({ last_sign_in_at: '2026-01-01T00:00:00Z' })
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await resendInvite(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('This user has already accepted their invitation')
+    expect(mockGenerateLink).not.toHaveBeenCalled()
+  })
+
+  it('resends a recovery-type link via the branded email', async () => {
+    mockResendHappyPath()
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await resendInvite(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toBe('Invitation resent successfully')
+    expect(mockGenerateLink).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'recovery', email: 'pending@example.com' })
+    )
+    expect(mockSendInviteEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'pending@example.com',
+        actionUrl: expect.stringContaining('/api/auth/callback?token_hash=hash123&type=recovery'),
+      })
+    )
+  })
+
+  it('reports failure when the resend email fails', async () => {
+    mockResendHappyPath()
+    mockSendInviteEmail.mockResolvedValue({ data: null, error: { message: 'Resend down' } })
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await resendInvite(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Failed to send invitation email')
   })
 })
 

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 
+import { sendInviteEmail } from '@/lib/invite-email'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { inviteUserSchema, updateRoleSchema, userActionSchema } from '@/lib/validators/user'
@@ -10,6 +11,12 @@ type ActionState = {
   success: boolean
   message: string
   errors?: Record<string, string[]>
+}
+
+function inviteActionUrl(hashedToken: string, type: 'invite' | 'recovery'): string {
+  const base = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://stbasilsboston.org'
+  const params = new URLSearchParams({ token_hash: hashedToken, type })
+  return `${base}/api/auth/callback?${params.toString()}`
 }
 
 export async function inviteUser(prevState: ActionState, formData: FormData): Promise<ActionState> {
@@ -36,10 +43,10 @@ export async function inviteUser(prevState: ActionState, formData: FormData): Pr
   } = await supabase.auth.getUser()
   if (!user) return { success: false, message: 'Unauthorized' }
 
-  // 3. Admin check
+  // 3. Admin check (also grab inviter's name for the branded email)
   const { data: profile } = await supabase
     .from('profiles')
-    .select('role')
+    .select('role, full_name')
     .eq('id', user.id)
     .single()
 
@@ -47,17 +54,26 @@ export async function inviteUser(prevState: ActionState, formData: FormData): Pr
     return { success: false, message: 'Forbidden: admin access required' }
   }
 
-  // 4. Invite user via admin client (service role required for inviteUserByEmail)
-  const adminClient = createAdminClient()
-  const { data: inviteData, error: inviteError } = await adminClient.auth.admin.inviteUserByEmail(
-    parsed.data.email,
-    {
-      data: { full_name: parsed.data.full_name },
-    }
-  )
+  const inviterName = profile?.full_name || user.email || "St. Basil's Boston"
 
-  if (inviteError) {
-    if (inviteError.message?.toLowerCase().includes('already')) {
+  // 4. Create the user + generate the invite token WITHOUT sending Supabase's
+  //    default mailer, then send our own branded email via Resend. We build the
+  //    link from the hashed_token (verified server-side via verifyOtp in the auth
+  //    callback) rather than properties.action_link — action_link points at
+  //    Supabase's /verify endpoint which redirects with an implicit-flow
+  //    #access_token hash the server callback cannot read.
+  const adminClient = createAdminClient()
+  const { data: linkData, error: linkError } = await adminClient.auth.admin.generateLink({
+    type: 'invite',
+    email: parsed.data.email,
+    options: {
+      data: { full_name: parsed.data.full_name },
+    },
+  })
+
+  if (linkError) {
+    const msg = linkError.message?.toLowerCase() ?? ''
+    if (msg.includes('already') || msg.includes('registered') || msg.includes('exists')) {
       return {
         success: false,
         message: 'A user with this email already exists',
@@ -67,7 +83,12 @@ export async function inviteUser(prevState: ActionState, formData: FormData): Pr
     return { success: false, message: 'Failed to invite user' }
   }
 
-  const newUserId = inviteData.user.id
+  const newUserId = linkData.user?.id
+  const hashedToken = linkData.properties?.hashed_token
+  if (!newUserId || !hashedToken) {
+    return { success: false, message: 'Failed to invite user' }
+  }
+  const actionUrl = inviteActionUrl(hashedToken, 'invite')
 
   // 5. If role is admin, update the profile (handle_new_user trigger defaults to "member")
   if (parsed.data.role === 'admin') {
@@ -94,7 +115,24 @@ export async function inviteUser(prevState: ActionState, formData: FormData): Pr
     )
   }
 
-  // 7. Write audit log (authenticated client — RLS enforces admin-only inserts)
+  // 7. Send the branded invite email via Resend. Non-fatal: the user already
+  //    exists, so on failure report it and let the admin resend rather than
+  //    leaving the account in a half-created state.
+  let inviteEmailError: unknown = null
+  try {
+    const { error } = await sendInviteEmail({
+      email: parsed.data.email,
+      inviteeName: parsed.data.full_name,
+      inviterName,
+      role: parsed.data.role,
+      actionUrl,
+    })
+    inviteEmailError = error
+  } catch (error) {
+    inviteEmailError = error
+  }
+
+  // 8. Write audit log (authenticated client — RLS enforces admin-only inserts)
   await supabase.from('admin_audit_log').insert({
     actor_id: user.id,
     action: 'user.invite',
@@ -107,9 +145,19 @@ export async function inviteUser(prevState: ActionState, formData: FormData): Pr
     },
   })
 
-  // 8. Revalidate and return
+  // 9. Revalidate and return
   revalidatePath('/admin/users')
   revalidatePath('/admin/subscribers')
+
+  if (inviteEmailError) {
+    console.error('Invite created but email failed to send:', inviteEmailError)
+    return {
+      success: false,
+      message:
+        'User created, but the invitation email failed to send. Use "Resend invite" to try again.',
+    }
+  }
+
   return { success: true, message: 'Invitation sent successfully' }
 }
 
@@ -413,6 +461,118 @@ export async function sendPasswordReset(
   // 6. Revalidate and return
   revalidatePath('/admin/users')
   return { success: true, message: 'Password reset email sent successfully' }
+}
+
+export async function resendInvite(
+  prevState: ActionState,
+  formData: FormData
+): Promise<ActionState> {
+  // 1. Validate with Zod
+  const parsed = userActionSchema.safeParse({
+    user_id: formData.get('user_id'),
+  })
+
+  if (!parsed.success) {
+    return {
+      success: false,
+      message: 'Validation failed',
+      errors: parsed.error.flatten().fieldErrors as Record<string, string[]>,
+    }
+  }
+
+  // 2. Auth check
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return { success: false, message: 'Unauthorized' }
+
+  // 3. Admin check (also grab inviter's name for the branded email)
+  const { data: actorProfile } = await supabase
+    .from('profiles')
+    .select('role, full_name')
+    .eq('id', user.id)
+    .single()
+
+  if (actorProfile?.role !== 'admin') {
+    return { success: false, message: 'Forbidden: admin access required' }
+  }
+
+  // 4. Look up the target user's details
+  const { data: target, error: targetError } = await supabase
+    .from('profiles')
+    .select('email, full_name, role')
+    .eq('id', parsed.data.user_id)
+    .single()
+
+  if (targetError || !target?.email) {
+    return { success: false, message: 'Could not find email for this user' }
+  }
+
+  const adminClient = createAdminClient()
+
+  // 5. Only resend to users who have not yet accepted (never signed in).
+  //    last_sign_in_at is a server-trusted signal the client cannot mutate.
+  const { data: authUser, error: authUserError } = await adminClient.auth.admin.getUserById(
+    parsed.data.user_id
+  )
+  if (authUserError || !authUser?.user) {
+    return { success: false, message: 'Could not load user account' }
+  }
+  if (authUser.user.last_sign_in_at) {
+    return { success: false, message: 'This user has already accepted their invitation' }
+  }
+
+  // 6. Generate a fresh link. For an existing user, type 'recovery' is the type
+  //    that issues a new link (type 'invite' rejects existing users); the auth
+  //    callback routes recovery → /set-password, so the invitee still sets a
+  //    password and lands logged in.
+  const { data: linkData, error: linkError } = await adminClient.auth.admin.generateLink({
+    type: 'recovery',
+    email: target.email,
+  })
+
+  if (linkError || !linkData.properties?.hashed_token) {
+    return { success: false, message: 'Failed to generate invite link' }
+  }
+
+  // 7. Send the same branded invite email
+  const inviterName = actorProfile?.full_name || user.email || "St. Basil's Boston"
+  let inviteEmailError: unknown = null
+  try {
+    const { error } = await sendInviteEmail({
+      email: target.email,
+      inviteeName: target.full_name || target.email,
+      inviterName,
+      role: target.role as 'admin' | 'member',
+      actionUrl: inviteActionUrl(linkData.properties.hashed_token, 'recovery'),
+    })
+    inviteEmailError = error
+  } catch (error) {
+    inviteEmailError = error
+  }
+
+  // 8. Audit log (non-fatal)
+  const { error: auditError } = await supabase.from('admin_audit_log').insert({
+    actor_id: user.id,
+    action: 'user.invite.resend',
+    target_user_id: parsed.data.user_id,
+    metadata: { email: target.email, role: target.role },
+  })
+
+  if (auditError) {
+    console.error('Failed to write audit log for user.invite.resend:', auditError)
+  }
+
+  // 9. Revalidate and return
+  revalidatePath('/admin/users')
+
+  if (inviteEmailError) {
+    console.error('Resend invite email failed:', inviteEmailError)
+    return { success: false, message: 'Failed to send invitation email' }
+  }
+
+  return { success: true, message: 'Invitation resent successfully' }
 }
 
 // ─── Audit Log Query ─────────────────────────────────────────────────

--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,14 +1,19 @@
 import { createServerClient } from '@supabase/ssr'
+import type { EmailOtpType } from '@supabase/supabase-js'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code')
+  // token_hash is the server-side verification path used by our branded
+  // invite/recovery emails (generateLink → verifyOtp). code is the PKCE/OAuth path.
+  const tokenHash = request.nextUrl.searchParams.get('token_hash')
   const type = request.nextUrl.searchParams.get('type')
 
-  if (!code) {
+  if (!code && !tokenHash) {
     const url = request.nextUrl.clone()
     url.pathname = '/login'
     url.searchParams.delete('code')
+    url.searchParams.delete('token_hash')
     url.searchParams.delete('type')
     url.searchParams.set('error', 'missing_code')
     return NextResponse.redirect(url)
@@ -44,7 +49,12 @@ export async function GET(request: NextRequest) {
     }
   )
 
-  const { error } = await supabase.auth.exchangeCodeForSession(code)
+  const { error } = tokenHash
+    ? await supabase.auth.verifyOtp({
+        type: (type as EmailOtpType | null) ?? 'email',
+        token_hash: tokenHash,
+      })
+    : await supabase.auth.exchangeCodeForSession(code!)
 
   if (error) {
     const errorUrl = request.nextUrl.clone()

--- a/src/emails/invite-user.tsx
+++ b/src/emails/invite-user.tsx
@@ -1,0 +1,80 @@
+import { Link, Section, Text } from '@react-email/components'
+
+import { EmailLayout, emailStyles } from './components/email-layout'
+
+interface InviteUserProps {
+  inviteeName: string
+  inviterName: string
+  role: 'admin' | 'member'
+  actionUrl: string
+  supportEmail?: string
+  siteUrl?: string
+  expiresInHours?: number
+}
+
+const ROLE_LABELS: Record<InviteUserProps['role'], string> = {
+  admin: 'an Administrator',
+  member: 'a Member',
+}
+
+const ROLE_ACCESS: Record<InviteUserProps['role'], string> = {
+  admin: 'manage events, announcements, members, and the rest of the parish admin portal',
+  member: 'view parish announcements, events, and member resources',
+}
+
+export function InviteUser({
+  inviteeName = 'friend',
+  inviterName = "St. Basil's Boston",
+  role = 'member',
+  actionUrl = 'https://stbasilsboston.org/api/auth/callback',
+  supportEmail = 'contact@stbasilsboston.org',
+  siteUrl = 'https://stbasilsboston.org',
+  expiresInHours = 24,
+}: InviteUserProps) {
+  return (
+    <EmailLayout
+      previewText={`${inviterName} invited you to St. Basil's Boston`}
+      heading="You're invited"
+      siteUrl={siteUrl}
+    >
+      <Text style={emailStyles.paragraph}>Dear {inviteeName},</Text>
+      <Text style={emailStyles.paragraph}>
+        {inviterName} has invited you to join the St. Basil&apos;s Syriac Orthodox Church portal as{' '}
+        {ROLE_LABELS[role]}. Your account lets you {ROLE_ACCESS[role]}.
+      </Text>
+      <Text style={emailStyles.paragraph}>
+        To accept, click the button below and set your password.
+      </Text>
+      <Section style={emailStyles.ctaSection}>
+        <Link href={actionUrl} style={emailStyles.ctaButton}>
+          Accept invitation
+        </Link>
+      </Section>
+      <Text style={smallText}>
+        This invitation link expires in {expiresInHours} hours. If it has expired, ask {inviterName}{' '}
+        to send a new one.
+      </Text>
+      <Text style={smallText}>
+        Questions? Contact us at{' '}
+        <Link href={`mailto:${supportEmail}`} style={supportLink}>
+          {supportEmail}
+        </Link>
+        .
+      </Text>
+    </EmailLayout>
+  )
+}
+
+export default InviteUser
+
+const smallText = {
+  fontSize: '12px',
+  color: '#9ca3af',
+  lineHeight: '1.5',
+  margin: '16px 0 0',
+}
+
+const supportLink = {
+  color: '#9B1B3D',
+  textDecoration: 'underline',
+}

--- a/src/lib/invite-email.ts
+++ b/src/lib/invite-email.ts
@@ -1,0 +1,47 @@
+import 'server-only'
+
+import { InviteUser } from '@/emails/invite-user'
+import { sendEmail } from '@/lib/email'
+import { FROM_ADDRESS } from '@/lib/notifications'
+
+const SUPPORT_EMAIL = 'contact@stbasilsboston.org'
+const INVITE_SUBJECT = "You're invited to join St. Basil's Boston portal"
+
+interface SendInviteEmailParams {
+  email: string
+  inviteeName: string
+  inviterName: string
+  role: 'admin' | 'member'
+  actionUrl: string
+}
+
+/**
+ * Sends the branded invite email via Resend (our transactional stack), replacing
+ * Supabase Auth's default mailer. Both the initial invite and the resend-invite
+ * paths call this so neither emits the unbranded Supabase email.
+ */
+export async function sendInviteEmail({
+  email,
+  inviteeName,
+  inviterName,
+  role,
+  actionUrl,
+}: SendInviteEmailParams) {
+  return sendEmail({
+    from: FROM_ADDRESS,
+    to: email,
+    subject: INVITE_SUBJECT,
+    react: InviteUser({
+      inviteeName,
+      inviterName,
+      role,
+      actionUrl,
+      supportEmail: SUPPORT_EMAIL,
+    }),
+    metadata: {
+      template: 'invite-user',
+      actionUrl,
+      role,
+    },
+  })
+}


### PR DESCRIPTION
Closes #212.

## Problem
User invites used `admin.inviteUserByEmail`, which always sends Supabase Auth's **default mailer**: plain text from `noreply@mail.app.supabase.io`, no church branding, no inviter/role context, and a link that falls back to Supabase's Site URL (`http://localhost:3000` in prod → broken for the invitee).

## Approach
Stop relying on Supabase's mailer; route invites through the existing Resend + React Email stack (same one used for newsletters, payments, etc.).

- **New `src/emails/invite-user.tsx`** — branded template on the shared `EmailLayout`: invitee/inviter names, granted role + what it grants, burgundy CTA, 24h expiry note, `contact@stbasilsboston.org` support line.
- **New `src/lib/invite-email.ts`** — `sendInviteEmail()` helper sending from `noreply@stbasilsboston.org` with `metadata.template = invite-user` + `actionUrl` (E2E-readable).
- **`src/actions/users.ts`**
  - `inviteUser`: `inviteUserByEmail` → `admin.generateLink` (creates the user, sends nothing), then send our branded email.
  - New `resendInvite` server action — recovery-type link, pending-only guard (`last_sign_in_at`), audit `user.invite.resend`. **Backend only; UI button is #174.**
- **`src/app/api/auth/callback/route.ts`** — verify `token_hash` via `verifyOtp` (kept the `code`/PKCE branch for OAuth).

## The link fix (and a bug this caught)
The invite link is built from `generateLink`'s `properties.hashed_token` → `${NEXT_PUBLIC_SITE_URL}/api/auth/callback?token_hash=…&type=invite`. This fixes the localhost-link bug **and** sidesteps a flow bug: `properties.action_link` redirects with an implicit-flow `#access_token` hash fragment the server callback cannot read (it lands the user on the dashboard, never set-password). `token_hash` + `verifyOtp` keeps the whole flow server-verified.

## Testing
- `npm test` → **261 pass** · `tsc --noEmit` → clean · `eslint` → clean
- **Live browser, full chain:** admin invite → branded email captured (correct sender/subject/template) → click link → `/api/auth/callback` → `/set-password?flow=invite` → set password → role-based redirect to `/member`. Welcome email still fires on completion. Branded email render screenshotted.

## Deploy note
Set `NEXT_PUBLIC_SITE_URL=https://stbasilsboston.org` in Vercel **Production** (and the correct preview value). The Supabase Redirect-URL allowlist step is **not** needed with this approach — `verifyOtp` is a server-side call, no Supabase redirect involved.

## Out of scope (deferred)
- Resend-invite **UI** button / status badges → #174
- Bulk invite → #213; bulk resend → #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Invitations now include branded, personalized emails displaying role-specific information with a clear call-to-action
  * Added ability to resend invitations to users who haven't yet accepted them

* **Improvements**
  * Enhanced authentication flow to securely verify invitations and password recovery through token-based email links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->