### PR TITLE
feat: admin in-app health status card (#247)

### DIFF
--- a/docs/operations/uptime-monitoring.md
+++ b/docs/operations/uptime-monitoring.md
@@ -108,7 +108,8 @@ Members can subscribe to the status page for incident updates.
 When an alert fires:
 
 1. **Confirm scope.** Open `https://stbasilsboston.org/api/health` and read the JSON
-   `{ ok, db, cms, latency_ms }`.
+   `{ ok, db, cms, latency_ms }` — or, if signed in as an admin, glance at the in-app
+   card at `/admin/health` (renders the same endpoint with per-dependency status + latency).
 2. **Triage by signal:**
    - `db: false` → Supabase is unreachable. On the free tier the project **auto-pauses after
      inactivity** — open the Supabase dashboard and resume it. Otherwise check Supabase status / the
@@ -133,15 +134,24 @@ When an alert fires:
 (logic in `src/lib/health.ts`).
 
 ```json
-{ "ok": true, "db": true, "cms": true, "latency_ms": 142 }
+{
+  "ok": true,
+  "db": true,
+  "cms": true,
+  "latency_ms": 142,
+  "db_latency_ms": 126,
+  "cms_latency_ms": 88
+}
 ```
 
-| Field        | Meaning                                                            |
-| ------------ | ------------------------------------------------------------------ |
-| `ok`         | `db && cms`. Drives the HTTP status.                               |
-| `db`         | Supabase Postgres reachable (a tiny `select … limit 1` within 2s). |
-| `cms`        | Sanity reachable (a GROQ literal `1` ping within 2s).              |
-| `latency_ms` | Total time to probe both dependencies.                             |
+| Field            | Meaning                                                                          |
+| ---------------- | -------------------------------------------------------------------------------- |
+| `ok`             | `db && cms`. Drives the HTTP status.                                             |
+| `db`             | Supabase Postgres reachable (a tiny `select … limit 1` within 2s).               |
+| `cms`            | Sanity reachable (a GROQ literal `1` ping within 2s).                            |
+| `latency_ms`     | Total time to probe both dependencies (BetterStack's signal).                    |
+| `db_latency_ms`  | Per-dependency Supabase probe time; feeds the in-app admin `/admin/health` card. |
+| `cms_latency_ms` | Per-dependency Sanity probe time; feeds the in-app admin `/admin/health` card.   |
 
 - **HTTP status:** `200` when `ok`, **`503`** when any dependency is down.
 - **Caching (asymmetric):** healthy `200` responses are `public, max-age=0, s-maxage=30` — cached at

--- a/e2e/smoke/admin.spec.ts
+++ b/e2e/smoke/admin.spec.ts
@@ -19,7 +19,13 @@ test.describe('Admin login @smoke', () => {
 })
 
 test.describe('Admin auth guard @smoke', () => {
-  const PROTECTED_ROUTES = ['/admin', '/admin/dashboard', '/admin/events', '/admin/announcements']
+  const PROTECTED_ROUTES = [
+    '/admin',
+    '/admin/dashboard',
+    '/admin/events',
+    '/admin/announcements',
+    '/admin/health',
+  ]
 
   for (const route of PROTECTED_ROUTES) {
     test(`${route} redirects unauthenticated users`, async ({ page }) => {

--- a/e2e/smoke/health.spec.ts
+++ b/e2e/smoke/health.spec.ts
@@ -18,6 +18,9 @@ test.describe('Health endpoint @smoke', () => {
     expect(typeof body.db).toBe('boolean')
     expect(typeof body.cms).toBe('boolean')
     expect(typeof body.latency_ms).toBe('number')
+    // Per-dependency latency feeds the in-app admin /admin/health card.
+    expect(typeof body.db_latency_ms).toBe('number')
+    expect(typeof body.cms_latency_ms).toBe('number')
 
     // ok is the conjunction of the dependency flags...
     expect(body.ok).toBe(body.db && body.cms)

--- a/src/app/(admin)/admin/health/page.tsx
+++ b/src/app/(admin)/admin/health/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from 'next'
+
+import { HealthStatusCard } from '@/components/features/HealthStatusCard'
+
+export const metadata: Metadata = {
+  title: 'System Status',
+}
+
+// Access is enforced by the (admin) layout guard (profiles.role === 'admin').
+export default function HealthPage() {
+  const statusPageUrl = process.env.NEXT_PUBLIC_STATUS_PAGE_URL
+
+  return (
+    <main className="px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mb-8">
+        <h1 className="font-heading text-3xl font-semibold text-wood-900">System Status</h1>
+        <p className="mt-2 text-sm text-wood-800/60">
+          Live health of the website and its dependencies, read from{' '}
+          <code className="rounded bg-sand px-1 py-0.5 text-xs">/api/health</code>.
+        </p>
+      </div>
+
+      <HealthStatusCard statusPageUrl={statusPageUrl} />
+    </main>
+  )
+}

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -8,8 +8,11 @@ export const dynamic = 'force-dynamic'
 /**
  * Public health endpoint for external uptime monitoring (BetterStack).
  *
- * Returns `{ ok, db, cms, latency_ms }`:
+ * Returns `{ ok, db, cms, latency_ms, db_latency_ms, cms_latency_ms }`:
  * - 200 when every dependency is reachable, 503 otherwise.
+ * - `latency_ms` is the total probe time (BetterStack's signal); `db_latency_ms`
+ *   and `cms_latency_ms` are per-dependency probe times feeding the in-app admin
+ *   `/admin/health` card. Additive fields — the BetterStack contract is unchanged.
  * - Caching is asymmetric on purpose:
  *   - Healthy (200): `s-maxage=30` so the public endpoint serves a cached
  *     response for 30s (cuts Supabase/Sanity load from repeated/public hits;
@@ -23,11 +26,11 @@ export const dynamic = 'force-dynamic'
  */
 export async function GET() {
   const start = Date.now()
-  const { ok, db, cms } = await checkDependencies()
+  const { ok, db, cms, db_latency_ms, cms_latency_ms } = await checkDependencies()
   const latency_ms = Date.now() - start
 
   return NextResponse.json(
-    { ok, db, cms, latency_ms },
+    { ok, db, cms, latency_ms, db_latency_ms, cms_latency_ms },
     {
       status: ok ? 200 : 503,
       headers: {

--- a/src/components/features/HealthStatusCard.tsx
+++ b/src/components/features/HealthStatusCard.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { Button, Card } from '@/components/ui'
+import { cn } from '@/lib/utils'
+import {
+  deriveHealthView,
+  type DependencyState,
+  type FetchOutcome,
+  type HealthRow,
+} from '@/lib/health-status'
+
+const POLL_INTERVAL_MS = 30_000
+// Past the server's 2s + 2s parallel probe budget, so a hung browser fetch can't
+// wedge the loop while still cutting off a genuinely stuck request.
+const PROBE_TIMEOUT_MS = 8_000
+
+export interface HealthStatusCardProps {
+  /** External status page (BetterStack). Link is hidden when unset. */
+  statusPageUrl?: string
+}
+
+const dotClass: Record<DependencyState, string> = {
+  operational: 'bg-emerald-500',
+  down: 'bg-red-500',
+  unknown: 'bg-wood-800/30',
+}
+
+const statusTextClass: Record<DependencyState, string> = {
+  operational: 'text-emerald-700',
+  down: 'text-red-700',
+  unknown: 'text-wood-800/50',
+}
+
+const stateLabel: Record<DependencyState, string> = {
+  operational: 'Operational',
+  down: 'Down',
+  unknown: 'Unknown',
+}
+
+const ROWS = [
+  { key: 'website', label: 'Website' },
+  { key: 'database', label: 'Database' },
+  { key: 'cms', label: 'Content (CMS)' },
+] as const
+
+export function HealthStatusCard({ statusPageUrl }: HealthStatusCardProps) {
+  const [outcome, setOutcome] = useState<FetchOutcome | null>(null)
+  const [lastChecked, setLastChecked] = useState<Date | null>(null)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const inFlightRef = useRef(false)
+  const controllerRef = useRef<AbortController | null>(null)
+  const mountedRef = useRef(true)
+
+  const probe = useCallback(async ({ fresh }: { fresh: boolean }) => {
+    // Skip if a probe is already running so the 30s interval can't stack on a slow request.
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+    setIsRefreshing(true)
+
+    const controller = new AbortController()
+    controllerRef.current = controller
+    const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+
+    let next: FetchOutcome
+    try {
+      // Auto-poll hits the bare (CDN-cacheable) endpoint; manual refresh busts the
+      // 30s edge cache with a unique query for a true "check now".
+      const url = fresh ? `/api/health?t=${Date.now()}` : '/api/health'
+      const res = await fetch(url, { cache: 'no-store', signal: controller.signal })
+      const body = await res.json()
+      next = { kind: 'response', status: res.status, body }
+    } catch {
+      next = { kind: 'error' }
+    } finally {
+      clearTimeout(timeout)
+      controllerRef.current = null
+      inFlightRef.current = false
+    }
+
+    if (mountedRef.current) {
+      setOutcome(next)
+      setLastChecked(new Date())
+      setIsRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    probe({ fresh: false })
+    const id = setInterval(() => probe({ fresh: false }), POLL_INTERVAL_MS)
+    return () => {
+      mountedRef.current = false
+      clearInterval(id)
+      controllerRef.current?.abort()
+    }
+  }, [probe])
+
+  const view = outcome ? deriveHealthView(outcome) : null
+
+  const overall: DependencyState = view?.overall ?? 'unknown'
+  const overallLabel = !view
+    ? 'Checking…'
+    : overall === 'operational'
+      ? 'All operational'
+      : 'Service issue'
+
+  // Bound only to `overall` so the polite live region re-announces solely when the
+  // overall state flips — not on every 30s latency/timestamp change.
+  const liveMessage = view
+    ? overall === 'operational'
+      ? 'System status: all operational'
+      : 'System status: service issue'
+    : ''
+
+  const rowFor = (key: (typeof ROWS)[number]['key']): HealthRow =>
+    view ? view[key] : { state: 'unknown', latencyMs: null }
+
+  return (
+    <Card variant="outlined" className="max-w-2xl">
+      <p className="sr-only" role="status" aria-live="polite">
+        {liveMessage}
+      </p>
+
+      <Card.Header className="flex items-center justify-between gap-4 pb-4">
+        <h2 className="font-heading text-lg font-semibold text-wood-900">System Status</h2>
+        <span className="inline-flex items-center gap-2 text-sm font-medium text-wood-900">
+          <span className={cn('h-2.5 w-2.5 rounded-full', dotClass[overall])} aria-hidden="true" />
+          {overallLabel}
+        </span>
+      </Card.Header>
+
+      <div className="mx-6 h-px bg-wood-800/10" aria-hidden="true" />
+
+      <Card.Body className="space-y-3">
+        {ROWS.map(({ key, label }) => {
+          const row = rowFor(key)
+          return (
+            <div key={key} className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2.5">
+                <span
+                  className={cn('h-2 w-2 rounded-full', dotClass[row.state])}
+                  aria-hidden="true"
+                />
+                <span className="text-sm font-medium text-wood-900">{label}</span>
+              </div>
+              <div className="flex items-center gap-3 text-sm">
+                <span className={statusTextClass[row.state]}>
+                  {view ? stateLabel[row.state] : 'Checking…'}
+                </span>
+                {row.latencyMs != null && (
+                  <span className="tabular-nums text-wood-800/50">{row.latencyMs} ms</span>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </Card.Body>
+
+      <div className="mx-6 h-px bg-wood-800/10" aria-hidden="true" />
+
+      <Card.Footer className="flex flex-wrap items-center justify-between gap-3 pt-4">
+        <span className="text-sm text-wood-800/60">
+          {lastChecked
+            ? `Last checked ${lastChecked.toLocaleTimeString()} · auto-refresh 30s`
+            : 'Checking…'}
+        </span>
+        <div className="flex items-center gap-4">
+          {statusPageUrl && (
+            <a
+              href={statusPageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-burgundy-700 transition-colors hover:text-burgundy-800"
+            >
+              Status history ↗
+            </a>
+          )}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => probe({ fresh: true })}
+            disabled={isRefreshing}
+          >
+            {isRefreshing ? 'Refreshing…' : 'Refresh'}
+          </Button>
+        </div>
+      </Card.Footer>
+    </Card>
+  )
+}

--- a/src/components/layout/AdminSidebar.tsx
+++ b/src/components/layout/AdminSidebar.tsx
@@ -57,6 +57,11 @@ const navigation: NavItem[] = [
     href: '/admin/settings',
     icon: <SettingsIcon />,
   },
+  {
+    label: 'System Status',
+    href: '/admin/health',
+    icon: <ActivityIcon />,
+  },
 ]
 
 // ─── Component ───────────────────────────────────────────────────────
@@ -350,6 +355,24 @@ function ArrowLeftIcon() {
       aria-hidden="true"
     >
       <path d="M19 12H5M12 19l-7-7 7-7" />
+    </svg>
+  )
+}
+
+function ActivityIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
     </svg>
   )
 }

--- a/src/lib/health-status.test.ts
+++ b/src/lib/health-status.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+
+import { deriveHealthView, isHealthBody, type FetchOutcome } from '@/lib/health-status'
+
+const healthyBody = {
+  ok: true,
+  db: true,
+  cms: true,
+  latency_ms: 142,
+  db_latency_ms: 126,
+  cms_latency_ms: 88,
+}
+
+describe('deriveHealthView', () => {
+  it('maps a healthy 200 to all operational with per-dependency latency', () => {
+    const outcome: FetchOutcome = { kind: 'response', status: 200, body: healthyBody }
+    expect(deriveHealthView(outcome)).toEqual({
+      overall: 'operational',
+      website: { state: 'operational', latencyMs: null },
+      database: { state: 'operational', latencyMs: 126 },
+      cms: { state: 'operational', latencyMs: 88 },
+      totalLatencyMs: 142,
+    })
+  })
+
+  it('maps a 503 with db down to website up, db down, overall down', () => {
+    const outcome: FetchOutcome = {
+      kind: 'response',
+      status: 503,
+      body: {
+        ok: false,
+        db: false,
+        cms: true,
+        latency_ms: 2010,
+        db_latency_ms: 2000,
+        cms_latency_ms: 71,
+      },
+    }
+    expect(deriveHealthView(outcome)).toEqual({
+      overall: 'down',
+      website: { state: 'operational', latencyMs: null },
+      database: { state: 'down', latencyMs: 2000 },
+      cms: { state: 'operational', latencyMs: 71 },
+      totalLatencyMs: 2010,
+    })
+  })
+
+  it('treats a network error as website down, dependencies unknown', () => {
+    expect(deriveHealthView({ kind: 'error' })).toEqual({
+      overall: 'down',
+      website: { state: 'down', latencyMs: null },
+      database: { state: 'unknown', latencyMs: null },
+      cms: { state: 'unknown', latencyMs: null },
+      totalLatencyMs: null,
+    })
+  })
+
+  it('treats an unexpected status (500) as website down even with a parsed body', () => {
+    const outcome: FetchOutcome = { kind: 'response', status: 500, body: healthyBody }
+    expect(deriveHealthView(outcome)).toEqual({
+      overall: 'down',
+      website: { state: 'down', latencyMs: null },
+      database: { state: 'unknown', latencyMs: null },
+      cms: { state: 'unknown', latencyMs: null },
+      totalLatencyMs: null,
+    })
+  })
+
+  it('treats a malformed body (200 but wrong shape) as website down', () => {
+    const outcome: FetchOutcome = { kind: 'response', status: 200, body: { hello: 'world' } }
+    expect(deriveHealthView(outcome)).toEqual({
+      overall: 'down',
+      website: { state: 'down', latencyMs: null },
+      database: { state: 'unknown', latencyMs: null },
+      cms: { state: 'unknown', latencyMs: null },
+      totalLatencyMs: null,
+    })
+  })
+
+  it('tolerates a valid body missing the optional per-dependency latency fields', () => {
+    const outcome: FetchOutcome = {
+      kind: 'response',
+      status: 200,
+      body: { ok: true, db: true, cms: true, latency_ms: 100 },
+    }
+    const view = deriveHealthView(outcome)
+    expect(view.overall).toBe('operational')
+    expect(view.database).toEqual({ state: 'operational', latencyMs: null })
+    expect(view.cms).toEqual({ state: 'operational', latencyMs: null })
+  })
+})
+
+describe('isHealthBody', () => {
+  it('accepts a well-formed body', () => {
+    expect(isHealthBody(healthyBody)).toBe(true)
+  })
+
+  it('rejects non-objects and bodies missing required booleans', () => {
+    expect(isHealthBody(null)).toBe(false)
+    expect(isHealthBody('ok')).toBe(false)
+    expect(isHealthBody({ ok: true, db: true })).toBe(false)
+    expect(isHealthBody({ ok: 'yes', db: true, cms: true, latency_ms: 1 })).toBe(false)
+  })
+})

--- a/src/lib/health-status.ts
+++ b/src/lib/health-status.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure mapping from a `/api/health` fetch outcome to a view model for the admin
+ * health card. No React — kept here so the rules are unit-tested independently of
+ * the component (the test env is node, with no DOM/RTL).
+ */
+
+/** Status of one dependency (or the overall system) as rendered in the card. */
+export type DependencyState = 'operational' | 'down' | 'unknown'
+
+/** Shape of the JSON body returned by `/api/health`. */
+export interface HealthApiResponse {
+  ok: boolean
+  db: boolean
+  cms: boolean
+  latency_ms: number
+  db_latency_ms?: number
+  cms_latency_ms?: number
+}
+
+/** Statuses that represent a real health response (not a server/edge error). */
+const EXPECTED_HEALTH_STATUSES = new Set([200, 503])
+
+/** A single row in the card: its state plus latency in ms (null when unknown). */
+export interface HealthRow {
+  state: DependencyState
+  latencyMs: number | null
+}
+
+/** Everything the card needs to render. */
+export interface HealthView {
+  overall: DependencyState
+  website: HealthRow
+  database: HealthRow
+  cms: HealthRow
+  /** Total probe time reported by the endpoint, or null when unavailable. */
+  totalLatencyMs: number | null
+}
+
+/**
+ * Result of attempting to fetch `/api/health`:
+ * - `response`: an HTTP response arrived and its JSON body parsed.
+ * - `error`: network failure, abort/timeout, or a body that did not parse as JSON.
+ */
+export type FetchOutcome = { kind: 'response'; status: number; body: unknown } | { kind: 'error' }
+
+/** Narrow an unknown JSON body to the expected health shape. */
+export function isHealthBody(body: unknown): body is HealthApiResponse {
+  if (typeof body !== 'object' || body === null) return false
+  const b = body as Record<string, unknown>
+  return (
+    typeof b.ok === 'boolean' &&
+    typeof b.db === 'boolean' &&
+    typeof b.cms === 'boolean' &&
+    typeof b.latency_ms === 'number'
+  )
+}
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' ? value : null
+}
+
+const UNKNOWN_ROW: HealthRow = { state: 'unknown', latencyMs: null }
+
+/** A view where nothing could be determined — the website itself is down. */
+function unreachableView(): HealthView {
+  return {
+    overall: 'down',
+    website: { state: 'down', latencyMs: null },
+    database: { ...UNKNOWN_ROW },
+    cms: { ...UNKNOWN_ROW },
+    totalLatencyMs: null,
+  }
+}
+
+/**
+ * Map a fetch outcome to the card's view model.
+ *
+ * The website is "operational" only when the endpoint answered with an *expected*
+ * health status (200 or 503) and a well-formed body. A 500, a 401, a redirect, or
+ * an HTML/garbage body all mean the site is not serving health correctly — website
+ * `down`, dependencies `unknown`.
+ */
+export function deriveHealthView(outcome: FetchOutcome): HealthView {
+  if (outcome.kind === 'error') {
+    return unreachableView()
+  }
+
+  if (!EXPECTED_HEALTH_STATUSES.has(outcome.status) || !isHealthBody(outcome.body)) {
+    return unreachableView()
+  }
+
+  const body = outcome.body
+  return {
+    overall: body.ok ? 'operational' : 'down',
+    website: { state: 'operational', latencyMs: null },
+    database: { state: body.db ? 'operational' : 'down', latencyMs: num(body.db_latency_ms) },
+    cms: { state: body.cms ? 'operational' : 'down', latencyMs: num(body.cms_latency_ms) },
+    totalLatencyMs: num(body.latency_ms),
+  }
+}

--- a/src/lib/health.test.ts
+++ b/src/lib/health.test.ts
@@ -47,23 +47,39 @@ beforeEach(() => {
 })
 
 describe('checkDependencies', () => {
+  // Per-dependency latency is non-deterministic; assert the booleans exactly and
+  // that each latency field is a number.
+  const withLatency = (flags: { ok: boolean; db: boolean; cms: boolean }) => ({
+    ...flags,
+    db_latency_ms: expect.any(Number),
+    cms_latency_ms: expect.any(Number),
+  })
+
   it('reports all healthy when DB and CMS both respond', async () => {
-    await expect(checkDependencies()).resolves.toEqual({ ok: true, db: true, cms: true })
+    await expect(checkDependencies()).resolves.toEqual(
+      withLatency({ ok: true, db: true, cms: true })
+    )
   })
 
   it('reports db false on a Supabase error response', async () => {
     mockedCreateAdminClient.mockReturnValue(stubAdmin({ resolve: { error: { message: 'boom' } } }))
-    await expect(checkDependencies()).resolves.toEqual({ ok: false, db: false, cms: true })
+    await expect(checkDependencies()).resolves.toEqual(
+      withLatency({ ok: false, db: false, cms: true })
+    )
   })
 
   it('reports db false when the Supabase query rejects (timeout/connection)', async () => {
     mockedCreateAdminClient.mockReturnValue(stubAdmin({ reject: new Error('ETIMEDOUT') }))
-    await expect(checkDependencies()).resolves.toEqual({ ok: false, db: false, cms: true })
+    await expect(checkDependencies()).resolves.toEqual(
+      withLatency({ ok: false, db: false, cms: true })
+    )
   })
 
   it('reports cms false when the Sanity ping rejects', async () => {
     mockSanityFetch.mockRejectedValue(new Error('cms down'))
-    await expect(checkDependencies()).resolves.toEqual({ ok: false, db: true, cms: false })
+    await expect(checkDependencies()).resolves.toEqual(
+      withLatency({ ok: false, db: true, cms: false })
+    )
   })
 
   it('reports both false when Supabase env is missing and Sanity is unconfigured', async () => {
@@ -71,7 +87,9 @@ describe('checkDependencies', () => {
       throw new Error('Missing Supabase admin environment variables')
     })
     sanityState.hasConfig = false
-    await expect(checkDependencies()).resolves.toEqual({ ok: false, db: false, cms: false })
+    await expect(checkDependencies()).resolves.toEqual(
+      withLatency({ ok: false, db: false, cms: false })
+    )
     // Unconfigured Sanity must not even attempt a network ping.
     expect(mockSanityFetch).not.toHaveBeenCalled()
   })

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -9,6 +9,10 @@ export interface DependencyHealth {
   db: boolean
   /** Sanity CMS reachable. */
   cms: boolean
+  /** Time in ms to probe Supabase (capped near PROBE_TIMEOUT_MS on a hang). */
+  db_latency_ms: number
+  /** Time in ms to probe Sanity (capped near PROBE_TIMEOUT_MS on a hang). */
+  cms_latency_ms: number
 }
 
 /** Per-dependency probe budget. Keeps a single hung dependency from stalling the probe. */
@@ -72,11 +76,25 @@ function checkCms(): Promise<boolean> {
   return withTimeout(probe, PROBE_TIMEOUT_MS)
 }
 
+/** Run a boolean probe and measure how long it took to settle. */
+async function timed(probe: () => Promise<boolean>): Promise<{ ok: boolean; latency_ms: number }> {
+  const start = Date.now()
+  const ok = await probe()
+  return { ok, latency_ms: Date.now() - start }
+}
+
 /**
  * Probe all external dependencies in parallel. Never throws — any failure or
  * timeout surfaces as `false` on the relevant flag. `ok` is the conjunction.
+ * Per-dependency latency is measured for the in-app admin /admin/health card.
  */
 export async function checkDependencies(): Promise<DependencyHealth> {
-  const [db, cms] = await Promise.all([checkDb(), checkCms()])
-  return { ok: db && cms, db, cms }
+  const [db, cms] = await Promise.all([timed(checkDb), timed(checkCms)])
+  return {
+    ok: db.ok && cms.ok,
+    db: db.ok,
+    cms: cms.ok,
+    db_latency_ms: db.latency_ms,
+    cms_latency_ms: cms.latency_ms,
+  }
 }


### PR DESCRIPTION
Closes #247

## What

Admin-only `/admin/health` view that renders the existing `/api/health` endpoint as a readable status card — a quick "is everything green right now?" glance without curling JSON or opening the BetterStack dashboard. In-app convenience only; the public status page stays external (BetterStack, #218) by design, since an in-app page goes down with the app.

## Changes

**Endpoint (additive — BetterStack contract unchanged)**
- `src/lib/health.ts`, `src/app/api/health/route.ts`: add per-dependency latency (`db_latency_ms`, `cms_latency_ms`). Keep aggregate `latency_ms`, the 200/503 status, and the asymmetric cache headers. The external monitor keys on status code + `"ok":true`, so it is unaffected.

**View model (pure, unit-tested)**
- `src/lib/health-status.ts`: `deriveHealthView()` maps the fetch outcome to the card model. Website is `operational` only on an *expected* health status (200 or 503) with a valid body — a 500, a redirect, or a malformed body reads as `down`/`unknown`.

**UI**
- `src/components/features/HealthStatusCard.tsx` (client): per-dependency green/red + latency, overall banner, "last checked" + 30s auto-refresh, manual Refresh. Auto-poll hits the bare cacheable endpoint to ride its 30s edge cache; manual Refresh cache-busts for a true "check now". `AbortController` timeout + in-flight guard keep the polling loop from stacking or wedging. A single `sr-only` polite live region bound only to overall state (no per-tick announcement spam).
- `src/app/(admin)/admin/health/page.tsx` (server): sits under the existing `(admin)` auth guard; reads `NEXT_PUBLIC_STATUS_PAGE_URL` and passes it to the card (external status link rendered only when set).
- `src/components/layout/AdminSidebar.tsx`: "System Status" nav entry.

**Tests + docs**
- New `health-status.test.ts` (all-up / db-down / network-error / unexpected-status / malformed-body), updated `health.test.ts` for the new shape, smoke assertions for the two new fields, `/admin/health` added to the protected-route guard list, and the uptime runbook updated with the new fields + card.

## Note on the issue sketch

The issue sketch shows per-dependency latency. The original endpoint returned only one aggregate `latency_ms`, so this PR enriches it (additively) to report per-dependency timing — confirmed with the issue owner.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓ (no new warnings)
- `npm test` ✓ (274 passing)
- `npm run format:check` ✓
- Live: `GET /api/health` returns `db_latency_ms`/`cms_latency_ms` alongside `latency_ms`; `/admin/health` is behind the same auth guard as the other admin routes.

Full visual render of the card requires valid Supabase credentials (not available in this environment), so it was verified via typecheck + the unit-tested view model + the live endpoint shape.

## Acceptance

- [x] Admin-only route renders Website / Database / CMS
- [x] Per-dependency green/red + latency + overall banner
- [x] Auto-refresh + last-checked timestamp
- [x] External status-page link when `NEXT_PUBLIC_STATUS_PAGE_URL` is set
- [x] Behind the existing admin auth guard, no public exposure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a System Status page for admin users to monitor system health with real-time dependency status and latency metrics
  * Enhanced the health API endpoint to include per-dependency latency measurements

* **Documentation**
  * Updated health monitoring runbook with endpoint reference details

* **Tests**
  * Added comprehensive test coverage for health status monitoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->