### PR TITLE
feat: branded password reset email via Resend API

### DIFF
--- a/src/actions/users.test.ts
+++ b/src/actions/users.test.ts
@@ -41,6 +41,11 @@ vi.mock('@/lib/invite-email', () => ({
   sendInviteEmail: (...args: unknown[]) => mockSendInviteEmail(...args),
 }))
 
+const mockSendPasswordResetEmail = vi.fn()
+vi.mock('@/lib/password-reset-email', () => ({
+  sendPasswordResetEmail: (...args: unknown[]) => mockSendPasswordResetEmail(...args),
+}))
+
 vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }))
@@ -348,10 +353,12 @@ describe('resendInvite', () => {
 describe('sendPasswordReset', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockResetPasswordForEmail.mockResolvedValue({ error: null })
+    mockSendPasswordResetEmail.mockResolvedValue({ data: {}, error: null })
   })
 
-  it('sends reset email with the recovery callback redirect URL', async () => {
+  // Sets up: authenticated user, target profile fetch (email + full_name),
+  // audit-log insert, and a successful recovery generateLink.
+  function mockResetHappyPath() {
     mockGetUser.mockResolvedValue({ data: { user: { id: ADMIN_ID } } })
     mockFrom.mockImplementation((table: string) => {
       if (table === 'profiles') {
@@ -360,7 +367,7 @@ describe('sendPasswordReset', () => {
             eq: () => ({
               single: () =>
                 Promise.resolve({
-                  data: { email: 'member@example.com' },
+                  data: { email: 'member@example.com', full_name: 'Member Name' },
                   error: null,
                 }),
             }),
@@ -373,15 +380,58 @@ describe('sendPasswordReset', () => {
       return {}
     })
     mockInsert.mockResolvedValue({ error: null })
+    mockGenerateLink.mockResolvedValue(LINK_SUCCESS)
+  }
+
+  it('generates a recovery link and sends the branded email (no Supabase mailer)', async () => {
+    mockResetHappyPath()
 
     const fd = makeFormData({ user_id: TARGET_ID })
     const result = await sendPasswordReset(INITIAL_STATE, fd)
 
     expect(result.success).toBe(true)
     expect(result.message).toBe('Password reset email sent successfully')
-    expect(mockResetPasswordForEmail).toHaveBeenCalledWith('member@example.com', {
-      redirectTo: 'https://stbasilsboston.org/api/auth/callback?type=recovery',
-    })
+    // Recovery link generated with redirectTo derived from getSiteUrl() (no #245 regression)
+    expect(mockGenerateLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'recovery',
+        email: 'member@example.com',
+        options: { redirectTo: 'https://stbasilsboston.org/api/auth/callback?type=recovery' },
+      })
+    )
+    // Branded email sent via Resend with a server-verified church-domain callback link
+    expect(mockSendPasswordResetEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'member@example.com',
+        recipientName: 'Member Name',
+        actionUrl: expect.stringContaining('/api/auth/callback?token_hash=hash123&type=recovery'),
+      })
+    )
+    // Must NOT use Supabase's default mailer — single send path, no duplicate email
+    expect(mockResetPasswordForEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns failure when generateLink fails', async () => {
+    mockResetHappyPath()
+    mockGenerateLink.mockResolvedValue({ data: { properties: null }, error: { message: 'boom' } })
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await sendPasswordReset(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Failed to send password reset email')
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled()
+  })
+
+  it('returns failure when the branded email fails to send', async () => {
+    mockResetHappyPath()
+    mockSendPasswordResetEmail.mockResolvedValue({ data: null, error: { message: 'Resend down' } })
+
+    const fd = makeFormData({ user_id: TARGET_ID })
+    const result = await sendPasswordReset(INITIAL_STATE, fd)
+
+    expect(result.success).toBe(false)
+    expect(result.message).toBe('Failed to send password reset email')
   })
 })
 

--- a/src/actions/users.ts
+++ b/src/actions/users.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache'
 
 import { sendInviteEmail } from '@/lib/invite-email'
+import { sendPasswordResetEmail } from '@/lib/password-reset-email'
 import { getSiteUrl } from '@/lib/site-url'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
@@ -422,10 +423,10 @@ export async function sendPasswordReset(
   } = await supabase.auth.getUser()
   if (!user) return { success: false, message: 'Unauthorized' }
 
-  // 3. Look up the target user's email from their profile
+  // 3. Look up the target user's email (and name for the branded greeting)
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('email')
+    .select('email, full_name')
     .eq('id', parsed.data.user_id)
     .single()
 
@@ -439,14 +440,42 @@ export async function sendPasswordReset(
     return { success: false, message: 'Could not find email for this user' }
   }
 
-  // 4. Send password reset email via Supabase auth mailer
+  // 4. Generate a recovery link WITHOUT sending Supabase's default mailer, then
+  //    send our own branded email via Resend — mirrors inviteUser / resendInvite.
+  //    We build the link from hashed_token (verified server-side via verifyOtp in
+  //    the auth callback) rather than the Supabase action_link, so the link in the
+  //    email points at our church-domain callback. redirectTo is unchanged from
+  //    #245 and still derived from getSiteUrl() (preview vs production).
   const adminClient = createAdminClient()
   const redirectTo = `${getSiteUrl()}/api/auth/callback?type=recovery`
-  const { error: resetError } = await adminClient.auth.resetPasswordForEmail(profile.email, {
-    redirectTo,
+  const { data: linkData, error: linkError } = await adminClient.auth.admin.generateLink({
+    type: 'recovery',
+    email: profile.email,
+    options: { redirectTo },
   })
 
-  if (resetError) {
+  if (linkError || !linkData.properties?.hashed_token) {
+    return { success: false, message: 'Failed to send password reset email' }
+  }
+
+  const actionUrl = inviteActionUrl(linkData.properties.hashed_token, 'recovery')
+
+  // Send the branded password reset email. This is the only send path (we did not
+  // call resetPasswordForEmail), so there is no duplicate Supabase email.
+  let resetEmailError: unknown = null
+  try {
+    const { error } = await sendPasswordResetEmail({
+      email: profile.email,
+      recipientName: profile.full_name ?? undefined,
+      actionUrl,
+    })
+    resetEmailError = error
+  } catch (error) {
+    resetEmailError = error
+  }
+
+  if (resetEmailError) {
+    console.error('Password reset email failed to send:', resetEmailError)
     return { success: false, message: 'Failed to send password reset email' }
   }
 

--- a/src/emails/password-reset.tsx
+++ b/src/emails/password-reset.tsx
@@ -1,0 +1,69 @@
+import { Link, Section, Text } from '@react-email/components'
+
+import { EmailLayout, emailStyles } from './components/email-layout'
+
+interface PasswordResetProps {
+  recipientName?: string
+  actionUrl: string
+  supportEmail?: string
+  siteUrl?: string
+  expiresInHours?: number
+}
+
+export function PasswordReset({
+  recipientName = 'there',
+  actionUrl = 'https://stbasilsboston.org/api/auth/callback',
+  supportEmail = 'contact@stbasilsboston.org',
+  siteUrl = 'https://stbasilsboston.org',
+  expiresInHours = 1,
+}: PasswordResetProps) {
+  const expiryLabel = expiresInHours === 1 ? 'one hour' : `${expiresInHours} hours`
+
+  return (
+    <EmailLayout
+      previewText="Reset your St. Basil's Boston password"
+      heading="Reset your password"
+      siteUrl={siteUrl}
+    >
+      <Text style={emailStyles.paragraph}>Dear {recipientName},</Text>
+      <Text style={emailStyles.paragraph}>
+        We received a request to reset the password for your St. Basil&apos;s Syriac Orthodox Church
+        portal account. Click the button below to choose a new password.
+      </Text>
+      <Section style={emailStyles.ctaSection}>
+        <Link href={actionUrl} style={emailStyles.ctaButton}>
+          Reset password
+        </Link>
+      </Section>
+      <Text style={smallText}>
+        This link expires in {expiryLabel}. If it has expired, ask an administrator to send a new
+        one.
+      </Text>
+      <Text style={smallText}>
+        If you didn&apos;t request a password reset, you can safely ignore this email — your password
+        will not change.
+      </Text>
+      <Text style={smallText}>
+        Questions? Contact us at{' '}
+        <Link href={`mailto:${supportEmail}`} style={supportLink}>
+          {supportEmail}
+        </Link>
+        .
+      </Text>
+    </EmailLayout>
+  )
+}
+
+export default PasswordReset
+
+const smallText = {
+  fontSize: '12px',
+  color: '#9ca3af',
+  lineHeight: '1.5',
+  margin: '16px 0 0',
+}
+
+const supportLink = {
+  color: '#9B1B3D',
+  textDecoration: 'underline',
+}

--- a/src/lib/password-reset-email.ts
+++ b/src/lib/password-reset-email.ts
@@ -1,0 +1,42 @@
+import 'server-only'
+
+import { PasswordReset } from '@/emails/password-reset'
+import { sendEmail } from '@/lib/email'
+import { FROM_ADDRESS } from '@/lib/notifications'
+
+const SUPPORT_EMAIL = 'contact@stbasilsboston.org'
+const PASSWORD_RESET_SUBJECT = "Reset your St. Basil's Boston password"
+
+interface SendPasswordResetEmailParams {
+  email: string
+  recipientName?: string
+  actionUrl: string
+}
+
+/**
+ * Sends the branded password reset email via Resend (our transactional stack),
+ * replacing Supabase Auth's default mailer. Mirrors sendInviteEmail: the action
+ * generates the recovery link with generateLink (no Supabase send) and builds a
+ * server-verified callback URL from the hashed_token, so this is the only send
+ * path — no duplicate Supabase email.
+ */
+export async function sendPasswordResetEmail({
+  email,
+  recipientName,
+  actionUrl,
+}: SendPasswordResetEmailParams) {
+  return sendEmail({
+    from: FROM_ADDRESS,
+    to: email,
+    subject: PASSWORD_RESET_SUBJECT,
+    react: PasswordReset({
+      recipientName,
+      actionUrl,
+      supportEmail: SUPPORT_EMAIL,
+    }),
+    metadata: {
+      template: 'password-reset',
+      actionUrl,
+    },
+  })
+}


### PR DESCRIPTION
Closes #254

## Summary

Password reset emails now use the **branded React Email + Resend** stack already used by invites, instead of Supabase Auth's default SMTP mailer (plain HTML with a raw `*.supabase.co/auth/v1/verify` link → poor deliverability, Gmail "might be dangerous").

`sendPasswordReset` now mirrors `inviteUser` / `resendInvite`:
- `admin.generateLink({ type: 'recovery', email, options: { redirectTo } })` — no Supabase mailer
- builds the email CTA from `hashed_token` via `inviteActionUrl(...)` → church-domain `/api/auth/callback?token_hash=…&type=recovery`
- sends the branded `PasswordReset` email via Resend
- `resetPasswordForEmail` removed → single send path, no duplicate email
- `redirectTo` still derived from `getSiteUrl()` (no #245 regression)

The existing auth callback route already handles `type=recovery` → `verifyOtp(token_hash)` → `/set-password?flow=recovery`, so no route or set-password changes were needed.

## Changes
- **New** `src/emails/password-reset.tsx` — branded template (shared `EmailLayout` / design system, 1h expiry note, "didn't request this" line)
- **New** `src/lib/password-reset-email.ts` — `sendPasswordResetEmail()`, mirrors `invite-email.ts`
- **Edit** `src/actions/users.ts` — rewrite `sendPasswordReset`
- **Edit** `src/actions/users.test.ts` — assert recovery `generateLink` (with `redirectTo`), branded send with church-domain `actionUrl`, and that `resetPasswordForEmail` is no longer called

## Verification
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm test -- users.test` — 26 passed (incl. 3 new `sendPasswordReset` cases)

## Out of scope
- Storing Resend `email_id` on `admin_audit_log` (optional follow-up ticket)
- Supabase Send Email Auth Hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Password reset emails are now custom-branded with improved design, clearer instructions, and integrated support contact information for enhanced user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->